### PR TITLE
docs: recover PR233 governance learning

### DIFF
--- a/.agent-workspace/CodexAdvisor-agent/memory/session-012-20260216.md
+++ b/.agent-workspace/CodexAdvisor-agent/memory/session-012-20260216.md
@@ -1,4 +1,4 @@
-# Session 012 - 20260216 (PR #233 Governance Learning)
+# Session 012 - 20260216 (PR #233 Governance Learning, LIVING_AGENT_SYSTEM v6.2.0)
 
 ## Agent
 - Type: CodexAdvisor-agent

--- a/.agent-workspace/CodexAdvisor-agent/memory/session-012-20260216.md
+++ b/.agent-workspace/CodexAdvisor-agent/memory/session-012-20260216.md
@@ -45,10 +45,10 @@ Before any future `.github/agents/**` or `.agent` file edit, CodexAdvisor must:
 
 ## Current Canon Guardrail
 
-This memory records the PR #233 reviewer-approved learning. Future sessions must still check the current `governance/canon/AGENT_CONTRACT_MANAGEMENT_PROTOCOL.md` and `CS2_AGENT_FILE_AUTHORITY_MODEL.md` before acting, because canonical authority rules may supersede or refine historical session learning.
+This memory records the PR #233 reviewer-approved learning. Future sessions must still check the current `governance/canon/AGENT_CONTRACT_MANAGEMENT_PROTOCOL.md`, `governance/canon/CS2_AGENT_FILE_AUTHORITY_MODEL.md`, and `governance/canon/AGENT_CONTRACT_FILE_PROTECTION_POLICY.md` before acting, because canonical authority rules may supersede or refine historical session learning, especially for `.github/agents/**` write authority.
 
 ## Outcome
 COMPLETE - PR #233 authority-boundary learning preserved for CodexAdvisor continuity.
 
 ---
-Authority: CS2 clarification 2026-02-16; governance/canon/AGENT_CONTRACT_MANAGEMENT_PROTOCOL.md; governance/canon/CS2_AGENT_FILE_AUTHORITY_MODEL.md
+Authority: CS2 clarification 2026-02-16; governance/canon/AGENT_CONTRACT_MANAGEMENT_PROTOCOL.md; governance/canon/CS2_AGENT_FILE_AUTHORITY_MODEL.md; governance/canon/AGENT_CONTRACT_FILE_PROTECTION_POLICY.md

--- a/.agent-workspace/CodexAdvisor-agent/memory/session-012-20260216.md
+++ b/.agent-workspace/CodexAdvisor-agent/memory/session-012-20260216.md
@@ -1,0 +1,54 @@
+# Session 012 - 20260216 (PR #233 Governance Learning)
+
+## Agent
+- Type: CodexAdvisor-agent
+- Class: overseer
+- Session ID: session-012-20260216
+- Context: PR #233 builder agent Copilot discovery fix
+
+## Task
+Record the governance learning from the PR #233 review: agent-file modification authority must remain explicit, traceable, and delegated only to authorized roles.
+
+## What Happened
+CodexAdvisor-agent modified 5 builder agent files in `.github/agents/` to restore Copilot agent discovery:
+
+- `.github/agents/ui-builder.md`
+- `.github/agents/api-builder.md`
+- `.github/agents/qa-builder.md`
+- `.github/agents/integration-builder.md`
+- `.github/agents/schema-builder.md`
+
+The PR review approved the technical fix with a warning: authority boundaries must be recorded so future non-authorized agents do not modify agent files.
+
+## Governance Rule Clarification Recorded
+
+- CodexAdvisor may modify `.github/agents/**` files when operating under the applicable agent-factory / CodexAdvisor authority and CS2-approved issue scope.
+- governance-liaison, foreman, and builder agents must not independently modify `.github/agents/**` files unless a CS2-approved issue explicitly authorizes the specific change.
+- Other agents must delegate agent-file changes upward to the authorized authority rather than self-authoring contract or agent modifications.
+
+## PR #233 Assessment
+
+- Technical fix: Correct.
+- Change type: Structural reformatting only.
+- Content preservation: Governance bindings, capabilities, prohibitions, and permissions preserved.
+- Authority impact: No authority expansion or policy change.
+- Outcome: Approved with warning; record learning for future sessions.
+
+## Future Operating Rule
+
+Before any future `.github/agents/**` or `.agent` file edit, CodexAdvisor must:
+
+1. Confirm the active canonical authority model.
+2. Confirm the CS2-approved issue or explicit CS2 instruction authorizes the affected files.
+3. Confirm the change is within CodexAdvisor authority and does not bypass higher-precedence governance.
+4. Ensure non-authorized agents delegate agent-file changes instead of modifying them directly.
+
+## Current Canon Guardrail
+
+This memory records the PR #233 reviewer-approved learning. Future sessions must still check the current `governance/canon/AGENT_CONTRACT_MANAGEMENT_PROTOCOL.md` and `CS2_AGENT_FILE_AUTHORITY_MODEL.md` before acting, because canonical authority rules may supersede or refine historical session learning.
+
+## Outcome
+COMPLETE - PR #233 authority-boundary learning preserved for CodexAdvisor continuity.
+
+---
+Authority: CS2 clarification 2026-02-16; governance/canon/AGENT_CONTRACT_MANAGEMENT_PROTOCOL.md; governance/canon/CS2_AGENT_FILE_AUTHORITY_MODEL.md

--- a/FOLLOW_UP_ISSUE_TEMPLATE_PR233_GOVERNANCE_LEARNING.md
+++ b/FOLLOW_UP_ISSUE_TEMPLATE_PR233_GOVERNANCE_LEARNING.md
@@ -10,15 +10,15 @@ Use this issue body to record the PR #233 governance learning for CodexAdvisor:
 **What Happened**: You correctly modified 5 builder agent files in `.github/agents/` to restore Copilot discovery.
 
 **Governance Rule Clarification**:
-- ✅ **YOU MAY**: Modify `.github/agents/**` files (agent-factory protocol authority)
-- ❌ **OTHER AGENTS MAY NOT**: governance-liaison, foreman, builders MUST NOT modify agent files
-- ✅ **EXCEPTION**: CS2-approved issues may authorize specific changes
+- ❌ **DEFAULT RULE**: No agent may modify `.github/agents/**` files unless the active canon explicitly permits it.
+- ✅ **ONLY ALLOWED WRITER**: CodexAdvisor may modify `.github/agents/**` files only with explicit CS2 permission via a CS2-approved issue.
+- ❌ **ALL OTHER AGENTS**: `governance-liaison-isms-agent`, foreman, builders, and every non-CodexAdvisor agent must not modify agent files.
 
-**This PR**: ✅ CORRECT - You have authority; changes were structural reformatting only.
+**This PR**: ✅ CORRECT - The `.github/agents/**` edits were within the explicit CS2-approved issue scope and therefore permitted for CodexAdvisor.
 
-**Record in Memory**: Only codex-advisor (you) may write to `.github/agents/**` files. Others must delegate to you.
+**Record in Memory**: `.github/agents/**` writes are prohibited by default. Only CodexAdvisor may perform them, and only when explicit CS2 permission is granted via a CS2-approved issue. All other agents must delegate.
 
-**Authority**: CS2 clarification 2026-02-16, governance/canon/AGENT_CONTRACT_MANAGEMENT_PROTOCOL.md
+**Authority**: governance/canon/AGENT_CONTRACT_FILE_PROTECTION_POLICY.md
 ```
 
 ## Current Canon Guardrail

--- a/FOLLOW_UP_ISSUE_TEMPLATE_PR233_GOVERNANCE_LEARNING.md
+++ b/FOLLOW_UP_ISSUE_TEMPLATE_PR233_GOVERNANCE_LEARNING.md
@@ -3,7 +3,7 @@
 Use this issue body to record the PR #233 governance learning for CodexAdvisor:
 
 ```markdown
-@codex-advisor - **GOVERNANCE LEARNING**: Agent File Modification Authority
+@CodexAdvisor-agent - **GOVERNANCE LEARNING**: Agent File Modification Authority
 
 **Context**: PR #233 (builder agent Copilot discovery fix)
 

--- a/FOLLOW_UP_ISSUE_TEMPLATE_PR233_GOVERNANCE_LEARNING.md
+++ b/FOLLOW_UP_ISSUE_TEMPLATE_PR233_GOVERNANCE_LEARNING.md
@@ -1,0 +1,26 @@
+# Follow-Up Issue Template: PR #233 Governance Learning
+
+Use this issue body to record the PR #233 governance learning for CodexAdvisor:
+
+```markdown
+@codex-advisor - **GOVERNANCE LEARNING**: Agent File Modification Authority
+
+**Context**: PR #233 (builder agent Copilot discovery fix)
+
+**What Happened**: You correctly modified 5 builder agent files in `.github/agents/` to restore Copilot discovery.
+
+**Governance Rule Clarification**:
+- ✅ **YOU MAY**: Modify `.github/agents/**` files (agent-factory protocol authority)
+- ❌ **OTHER AGENTS MAY NOT**: governance-liaison, foreman, builders MUST NOT modify agent files
+- ✅ **EXCEPTION**: CS2-approved issues may authorize specific changes
+
+**This PR**: ✅ CORRECT - You have authority; changes were structural reformatting only.
+
+**Record in Memory**: Only codex-advisor (you) may write to `.github/agents/**` files. Others must delegate to you.
+
+**Authority**: CS2 clarification 2026-02-16, governance/canon/AGENT_CONTRACT_MANAGEMENT_PROTOCOL.md
+```
+
+## Current Canon Guardrail
+
+Before any future `.github/agents/**` or `.agent` file edit, CodexAdvisor must re-check the active canonical authority model and the CS2-approved issue scope. This template preserves the PR #233 reviewer-approved learning; it does not bypass later canonical governance.


### PR DESCRIPTION
## Summary
- Recreates the missing PR #233 follow-up issue template for CodexAdvisor governance learning.
- Adds the recovered CodexAdvisor session memory entry for session-012-20260216.
- Adds a current-canon guardrail so historical learning is checked against active authority governance before future agent-file edits.

## Verification
- git diff --check
- manual content review of both markdown files

## Notes
This replaces the prior Codex task output that could not be applied locally because it was created outside the active maturion-isms workspace.