### PR TITLE
[Ripple] Propagate governance layer-down (repository_dispatch)

### DIFF
--- a/.agent-admin/ripple/layer-down-received-20260227T124221Z.json
+++ b/.agent-admin/ripple/layer-down-received-20260227T124221Z.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0.0",
+  "type": "layer_down_received",
+  "timestamp": "2026-02-27T12:42:21Z",
+  "source_repo": "APGI-cmy/maturion-foreman-governance",
+  "canonical_commit": "a925dd789b25f27f804b35df9019494371449aae  ",
+  "requires_cs2_approval": false,
+  "escalated": false,
+  "trigger": "repository_dispatch"
+}

--- a/.agent-admin/ripple/ripple-received-20260227T124217Z.json
+++ b/.agent-admin/ripple/ripple-received-20260227T124217Z.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "1.0.0",
+  "type": "governance_ripple_received",
+  "timestamp": "2026-02-27T12:42:17Z",
+  "source_repo": "APGI-cmy/maturion-foreman-governance",
+  "canonical_commit": "fad4bc8786eb99ed75354aed50c0a50cdd8d055a",
+  "commit_message": "Merge pull request #1232 from APGI-cmy/copilot/trigger-governance-pipeline-test",
+  "workflow_run": "22486651880"
+}


### PR DESCRIPTION
## Ripple Integration
This PR propagates governance artefacts from the upstream layer-down.
### Source
- **Trigger**: `repository_dispatch` from `APGI-cmy/maturion-foreman-governance`
- **Canonical commit**: `a925dd789b25f27f804b35df9019494371449aae  `
- **Canonical version**: `1.0.0`
- **Files updated**: 6
- **Ripple timestamp**: 2026-02-27T12:42:04Z
### Agent File Gate
✅ No agent contract files changed — standard auto-merge path.
---
**Authority**: CROSS_REPO_RIPPLE_TRANSPORT_PROTOCOL.md, LAYERING_AND_RIPPLING_AUTOMATION_STRATEGY.md v1.0.0