### PR TITLE
Fix MMM CWT pnpm setup ordering

### DIFF
--- a/.github/workflows/deploy-mmm-ai-gateway.yml
+++ b/.github/workflows/deploy-mmm-ai-gateway.yml
@@ -250,11 +250,15 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v5
+      - name: Install pnpm before Node cache resolution
+        uses: pnpm/action-setup@v4
+        with:
+          version: '8.15.7'
+          run_install: false
       - uses: actions/setup-node@v5
         with:
           node-version: 'lts/*'
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
+          package-manager-cache: false
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run Combined Wave Tests (MMM-T-0001–0959)


### PR DESCRIPTION
# Objective

Fix the MMM AI Gateway Combined Wave Test setup failure where `actions/setup-node@v5` cannot locate the `pnpm` executable.

The failed job stopped before tests ran with:

```txt
Error: Unable to locate executable file: pnpm
```

---

# Root Cause

The CWT job configured Node before installing/enabling pnpm:

```yaml
- uses: actions/setup-node@v5
- name: Install pnpm
  uses: pnpm/action-setup@v4
```

With newer setup-node behavior, pnpm-related cache/package-manager detection can require the pnpm executable to already be available on PATH.

---

# Fix

Reorder the CWT job setup so pnpm is installed before Node setup:

```yaml
- name: Install pnpm before Node cache resolution
  uses: pnpm/action-setup@v4
  with:
    version: '8.15.7'
    run_install: false

- uses: actions/setup-node@v5
  with:
    node-version: 'lts/*'
    package-manager-cache: false
```

This keeps the fix narrow and targeted to the failing CWT job.

---

# Scope

Changed file:

- `.github/workflows/deploy-mmm-ai-gateway.yml`

No application runtime code changes.
No product behavior changes.

---

# Expected Result

The Combined Wave Test job should proceed past setup-node and reach:

```bash
pnpm install --frozen-lockfile
pnpm test
```

