### PR TITLE
fix(cwt): anchor AI gateway pending auth-order test to actual listPending call

### DIFF
--- a/SCOPE_DECLARATION.md
+++ b/SCOPE_DECLARATION.md
@@ -1,37 +1,23 @@
-# Scope Declaration — harden-deploy-mmm-supabase-migrations-20260427
+# Scope Declaration — fix-ai-gateway-cwt-listpending-source-anchor-20260428
 
-**Wave**: harden-deploy-mmm-supabase-migrations-20260427
-**Issue**: maturion-isms#1486
-**Branch**: copilot/harden-deploy-mmm-supabase-migrations
-**Date**: 2026-04-27
+**Wave**: fix-ai-gateway-cwt-listpending-source-anchor-20260428
+**Issue**: maturion-isms#1488
+**Branch**: cs2/fix-ai-gateway-cwt-listpending-source-anchor
+**Date**: 2026-04-28
 **Authority**: SCOPE_TO_DIFF_RULE.md, MERGE_GATE_PHILOSOPHY.md (BL-027)
 
 ## Scope Decision
 
-Replace the interactive `supabase link + supabase db push` mechanism with the proven
-Management API approach (apply-migrations-via-api.py) to make MMM-native migrations
-non-interactive and eliminate the SASL auth/password failure.
+Fix the AI gateway Combined Wave Test source-inspection assertion for W9.11-FU-T-007 so it anchors privileged access ordering to the actual `pipeline.listPending(` call instead of the first textual `listPending(` occurrence, which may appear in comments before the Forbidden/auth guard.
 
 ## Changed Files
 
-- `.github/scripts/apply-migrations-via-api.py`
-- `.github/workflows/deploy-mmm-supabase-migrations.yml`
+- `api/ai/feedback.supabase-wiring.test.ts`
 - `SCOPE_DECLARATION.md`
-- `.agent-workspace/foreman-v2/personal/wave-current-tasks.md`
-- `.agent-workspace/foreman-v2/personal/scope-declaration-wave-harden-deploy-mmm-supabase-migrations-20260427.md`
-- `.agent-admin/assurance/iaa-wave-record-harden-deploy-mmm-supabase-migrations-20260427.md`
-- `.agent-workspace/foreman-v2/memory/PREHANDOVER-session-075-harden-deploy-mmm-supabase-migrations-20260427.md`
-- `.agent-workspace/foreman-v2/memory/PREHANDOVER-session-075-harden-deploy-mmm-supabase-migrations-20260427-R1.md`
-- `.agent-admin/prehandover/proof-session-075-harden-deploy-mmm-supabase-migrations-20260427.md`
-- `.agent-admin/prehandover/proof-session-075-harden-deploy-mmm-supabase-migrations-20260427-R1.md`
-- `.agent-workspace/foreman-v2/memory/session-075-20260427.md`
-- `.agent-admin/prehandover/OVL-CI-005-S033-evidence-session-075-harden-deploy-mmm-supabase-migrations-20260427.md`
-- `.agent-workspace/foreman-v2/parking-station/suggestions-log.md`
-- `.agent-workspace/independent-assurance-agent/memory/session-075-20260427.md`
-- `.agent-workspace/independent-assurance-agent/memory/session-076-20260427.md`
 
 ## Out of Scope
 
-- Any agent contract files (.github/agents/*.md)
-- Any application code or schema migrations
+- Runtime changes to `api/ai/feedback/pending.ts`
+- Any Supabase schema or migration changes
+- Any deployment workflow changes
 - Any files not listed above

--- a/api/ai/feedback.supabase-wiring.test.ts
+++ b/api/ai/feedback.supabase-wiring.test.ts
@@ -40,18 +40,19 @@ describe('Wave 9.11-FU — Supabase Client Wiring', () => {
   });
   it('W9.11-FU-T-007: pending.ts enforces auth guard before privileged access (Forbidden path present)', () => {
     // Security boundary: unauthenticated requests must fail with a Forbidden response
-    // before any privileged list operation is performed. Assert not only presence of
-    // the guard markers, but also that the privileged listPending() call appears after them.
+    // before any privileged list operation is performed. Anchor privileged access to
+    // the concrete pipeline.listPending(...) call so comments mentioning listPending()
+    // do not produce false source-order failures.
     const pendingSource = readFileSync(resolve(__dirname, 'feedback', 'pending.ts'), 'utf-8');
     expect(pendingSource).toContain('Forbidden');
     expect(pendingSource).toContain('x-arc-token');
     expect(pendingSource).toContain('ARC_APPROVAL_TOKEN');
-    expect(pendingSource).toContain('listPending(');
+    expect(pendingSource).toContain('pipeline.listPending(');
 
     const forbiddenIndex = pendingSource.indexOf('Forbidden');
     const arcHeaderIndex = pendingSource.indexOf('x-arc-token');
     const arcTokenIndex = pendingSource.indexOf('ARC_APPROVAL_TOKEN');
-    const listPendingIndex = pendingSource.indexOf('listPending(');
+    const listPendingIndex = pendingSource.indexOf('pipeline.listPending(');
 
     expect(forbiddenIndex).toBeGreaterThanOrEqual(0);
     expect(arcHeaderIndex).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
## Summary

Fix the failing `Deploy MMM AI Gateway` Combined Wave Test by making W9.11-FU-T-007 anchor privileged-access ordering to the actual `pipeline.listPending(` call in `api/ai/feedback/pending.ts`.

The current test uses:

```ts
pendingSource.indexOf('listPending(')
```

That matches an earlier comment in `pending.ts` before the auth guard, not the real privileged call. The endpoint implementation already performs the Forbidden/auth guard before `pipeline.listPending(organisationId)`, but the source-inspection test compares against the wrong occurrence and fails incorrectly.

## Changes

- `api/ai/feedback.supabase-wiring.test.ts`
  - Change W9.11-FU-T-007 to look for `pipeline.listPending(` instead of bare `listPending(`.
  - Update the test comment to explain why the call must be anchored to the concrete pipeline invocation.
- `SCOPE_DECLARATION.md`
  - Refresh scope for this two-file CWT test fix.

## Expected effect

The AI gateway CWT should stop failing on the false ordering error:

```text
AssertionError: expected 5934 to be less than 3122
```

because the test now compares the auth/Forbidden markers against the actual privileged call location, not a comment mention.

## Governing issue

Addresses the AI gateway CWT/security-contract reconciliation tracked under `maturion-isms#1488`.