### PR TITLE
Authorize PIT Stage 12 kickoff

### DIFF
--- a/modules/pit/12-build/stage12-kickoff-authorization.md
+++ b/modules/pit/12-build/stage12-kickoff-authorization.md
@@ -1,0 +1,107 @@
+# PIT Stage 12 Kickoff Authorization
+
+**Module**: PIT (Project Implementation Tracker)  
+**Stage**: Stage 12 — Build Execution & Evidence  
+**Issue**: maturion-isms#1767  
+**Authority**: CS2 proxy authorization from Johan Ras  
+**Date**: 2026-06-01  
+**Builder**: `pit-specialist`  
+**Status**: AUTHORIZED_TO_START — implementation not complete, no FUNCTIONAL_PASS claim
+
+---
+
+## 1. Decision
+
+PIT is approved to enter Stage 12 Build Execution & Evidence.
+
+This artifact does not certify PIT as built, deployed, functionally complete, or ready for handover. It records that Stages 1–11 are sufficiently complete and governance-compliant for the appointed builder to begin build execution under the governed build model.
+
+---
+
+## 2. Entry basis
+
+Stage 12 entry is authorized because the build tracker records:
+
+- Stage 1 App Description: CS2 approved
+- Stage 2 UX Workflow & Wiring Spec: CS2 re-confirmed
+- Stage 3 FRS: hardened and CS2 re-confirmed
+- Stage 4 TRS: CS2 approved
+- Stage 5 Architecture: gate-passed
+- Stage 5b LFV Package: merged
+- Stage 6 QA-to-Red: gate-passed
+- Stage 7 PBFAG: gate-passed
+- Stage 8 Implementation Plan: gate-passed
+- Stage 9 Builder Checklist: gate-passed
+- Stage 10 IAA Pre-Brief: gate-passed
+- Stage 11 Builder Appointment: gate-passed
+- Build Authorization: CLEARED by CS2 in the tracker
+
+---
+
+## 3. Binding baseline
+
+The Stage 12 builder must build against the reconciled 147-test RED baseline.
+
+The following previously disputed rows are binding members of the baseline:
+
+- `PIT-RED-ROUTE-029`
+- `PIT-RED-TIMELINE-011`
+- `PIT-RED-TIMELINE-012`
+
+No Stage 12 closure may claim success unless the 147-test baseline is green with zero skipped/todo/placeholder tests.
+
+---
+
+## 4. Tracker hygiene cleanup note
+
+The CS2 proxy review identified two non-blocking tracker hygiene issues before kickoff:
+
+1. Older historical notes near the bottom of `modules/pit/BUILD_PROGRESS_TRACKER.md` still describe Stage 2 as awaiting re-confirmation and Stage 3/4 as pending. Those notes are superseded by the current stage sections and current stage summary, which mark Stage 2 and Stage 3 as CS2 re-confirmed and Stage 4 as CS2 approved.
+2. The tracker progress wording previously mixed an approximate `~91% complete` phrase with a weighted estimate that Stages 1–11 represent about 78% and Stage 12 represents about 22%. For Stage 12 governance, the authoritative status is: **pre-build Stages 1–11 are complete/gate-passed; Stage 12 is authorized to start but remains incomplete until build evidence is filed.**
+
+These hygiene issues do not reopen Stages 1–11 and do not block Stage 12 entry. They must not be used to claim `FUNCTIONAL_PASS` before deployed live verification.
+
+---
+
+## 5. Stage 12 hard constraints
+
+- No `FUNCTIONAL_PASS` until deployed LFV evidence and CS2 L3 verification exist.
+- No skipped/todo/placeholder tests can count as green evidence.
+- No scope expansion without CS2 approval and change-propagation audit.
+- Builder must build against the approved Stage 8 implementation plan.
+- Builder must build to the 147 RED baseline.
+- Builder may not self-QA final delivery.
+- Foreman/QP, ECAP, and IAA controls remain applicable.
+
+---
+
+## 6. Required Stage 12 closure evidence
+
+Stage 12 closure requires all of the following:
+
+- implementation code in `apps/` or `packages/`;
+- test evidence with 100% GREEN tests and zero failures/skips/todos;
+- QA validation results;
+- deployed visual runtime evidence;
+- deployed URL evidence;
+- role/permission evidence;
+- all 27 route coverage evidence;
+- evidence/report/notification/audit evidence;
+- accessibility smoke evidence;
+- CS2 live verification pack;
+- L1/L2/L3 closure declaration;
+- handover documentation;
+- no unresolved P0/P1 functional gaps.
+
+---
+
+## 7. First build-slice instruction
+
+The first Stage 12 implementation PR must start from the approved Stage 8 implementation plan under:
+
+- `modules/pit/08-implementation-plan/implementation-plan.md`
+- `modules/pit/08-implementation-plan/wave-to-red-test-manifest.md`
+- `modules/pit/08-implementation-plan/route-screen-state-acceptance-matrix.md`
+- `modules/pit/08-implementation-plan/wave-definition-of-done-template.md`
+
+The first implementation slice should be scoped narrowly enough to produce concrete code, tests, and evidence without claiming full module completion.

--- a/modules/pit/BUILD_PROGRESS_TRACKER.md
+++ b/modules/pit/BUILD_PROGRESS_TRACKER.md
@@ -2,9 +2,9 @@
 
 **Module**: PIT (Project Implementation Tracker)  
 **Module Slug**: pit  
-**Last Updated**: 2026-05-21
-**Updated By**: foreman-v2-agent (CS2 Build Authorization clearance after Stage 11 builder appointment — PR #1738; appointed builder: pit-specialist; Stage 12 remains NOT_STARTED)
-> **Classification**: ACTIVE — STAGE 4 CS2 APPROVED — STAGE 5 ARCHITECTURE GATE-PASSED (CS2/FOREMAN) — STAGE 5b LFV PACKAGE MERGED — STAGE 6 QA-TO-RED GATE-PASSED (CS2/FOREMAN) — STAGE 7 PBFAG GATE-PASSED (PRE-BUILD PACKAGE) — STAGE 8 GATE_PASSED (IMPLEMENTATION PLAN COMPLETE AND APPROVED) — STAGE 9 GATE_PASSED (BUILDER CHECKLIST COMPLETE AND APPROVED) — STAGE 10 GATE_PASSED (IAA PRE-BRIEF ACCEPTED; READINESS ONLY) — STAGE 11 GATE_PASSED (BUILDER APPOINTED — pit-specialist) — BUILD AUTHORIZATION CLEARED BY CS2 (TRACKER-EXPLICIT) — STAGE 12 NOT_STARTED  
+**Last Updated**: 2026-06-01
+**Updated By**: CS2 proxy kickoff authorization (issue #1767; appointed builder: pit-specialist; Stage 12 authorized to start, not complete)
+> **Classification**: ACTIVE — STAGE 4 CS2 APPROVED — STAGE 5 ARCHITECTURE GATE-PASSED (CS2/FOREMAN) — STAGE 5b LFV PACKAGE MERGED — STAGE 6 QA-TO-RED GATE-PASSED (CS2/FOREMAN) — STAGE 7 PBFAG GATE-PASSED (PRE-BUILD PACKAGE) — STAGE 8 GATE_PASSED (IMPLEMENTATION PLAN COMPLETE AND APPROVED) — STAGE 9 GATE_PASSED (BUILDER CHECKLIST COMPLETE AND APPROVED) — STAGE 10 GATE_PASSED (IAA PRE-BRIEF ACCEPTED; READINESS ONLY) — STAGE 11 GATE_PASSED (BUILDER APPOINTED — pit-specialist) — BUILD AUTHORIZATION CLEARED BY CS2 (TRACKER-EXPLICIT) — STAGE 12 AUTHORIZED_TO_START / INCOMPLETE  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.1.0 (effective 2026-04-05)  
 > **Governing Issue**: [maturion-isms#1255](https://github.com/APGI-cmy/maturion-isms/issues/1255)
 > **Retrofit Issue**: [maturion-isms#1575](https://github.com/APGI-cmy/maturion-isms/issues/1575) — PIT pre-build functional delivery retrofit (PR #1576)
@@ -16,457 +16,70 @@
 This tracker was migrated from the legacy 6-stage format to the canonical 12-stage format
 per wave `align-12stage-prebuild-20260406` (2026-04-06).
 
-**Anomaly Flagged (RESOLVED)**: At migration time (2026-04-06), the `00-app-description/` folder was empty (no `app-description.md` found). This has since been resolved: App Description v1.0 was created per maturion-isms#1534 and approved by CS2/Johan Ras on 2026-05-06 per maturion-isms#1540. The Architecture work (`architecture.md`, `data-contracts/`, `exports/`, `integrations/`, `qa/`, `ui-ux/`, `watchdog/`, `_legacy/`) is preserved and will be gate-passed after the canonical upstream stages are completed.
+**Anomaly Flagged (RESOLVED)**: At migration time (2026-04-06), the `00-app-description/` folder was empty (no `app-description.md` found). This has since been resolved: App Description v1.0 was created per maturion-isms#1534 and approved by CS2/Johan Ras on 2026-05-06 per maturion-isms#1540. The Architecture work (`architecture.md`, `data-contracts/`, `exports`, `integrations`, `qa`, `ui-ux`, `watchdog`, `_legacy`) is preserved and was later superseded/reconciled by the gate-passed canonical Stage 5 Architecture package.
 
 **Old → New Stage Mapping**:
 | Old Stage | Old Name | New Stage | New Name | Status |
 |-----------|----------|-----------|----------|--------|
 | Stage 0 | App Description | Stage 1 | App Description | CS2_APPROVED_AUTHORITATIVE |
-| Stage 1 | FRS | Stage 3 | FRS | DRAFT_HARDENED v0.2 (pending CS2 approval) |
-| Stage 1.5 | TRS | Stage 4 | TRS | DRAFT_CREATED |
-| Stage 2 | Architecture | Stage 5 | Architecture | IN_PROGRESS |
+| Stage 1 | FRS | Stage 3 | FRS | CS2_RECONFIRMED v0.2-hardened |
+| Stage 1.5 | TRS | Stage 4 | TRS | CS2_APPROVED v0.2-draft |
+| Stage 2 | Architecture | Stage 5 | Architecture | GATE_PASSED — ARCHITECTURE_RECONCILIATION_COMPLETE_AND_APPROVED |
 | Stage 3 | Implementation Plan | Stage 8 | Implementation Plan | GATE_PASSED — IMPLEMENTATION_PLAN_COMPLETE_AND_APPROVED (maturion-isms#1679; 2026-05-19) |
 | Stage 4 | Builder Appointment | Stage 11 | Builder Appointment | GATE_PASSED — BUILDER_APPOINTED (pit-specialist; maturion-isms#1729) |
-| Stage 5 | Build | Stage 12 | Build | NOT_STARTED (partial AIMC artifact) |
-| — | (new stage) | Stage 2 | UX Workflow & Wiring Spec | NOT_STARTED |
-| — | (new stage) | Stage 6 | QA-to-Red | NOT_STARTED |
+| Stage 5 | Build | Stage 12 | Build | AUTHORIZED_TO_START / INCOMPLETE (partial AIMC artifact remains historical only) |
+| — | (new stage) | Stage 2 | UX Workflow & Wiring Spec | CS2_RECONFIRMED |
+| — | (new stage) | Stage 6 | QA-to-Red | GATE_PASSED — QA_TO_RED_DERIVATION_COMPLETE_AND_REVIEWED |
 | — | (new stage) | Stage 7 | PBFAG | GATE_PASSED — PBFAG_COMPLETE_AND_APPROVED (pre-build package; no live execution claim) |
 | — | (new stage) | Stage 9 | Builder Checklist | GATE_PASSED — BUILDER_CHECKLIST_COMPLETE_AND_APPROVED (maturion-isms#1687; 2026-05-19) |
 | — | (new stage) | Stage 10 | IAA Pre-Brief | GATE_PASSED — IAA_PRE_BRIEF_ACCEPTED (readiness-only; blocker carried forward) |
 
 ---
 
-## Module Lifecycle Progress
+## Stage 12 Kickoff Authorization Note
 
-Track the progression through the canonical module lifecycle stages per `PRE_BUILD_STAGE_MODEL_CANON.md` v1.1.0.
+PIT is approved to enter Stage 12 under issue [#1767](https://github.com/APGI-cmy/maturion-isms/issues/1767).
 
-### Stage 1: App Description
-**Status**: [x] CS2_APPROVED_AUTHORITATIVE  
-**Location**: `modules/pit/00-app-description/`  
-**Key Artifacts**:
-- [x] `app-description.md` — Full App Description v1.0 (Authoritative; 1750 lines; §AD-01–§AD-24 complete + MMM Lessons Promoted section)
-- [x] All §AD-01–§AD-24 sections per `APP_DESCRIPTION_REQUIREMENT_POLICY.md` v2.0 complete
-- [x] App Description approved by CS2/Johan Ras — **APPROVED 2026-05-06** (ref: maturion-isms#1540)
+This approval means Stage 12 build execution may begin under the appointed builder `pit-specialist` and the 147-test RED baseline. It does **not** mean PIT is built, deployed, functionally complete, or ready for handover. `FUNCTIONAL_PASS` remains not claimable until deployed LFV evidence, CS2 L3 verification, and Stage 12 closure evidence exist.
 
-**Artifact Paths**:
-- Authoritative (canonical per policy §4.1): `docs/governance/PIT_APP_DESCRIPTION.md`
-- Module-stage copy: `modules/pit/00-app-description/app-description.md`
-- Checklist Evidence: `.agent-admin/evidence/app-description-checklist/pit-20260506.md`
-
-**Checklist Result**: PASS — Authoritative / CS2 Approved  
-**Build Authorization**: NOT CLEARED — implementation blocked until Stages 2–11 completed and gate-passed  
-**Completion Date**: 2026-05-06 (CS2 approval)  
-**Notes**: App Description v1.0 filed per maturion-isms#1534 (Draft), approved per maturion-isms#1540.
-Module name corrected from "Penetration Intelligence Tool" to "Project Implementation Tracker".
-Source document was prepared by CS2/Johan + assistant-assisted drafting under Johan Ras direction.
-MMM Lessons Promoted Into PIT section added per Foreman governance directive (L-001 through L-008 +
-Stage 2 carry-forward requirements). Draft files deleted. Authoritative canonical location:
-`docs/governance/PIT_APP_DESCRIPTION.md`. Synchronised module-stage copy:
-`modules/pit/00-app-description/app-description.md`.
+Stage 12 kickoff artifact: `modules/pit/12-build/stage12-kickoff-authorization.md`.
 
 ---
 
-### Stage 2: UX Workflow & Wiring Spec
-**Status**: [x] CS2_APPROVED_RECONFIRMED (Johan/CS2) — baseline locked for Stage 4/5 derivation  
-**Location**: `modules/pit/01-ux-workflow-wiring-spec/`  
-**Key Artifacts**:
-- [x] `ux-workflow-wiring-spec.md` — Complete user journey maps, screen interactions, data flows, wiring (v0.2-draft)
-- [x] All primary and secondary user paths documented (23 journeys including all auth flows, My Work journey, and Invitation Acceptance)
-- [x] Explicit wiring between UI elements, API endpoints, schema tables, and reporting outputs (Section 7 wiring table)
-- [x] All 5 UI states for every primary page (Section 4 state matrix)
-- [x] All 7 Implementation Page top indicators (Section 3)
-- [x] App shell/navigation and root-level notification pattern (Section 5)
-- [x] Timeline creator interactions and date-alignment expectations (Section 6)
-- [x] AIMC-only AI touchpoints documented (Section 8)
-- [x] Deployment surface map (Section 9)
-- [x] Functional delivery retrofit verification added (Section 12 — maturion-isms#1575)
-- [x] UX-GAP-001 resolved (404 route state/wiring entries present in Section 4 and Section 7)
-- [x] UX-GAP-002 resolved (notification history screen spec `/notifications` added in Section 2, Section 4, Section 7, and Section 9 — PR #1594)
-- [x] CS2 approval/re-confirmation recorded by Johan/CS2 in tracker context
-- [x] Stage 2 re-confirmed after retrofit review (maturion-isms#1575)
+## Current Stage Summary
 
-**Completion Date**: 2026-05-11 (CS2 re-confirmation recorded; originally Foreman-reviewed 2026-05-06)  
-**Stage 2 Completion Evidence**: `.agent-admin/evidence/stage2-completion-checklist/pit-stage2-20260506.md`  
-**Retrofit Gap Register**: `modules/pit/_readiness/pit-functional-delivery-gap-register.md` (UX-GAP-001, UX-GAP-002)  
-**Notes**: Stage 2 UX Workflow & Wiring Spec v0.2-draft reviewed in retrofit wave (maturion-isms#1575). UX-GAP-001 and UX-GAP-002 resolved in PR #1594. CS2/Johan re-confirmation is now recorded. Build Authorization remains NOT CLEARED.
----
+**Current Stage**:
+- Stage 12 Build Execution & Evidence **AUTHORIZED_TO_START / INCOMPLETE** (issue #1767; builder: pit-specialist; 147 RED baseline binding; no FUNCTIONAL_PASS claim)
+- Stage 11 Builder Appointment **GATE_PASSED — BUILDER_APPOINTED** (maturion-isms#1729 / PR #1730; 2026-05-21; pit-specialist appointed)
+- Stage 10 IAA Pre-Brief **GATE_PASSED — IAA_PRE_BRIEF_ACCEPTED** (2026-05-20; readiness-only gate; blocker integrity preserved via `iaa-response.md` + `stage10-gate-pass-review.md`)
+- Stage 9 Builder Checklist **GATE_PASSED — BUILDER_CHECKLIST_COMPLETE_AND_APPROVED** (maturion-isms#1687; review 2026-05-19; reconfirmed 2026-05-20 per `stage9-post-stage8-hardening-reconfirmation.md`)
+- Stage 8 Implementation Plan **GATE_PASSED — IMPLEMENTATION_PLAN_COMPLETE_AND_APPROVED** (maturion-isms#1679; review 2026-05-19; all 9 Functional-Delivery Guardrails verified PASS; builder-executable hardening addendum artifacts filed under `modules/pit/08-implementation-plan/` via PR #1693)
+- Stage 7 PBFAG **GATE_PASSED** — PBFAG_COMPLETE_AND_APPROVED (2026-05-19; pre-build package assessment only)
+- Stage 6 QA-to-Red **GATE_PASSED** — RED suite reviewed and gate-passed by CS2/Foreman (2026-05-18)
+- Stage 5 Architecture **GATE_PASSED** — CS2/Foreman gate-pass recorded (2026-05-18; maturion-isms#1611 package reviewed)
+- Stage 5b LFV Package MERGED (maturion-isms#1623, PR #1624)
+- Stage 4 TRS CS2 APPROVED (maturion-isms#1604)
+- Stage 3 FRS CS2 re-confirmed
+- Stage 2 UX CS2 re-confirmed
+- Stage 1 App Description CS2 approved
 
-### Stage 3: Functional Requirements Specification (FRS)
-**Status**: [x] DRAFT_HARDENED_CS2_RECONFIRMED — baseline locked for Stage 4/5 derivation  
-**Location**: `modules/pit/02-frs/`  
-**Key Artifacts**:
-- [x] `functional-requirements.md` — Stage 3 FRS **v0.2-hardened**, derived from App Description v1.0 + UX Workflow & Wiring Spec v0.2-draft
-- [x] Derivation statements from both upstream artifacts included
-- [x] Numbered functional requirements (PIT-FR-001 through PIT-FR-123) — testable, phrased as "The system shall..."
-- [x] Auth/onboarding, all primary screens, 5 UI states, project hierarchy, timeline, evidence, assignment, watchdog, reporting, audit, QA dashboard, AIMC, cross-module integrations covered
-- [x] Acceptance criteria for every requirement or requirement group
-- [x] Traceability matrix (App Description → Stage 2 → FRS requirement ID → future stage placeholder)
-- [x] Domain-based Requirement Index added (§1.5)
-- [x] Table/entity naming caveat added (§1.4)
-- [x] Role-scope matrix added (§3.1)
-- [x] PIT-FR-113 Permission Negative-Path Contract added
-- [x] PIT-FR-121 Lifecycle Removal Semantics (archive/delete/restore/cancel) added
-- [x] PIT-FR-054 task status lifecycle updated (added `cancelled`)
-- [x] PIT-FR-052 evidence completion logic clarified (task-level and deliverable-level paths)
-- [x] PIT-FR-114 Progress Roll-Up Method added
-- [x] RAG Threshold Central Table added (§29)
-- [x] PIT-FR-115–117 Notification read/history/preference requirements added
-- [x] PIT-FR-118–119 Report permissions/states/history scope hardened (report history now mandatory)
-- [x] PIT-FR-120 QA Dashboard expanded requirements added
-- [x] AIMC endpoint candidate wording added (§24)
-- [x] Route Coverage Appendix added (Appendix A — all 27 routes)
-- [x] PIT-FR-122 Minimum Accessibility Outcomes added
-- [x] PIT-FR-123 Bulk Operations Non-Scope Declaration added
-- [x] Section 33 Build-Completeness Guardrails added
-- [x] Section 34 QA-to-Red Derivation Requirements added
-- [x] Section 38 Stage 4 readiness wording aligned with draft-only TRS governance
-- [x] Functional delivery retrofit verification note added (maturion-isms#1575)
-- [x] CS2 approval/re-confirmation recorded by Johan/CS2 in tracker context
-- [x] Stage 3 re-confirmed after retrofit review (maturion-isms#1575)
-
-**Completion Date**: 2026-05-11 (CS2 re-confirmation recorded; draft hardened 2026-05-07)  
-**Notes**: FRS v0.2-hardened verified in retrofit wave (maturion-isms#1575). All 19 hardening areas confirmed present. CS2/Johan re-confirmation now recorded. Build Authorization remains NOT CLEARED.
+**Retrofit Status**: COMPLETE — maturion-isms#1575 / PR #1576 (2026-05-08)  
+**Overall Progress**: Pre-build Stages 1–11 complete/gate-passed. Stage 12 is authorized to start but remains incomplete. No percentage-complete claim is made until Stage 12 implementation evidence exists.  
+**Build Authorization**: **CLEARED** — explicitly cleared by CS2 (`@APGI-cmy`) in tracker update PR #1738 and reaffirmed by issue #1767 after Stage 9/10/11 evidence verification and 147 RED baseline reconciliation confirmation. Appointed builder is `pit-specialist`.  
+**Blockers**: No Stage 1–11 governance blocker remains. Stage 12 closure remains blocked until implementation code, tests, deployed LFV evidence, CS2 L3 verification, and handover documentation are complete.  
+**Next Steps**:
+1. Begin Stage 12 execution from the approved Stage 8 implementation plan.
+2. Keep the 147 RED baseline binding for all build waves.
+3. Do not claim FUNCTIONAL_PASS until deployed LFV evidence and CS2 L3 verification exist.
+4. Maintain no-scope-expansion/no-test-debt/no-placeholder rules throughout Stage 12.
 
 ---
 
-### Stage 4: Technical Requirements Specification (TRS)
-**Status**: [x] **CS2_APPROVED** — CS2/Johan Ras approved/re-confirmed Stage 4 TRS v0.2-draft (ref: maturion-isms#1604, closed as "completed" by @APGI-cmy 2026-05-11)
-**Location**: `modules/pit/03-trs/`  
-**Key Artifacts**:
-- [x] `technical-requirements-specification.md` — Technical constraints, performance requirements, integration requirements, AIMC contracts, RLS design, table definitions, Edge Function contracts (PIT-TR-001 to PIT-TR-126)
-- [x] `frs-to-trs-traceability.md` — Traceability matrix linking all **123 FRS requirements** and 10 NF placeholders to TRS requirements across 32 domains
-- [x] `timeline-engine-technical-validation.md` — Stage 4 timeline engine technical validation + legacy Action tracker coverage/gap classification evidence
-- [x] FRS v0.2-hardened propagation complete — PIT-TR-116 through PIT-TR-126 added (Section 31 of TRS) — covers PIT-FR-113 to PIT-FR-123
-- [x] TRS derivation updated to reference FRS v0.2-hardened (maturion-isms#1556) — no longer derives from v0.1-draft
-- [x] FRS-to-TRS traceability Section 30 added — all 123 FRS requirements now traced
-- [x] Tool validation and quality gate definitions — included in `technical-requirements-specification.md` (Section 25, PIT-TR-100 to PIT-TR-107)
-- [x] Stale maturion-isms#1556 dependency notice resolved in retrofit wave (maturion-isms#1575 / PR #1576)
-- [x] TRS approved by designated authority — **CS2 APPROVED 2026-05-11 (maturion-isms#1604, closed by @APGI-cmy)**
-- [x] TRS re-confirmation preparation completed after retrofit review (maturion-isms#1575) with explicit timeline-engine feasibility validation (maturion-isms#1604)
-
-**Completion Date**: 2026-05-11 (CS2 approval — maturion-isms#1604 closed by @APGI-cmy)
-**Notes**: TRS v0.1-draft created per maturion-isms#1554 (wave: pit-stage4-trs). Updated to v0.2-draft in retrofit wave (maturion-isms#1575 / PR #1576): derivation updated to FRS v0.2-hardened; Section 31 added with PIT-TR-116 through PIT-TR-126 covering all FRS v0.2-hardened additions (PIT-FR-113 to PIT-FR-123); FRS-to-TRS traceability updated to cover all 123 FRS requirements. Stage 4 timeline-engine technical feasibility validation added per maturion-isms#1604. CS2/Johan Ras approved/re-confirmed Stage 4 TRS v0.2-draft by closing maturion-isms#1604 as "completed" on 2026-05-11. Stage 5 Architecture reconciliation now underway (maturion-isms#1611). Build Authorization remains NOT CLEARED.
-
----
-
-### Stage 5: Architecture
-**Status**: [x] **GATE_PASSED — ARCHITECTURE_RECONCILIATION_COMPLETE_AND_APPROVED** (maturion-isms#1611; CS2/Foreman gate-pass 2026-05-18)
-**Location**: `modules/pit/04-architecture/`  
-**Key Artifacts**:
-- [x] `architecture.md` — Stage 5 Architecture v1.0 — **REPLACED** legacy content; derived from approved Stages 1–4; all 27 routes and 22 screens mapped; all 126 TRS requirements reconciled (maturion-isms#1611)
-- [x] `stage5-architecture-reconciliation.md` — Stage 5 reconciliation evidence checklist (NEW — maturion-isms#1611)
-- [x] `trs-to-architecture-traceability.md` — Full TRS-to-Architecture traceability: all 126 TRS requirements (PIT-TR-001–PIT-TR-126) mapped to architecture sections (NEW — maturion-isms#1611)
-- [x] `timeline-engine-architecture-decision.md` — ADR-PIT-001: Timeline engine library evaluation (5 candidates), date-math contract, QA hooks, accessibility architecture (NEW — maturion-isms#1611)
-- [x] `app-description-to-architecture-traceability.md` — App Description §AD-01–AD-24 → Architecture coverage matrix: all 24 AD requirements COVERED, zero BLOCKING_GAP (NEW — maturion-isms#1611)
-- [x] `data-contracts/` — Legacy reference (superseded by architecture.md §6)
-- [x] `exports/` — Legacy reference (superseded by architecture.md §14)
-- [x] `integrations/` — Legacy reference (superseded by architecture.md §18)
-- [x] `qa/` — Legacy reference (superseded by per-section QA hooks in architecture.md)
-- [x] `ui-ux/` — Legacy reference (superseded by architecture.md §2–§3)
-- [x] `watchdog/` — Legacy reference (superseded by architecture.md §17)
-- [x] `_legacy/` — Legacy pre-canonical content preserved as reference only
-- [x] Architecture formally reconciled against all upstream approved artifacts (see reconciliation checklist)
-- [x] All TRS requirements (PIT-TR-001 to PIT-TR-126) traceable to architecture components (see trs-to-architecture-traceability.md — 126/126 COVERED)
-- [x] Architecture approved by CS2/Foreman — RECONCILIATION_COMPLETE — GATE_PASSED (2026-05-18 review authority: @APGI-cmy + foreman-v2-agent)
-
-**Stage 5 Reconciliation Requirements (added in retrofit wave maturion-isms#1575)**:
-
-Before Stage 5 Architecture can be gate-passed, it must be formally reconciled against ALL of the following:
-
-- [x] Approved Stage 1 App Description (`docs/governance/PIT_APP_DESCRIPTION.md` v1.0)
-- [x] CS2-approved Stage 2 UX Workflow & Wiring Spec (including UX-GAP-001 and UX-GAP-002 resolved)
-- [x] CS2-approved Stage 3 FRS v0.2-hardened (all 123 requirements, including PIT-FR-113 to PIT-FR-123)
-- [x] Updated Stage 4 TRS v0.2-draft (including PIT-TR-116 to PIT-TR-126) — CS2 approved maturion-isms#1604
-- [x] Route Coverage Appendix A (all 27 routes — component-level architecture for each route) — architecture.md §3.1
-- [x] RLS / access-control model (all tables with RLS policies per PIT-TR-026; negative-path enforcement per PIT-TR-116) — architecture.md §7
-- [x] Evidence upload / storage model (Supabase Storage per PIT-TR-060; retention per PIT-TR-122) — architecture.md §11
-- [x] Notification / report / audit / QA dashboard model (system-level component architecture for each domain) — architecture.md §12–§16
-- [x] Deployment / runtime delivery contract (per PIT-TR-095, PIT-TR-098, PIT-TR-113) — architecture.md §19
-- [x] MMM-derived functional delivery controls (L-001 through L-008 mapped to architecture components) — architecture.md §22
-- [x] Lifecycle removal semantics architecture (soft-delete, archive, restore, cancel — per PIT-TR-124) — architecture.md §6.4
-- [x] Accessibility compliance architecture (Axe-core integration per PIT-TR-125) — architecture.md §20
-- [x] Progress roll-up computation architecture (Edge Function or trigger per PIT-TR-117) — architecture.md §13
-
-**Completion Date**: 2026-05-18 (CS2/Foreman Stage 5 gate-pass review complete)
-**Notes**: Stage 5 Architecture gate-pass review completed per this issue. Reviewed against Stage 1–4 authority chain, App Description §AD-01–§AD-24 matrix, TRS coverage (PIT-TR-001 through PIT-TR-126), timeline architecture sufficiency, route/screen/state architecture, and architecture completeness requirements (including §§3.14–3.17). No Stage 5 `BLOCKING_GAP` rows remain. Path bindings for renamed/consolidated review inputs: `runtime-deployment-architecture.md` → `modules/pit/07-pbfag/runtime-deployment-contract.md`; `qa-catalog-alignment.md` → consolidated in `modules/pit/04-architecture/architecture.md` §26 and reflected in `modules/pit/07-pbfag/stage6-red-suite-assessment.md`. Build Authorization remains NOT CLEARED.
-
----
-
-### Stage 5b: PIT LFV Package
-**Status**: [x] MERGED — PR #1624 closed and merged
-**Location**: `modules/pit/05-live-functional-verification/`
-**Governing Issue**: [maturion-isms#1623](https://github.com/APGI-cmy/maturion-isms/issues/1623)
-**PR**: [#1624](https://github.com/APGI-cmy/maturion-isms/pulls/1624)
-**Wave**: pit-lfv-package-20260512 (2026-05-12)
-
-**Key Artifacts**:
-- [x] `01_FUNCTIONAL_USER_JOURNEY_CONTRACT.md` — 16 PIT user journeys with step tables, success/failure criteria
-- [x] `02_AGENT_ACCESS_MATRIX.md` — 18 secrets and runtime access matrix (all 5 execution contexts)
-- [x] `03_DEPLOYED_VERIFICATION_PLAN.md` — Vercel URL strategy, bypass mechanism, 8-gate pass/fail table
-- [x] `04_CTA_BACKEND_STATE_MAP.md` — 17 CTAs mapped: UI element → endpoint → table/bucket → state change → audit evidence
-- [x] `05_TEST_IDENTITY_AND_ROLE_MATRIX.md` — 7 test identities (cs2_admin through unauthenticated), fixture files, seed data
-- [x] `06_LIVE_VERIFICATION_WORKFLOW_SPEC.md` — Workflow architecture, 10 output fields, 5 artifacts, 8 readiness criteria
-- [x] `07_DASHBOARD_STATE_REFLECTION_GATE.md` — 11 reflection checks (before/after/evidence for each state change)
-- [x] `08_HANDOVER_EVIDENCE_REQUIREMENTS.md` — 8 evidence artifacts, 8 gates with evidence types, IAA three-tier verdict
-- [x] `09_CS2_UI_ACCEPTANCE_CHECKLIST.md` — CS2 (Johan Ras) manual verification checklist, 11 sections, sign-off block
-- [x] `pit-live-verification-workflow.yml` — DESIGN ARTIFACT (7 jobs, all PIT-specific secrets, full Playwright script)
-
-**IAA Verdict (this wave)**:
-- [x] ADMIN_PASS: yes — all 10 governance artifacts created and PIT-specific
-- [ ] CODE_PASS: deferred — no application code in this wave; CODE_PASS applies to Stage 12 build wave
-- [ ] FUNCTIONAL_PASS: NOT CLAIMABLE — PIT not yet built or deployed; requires live deployment + LFV workflow run + CS2 sign-off
-
-> **PIT LFV Package Lifecycle Note**:  
-> LFV artifacts are mandatory pre-build governance evidence required before Stage 12 (Build Execution)  
-> can claim FUNCTIONAL_PASS. These artifacts define the verification requirements; they do not execute  
-> them. FUNCTIONAL_PASS will be claimable only after:  
-> 1. Stage 12 build is complete and PIT is deployed to a live Vercel environment  
-> 2. `pit-live-verification.yml` workflow has been activated (Stage 8 authorisation) and run successfully  
-> 3. All 8 LFV gates PASS in the deployed environment  
-> 4. CS2 (Johan Ras) completes `09_CS2_UI_ACCEPTANCE_CHECKLIST.md` with FUNCTIONAL_PASS: yes sign-off  
->
-> **No implementation, builder appointment, or handover is authorised by this issue.**  
-> Build Authorization remains NOT CLEARED. Stage 6 and Stage 7 are gate-passed in pre-build scope.
-
-**Completion Date**: 2026-05-12 (LFV package created; Stage 5 review now gate-passed 2026-05-18)
-**Notes**: PIT LFV Package created per maturion-isms#1623 (PR #1624). All 9 markdown artifacts + 1 workflow design artifact produced. Content is PIT-specific (not generic template text). Covers all 27 PIT routes, all 7 roles, all 10 Edge Functions, both storage buckets, Supabase Realtime, and AIMC Gateway pattern. Workflow design artifact stored in `modules/pit/05-live-functional-verification/` — NOT in `.github/workflows/` (active installation deferred to Stage 8).
-
----
-
-### Stage 6: QA-to-Red
-**Status**: [x] GATE_PASSED — QA_TO_RED_DERIVATION_COMPLETE_AND_REVIEWED (maturion-isms#1625 / PR #1626; CS2/Foreman gate-pass 2026-05-18)  
-**Location**: `modules/pit/06-qa-to-red/`  
-> **Path Note**: Stage 5b LFV Package occupies `modules/pit/05-live-functional-verification/`. Stage 6 QA-to-Red is correctly located at `modules/pit/06-qa-to-red/` to avoid path conflict.  
-**Key Artifacts**:
-- [x] `qa-to-red-plan.md` — Stage 6 methodology, scope, sources, gates, non-goals
-- [x] `red-test-suite-catalog.md` — 147 RED tests across 13 categories (PIT-RED-ROUTE, AUTH, RLS, PROJECT, TIMELINE, EVIDENCE, NOTIFICATION, REPORT, AUDIT, QA, AIMC, LFV, NFR)
-- [x] `frs-to-red-traceability.md` — PIT-FR-001 through PIT-FR-123 all mapped (122 RED_TEST_DEFINED, 1 NOT_TESTABLE)
-- [x] `trs-to-red-traceability.md` — PIT-TR-001 through PIT-TR-126 all mapped (124 RED_TEST_DEFINED, 2 NOT_TESTABLE)
-- [x] `architecture-to-red-traceability.md` — 27 routes, 22 screens, all architecture domains covered
-- [x] `lfv-to-red-traceability.md` — 9 LFV artifacts + workflow fully mapped to RED tests
-- [x] `route-screen-state-red-matrix.md` — 27 routes × 5 states coverage matrix
-- [x] `role-denied-path-red-matrix.md` — 7 roles × protected action groups coverage matrix
-- [x] `timeline-engine-red-tests.md` — 12 timeline RED test specifications
-- [x] `live-functional-red-gates.md` — 10 LFV RED gates (all P1)
-- [x] `stage6-gate-readiness-checklist.md` — gate readiness checklist with posture declaration
-
-**Functional-Delivery Guardrails (added maturion-isms#1575 — MANDATORY for Stage 6 gate-pass)**:
-
-Stage 6 must derive RED tests for each of the following categories. Gaps in any category are a Stage 6 gate-fail:
-
-- [x] Every functional requirement (PIT-FR-001 through PIT-FR-123)
-- [x] Every TRS requirement that specifies a testable contract (PIT-TR-001 through PIT-TR-126)
-- [x] Every route (all 27 routes in Appendix A / Section 9) — direct browser load test per route
-- [x] Every screen (all 22 screens from Stage 2 Section 2)
-- [x] Every primary user journey (all 23 journeys from Stage 2 Section 1)
-- [x] Every five-state UI outcome on every primary screen (loading/empty/permission-denied/network-error/data)
-- [x] Every role-denied path (per PIT-FR-113 / PIT-TR-116): at least one denied-path test per protected action group
-- [x] Every create/edit/delete/archive/cancel/status transition (per PIT-FR-121 / PIT-TR-124)
-- [x] Evidence submission/review/blocking flows (per PIT-FR-062–067 / PIT-TR-060–063)
-- [x] All notification events, mark-as-read, history, preferences (per PIT-FR-115–117 / PIT-TR-118–120)
-- [x] Report export generation/download/history/failure (per PIT-FR-118–119 / PIT-TR-121–122), including denied-path tests
-- [x] All AIMC touchpoints and no-direct-provider-call rule (per PIT-FR-095 / PIT-TR-083)
-- [x] Direct SPA route loads (navigate directly to URL in deployed environment — not just file existence)
-- [x] App-shell and global-style visual rendering checks (per L-002 / PIT-TR-009, PIT-TR-092)
-- [x] Live deployment smoke checks (per L-007 / PIT-TR-114 — in deployed environment, not localhost only)
-- [x] Minimum accessibility outcomes (per PIT-FR-122 / PIT-TR-125): axe-core zero violations, keyboard navigation
-- [x] QA Dashboard evidence visibility (per PIT-FR-120 / PIT-TR-123): cs2_admin can see wave evidence; others denied
-- [x] Progress roll-up computation (per PIT-FR-114 / PIT-TR-117): unit test for computation; E2E for project-level update
-- [x] Lifecycle removal semantics (per PIT-FR-121 / PIT-TR-124): archive/restore/cancel confirmed excluded/included in roll-up
-
-> **LFV Derivation Added (maturion-isms#1625)**: Stage 5b LFV Package treated as input to Stage 6. All 9 LFV artifacts + workflow mapped in `lfv-to-red-traceability.md`. 10 LFV RED gates defined in `live-functional-red-gates.md`. No FUNCTIONAL_PASS without deployed LFV evidence.
-
-**Gate-Pass Prerequisites**: Stage 5 Architecture gate-pass and Stage 5b LFV package prerequisites are satisfied. Stage 7 PBFAG may now be assessed in a separate review step. No Stage 7 gate-pass is claimed in this issue.
-
-**Stage 6 RED Suite Statistics**: 147 tests defined (CS2 Option B reconciliation baseline); 0 BLOCKING_GAP; FRS coverage 122/123 (1 NOT_TESTABLE: PIT-FR-123); TRS coverage 124/126 (2 NOT_TESTABLE: PIT-TR-115, PIT-TR-126)
-
-**Completion Date**: 2026-05-18 (Stage 6 gate-pass review complete)  
-**Notes**: Stage 6 QA-to-Red review completed after Stage 5 gate-pass confirmation. Baseline has been reconciled to 147 RED tests under CS2 Option B (issue #1714 / PR #1715), explicitly including `PIT-RED-ROUTE-029`, `PIT-RED-TIMELINE-011`, and `PIT-RED-TIMELINE-012`. FRS/TRS traceability coverage, architecture-to-RED and LFV-to-RED mappings, route/screen/state matrix, role denied-path matrix, timeline RED tests, live-functional RED gates, and Stage 6 Functional-Delivery Guardrails derivation remain intact. No unresolved Stage 6 `BLOCKING_GAP` entries remain. Stage 6 does NOT start implementation, appoint a builder, install active workflows, clear Build Authorization, or claim FUNCTIONAL_PASS. Stage 7 may now be assessed separately. Build Authorization remains NOT CLEARED.
-
----
-
-### Stage 7: PBFAG (Pre-Build Functionality Assessment Gate)
-**Status**: [x] GATE_PASSED — PBFAG_COMPLETE_AND_APPROVED (pre-build package assessment)  
-**Location**: `modules/pit/07-pbfag/`  
-**Key Artifacts**:
-- [x] `pbfag-plan.md` — Stage 7 methodology, scope, prerequisites, non-goals
-- [x] `pbfag-checklist.md` — PBFAG checks with allowed-status declarations
-- [x] `change-propagation-audit.md` — upstream-to-downstream propagation matrix
-- [x] `runtime-deployment-contract.md` — pre-build deployment/runtime boundary contract
-- [x] `golden-path-verification-pack.md` — required golden-path verification definitions
-- [x] `stage6-red-suite-assessment.md` — Stage 6 RED assessment coverage artifact (includes explicit §3.17 QA Catalog alignment decision)
-- [x] `lfv-readiness-assessment.md` — LFV anti-regression readiness assertions
-- [x] `route-render-verification-plan.md` — deployed plan for all 27 PIT routes
-- [x] `role-negative-path-verification-plan.md` — deployed denied-path spot-check plan
-- [x] `stage7-gate-readiness-checklist.md` — prerequisite and boundary enforcement posture
-
-**Functional-Delivery Guardrails (added maturion-isms#1575 — MANDATORY for Stage 7 gate-pass)**:
-
-PBFAG must include all of the following verifications. Any FAIL is a PBFAG gate-fail.  
-**Assessment basis in this stage**: checked as pre-build package definition/evidence-contract coverage only; live deployed execution evidence remains post-build work.
-
-- [x] Deployed route render verification: all 27 routes render correct component in deployed environment (verification plan and evidence contract defined)
-- [x] Golden path verification pack: happy-path E2E for all primary journeys (Stage 2 journeys 1–23) is defined and mapped
-- [x] Visual rendering / app-shell / global CSS checks: no white screens, no layout flash, app shell renders in all 5 states are explicitly defined
-- [x] Auth / signup / invite / reset / onboarding checks: all auth-route checks are explicitly defined for deployed verification
-- [x] Role permission negative-path spot checks (per PIT-TR-116): minimum denied-path coverage contract is defined
-- [x] Evidence workflow check: upload → review → approve/return cycle functional end-to-end is explicitly defined
-- [x] Report export check: generation/download/permission-denied verification is explicitly defined
-- [x] Notification check: trigger notification → bell badge → mark-as-read cycle is explicitly defined
-- [x] Audit evidence check: representative audit event + export verification is explicitly defined
-- [x] Deployment contract check (per PIT-TR-113): deployment contract document is filed and current
-- [x] No unresolved FRS/TRS open assumptions that would block functionality in Stage 7 pre-build scope
-- [x] No build-authorisation leakage: Build Authorization remains NOT CLEARED
-
-**Completion Date**: 2026-05-19  
-**Notes**: Stage 7 PBFAG package under `modules/pit/07-pbfag/` was assessed and gate-passed for pre-build readiness scope on 2026-05-19 by foreman-v2-agent. This decision records that required verification definitions and evidence contracts are complete and that prerequisite Stage 5/6 gate-pass conditions are satisfied. It does NOT claim live deployed execution evidence, does NOT claim FUNCTIONAL_PASS, does NOT start implementation, does NOT appoint a builder, does NOT start Stage 8 in this issue, and does NOT clear Build Authorization.
-
----
-
-### Stage 8: Implementation Plan
-**Status**: [x] GATE_PASSED — IMPLEMENTATION_PLAN_COMPLETE_AND_APPROVED (maturion-isms#1679; review authority: foreman-v2-agent; 2026-05-19)  
-**Location**: `modules/pit/08-implementation-plan/`  
-**Key Artifacts**:
-- [x] `implementation-plan.md` — Delivery wave breakdown with explicit scope per wave
-- [x] `stage8-gate-pass-review.md` — Stage 8 gate-pass evidence: all 22 issue #1679 checklist items verified PASS; all 9 Functional-Delivery Guardrails verified PASS
-- [x] `wave-to-red-test-manifest.md` — Stage 8 hardening manifest with exact test-level allocation and blocker recording for catalog-count drift reconciliation
-- [x] `wave-data-api-contract-matrix.md` — per-wave data/API/audit/notification execution contract matrix
-- [x] `route-screen-state-acceptance-matrix.md` — route/screen/five-state acceptance matrix covering all 27 routes with Stage 2 22-screen reconciliation note
-- [x] `timeline-engine-builder-contract.md` — W8.6 timeline/date-grid algorithm and evidence contract
-- [x] `implementation-dependency-graph.md` — required wave sequencing dependencies
-- [x] `wave-definition-of-done-template.md` — per-wave completion template
-- [x] `builder-execution-responsibility-model.md` — role/sign-off authority model for future build waves
-- [x] `build-authorization-clearance-path.md` — positive clearance path definition (authorization remains NOT CLEARED)
-
-**Functional-Delivery Guardrails (added maturion-isms#1575 — MANDATORY for Stage 8 gate-pass)**:
-
-The implementation plan must satisfy all of the following. Any gap is a Stage 8 gate-fail:
-
-- [x] Work sequenced by functional slices (screens/journeys/domains), not only files/components
-- [x] Acceptance evidence defined per wave: what must be demonstrably GREEN before the wave is closed
-- [x] Route/page/state coverage identified per wave: which routes and screens are completed per wave
-- [x] UI/runtime verification required per wave: each wave must include a deployed-environment smoke check
-- [x] Negative-path and denied-path work explicitly included in at least one wave per protected domain
-- [x] Data/notification/audit/report evidence work explicitly scheduled as first-class wave scope
-- [x] No placeholder/TBD scope: every wave has fully specified acceptance criteria before the wave begins
-- [x] Rollback expectations documented: what is the rollback plan if a wave fails
-- [x] Handover expectations documented: what evidence must be filed at the end of each wave
-
-**Completion Date**: 2026-05-19  
-**Review Authority**: foreman-v2-agent (maturion-isms#1679; CS2-authorized)  
-**Gate-Pass Statement**: Stage 8 gate-pass confirms the implementation plan satisfies all Functional-Delivery Guardrails. This gate-pass does **not** start build execution, does **not** appoint a builder, does **not** clear Build Authorization, does **not** claim tests are GREEN, and does **not** claim FUNCTIONAL_PASS. Stage 9 is now initiated.  
-**Notes**: Stage 8 gate-pass review completed per maturion-isms#1679 after confirming all 22 issue checklist items PASS and all 9 Stage 8 Functional-Delivery Guardrails PASS. Review evidence at `modules/pit/08-implementation-plan/stage8-gate-pass-review.md`. Stage 8 derives from gate-passed Stages 1–7. Stage 8 was later hardened with builder-executable supporting artifacts in `modules/pit/08-implementation-plan/` (this issue) without reopening/reversing Stage 8 gate-pass and without starting Stages 10/11/12. Build Authorization remains NOT CLEARED.
-
----
-
-### Stage 9: Builder Checklist
-**Status**: [x] GATE_PASSED — BUILDER_CHECKLIST_COMPLETE_AND_APPROVED (maturion-isms#1687; review authority: foreman-v2-agent; 2026-05-19)  
-**Location**: `modules/pit/09-builder-checklist/`  
-**Key Artifacts**:
-- [x] `builder-checklist.md` — Stage 9 Builder Checklist v1.0 covering all 5 mandatory sections (authority chain, functional scope, RED suite, build boundary, Functional-Delivery Guardrails) and all 8 Stage 9 tracker guardrails
-- [x] `stage9-gate-pass-review.md` — Stage 9 gate-pass review evidence: all 19 issue #1687 criteria verified PASS; all 8 Functional-Delivery Guardrails verified PASS and ticked
-- [x] `stage9-post-stage8-hardening-reconfirmation.md` — Stage 9 reconfirmation after Stage 8 hardening (PR #1693): confirms Stage 9 gate-pass remains valid; records 144-vs-147 RED test delta history and its downstream reconciliation obligation; does NOT reclassify Stage 9 (maturion-isms#1694 / PR #1695 — 2026-05-20)
-
-**Functional-Delivery Guardrails (added maturion-isms#1575 — MANDATORY for Stage 9 gate-pass)**:
-
-The builder checklist must verify that each builder candidate understands and acknowledges:
-
-- [x] Stage 1–4 authority chain: builder has read App Description v1.0, UX Spec v0.2-draft, FRS v0.2-hardened, TRS v0.2-draft
-- [x] All route/screen/state obligations: builder can enumerate all 27 routes and all 5 UI states for primary screens
-- [x] RLS/access model: builder understands RLS-first enforcement and the role hierarchy (PIT-TR-023–026)
-- [x] Visual rendering and app-shell obligations: builder acknowledges L-002 (app shell in all states, no white screen)
-- [x] Evidence/report/audit/notification obligations: builder understands all evidence, report, audit, and notification requirements
-- [x] QA-to-Red expectations: builder understands and accepts the RED test suite as the source of truth
-- [x] No direct AIMC provider calls: builder acknowledges the no-direct-provider-call rule (PIT-TR-083)
-- [x] No build without Stage 11 appointment and Build Authorization: builder acknowledges Build Authorization is NOT CLEARED unless explicitly cleared by CS2
-
-**Completion Date**: 2026-05-19 (gate-pass review complete)  
-**Review Authority**: foreman-v2-agent (maturion-isms#1687; CS2-authorized)  
-**Gate-Pass Statement**: Stage 9 gate-pass confirms the Builder Checklist covers all 8 Functional-Delivery Guardrails and is ready to bind future builder candidates at Stage 11. This gate-pass does **not** appoint a builder, does **not** start build execution, does **not** clear Build Authorization, does **not** claim tests are GREEN, and does **not** claim FUNCTIONAL_PASS. Stage 10 IAA Pre-Brief is now initiated.  
-**Notes**: Stage 9 gate-pass review completed per maturion-isms#1687 after confirming all 19 issue criteria PASS and all 8 Stage 9 Functional-Delivery Guardrails PASS. Review evidence at `modules/pit/09-builder-checklist/stage9-gate-pass-review.md`. Stage 9 gate-pass is based on the checklist artifact being complete and binding for future candidates — no builder candidate has been appointed or authorised. Stage 11 is the only builder appointment stage. Build Authorization remains NOT CLEARED. After Stage 8 hardening artifacts were added by PR #1693, Stage 9 was reconfirmed valid in `stage9-post-stage8-hardening-reconfirmation.md` (maturion-isms#1694 / PR #1695 — 2026-05-20). The historical 144-vs-147 delta has now been reconciled by CS2 Option B (issue #1714 / PR #1715), so this delta no longer blocks Stage 11 appointment readiness.
-
----
-
-### Stage 10: IAA Pre-Brief
-**Status**: [x] GATE_PASSED — IAA_PRE_BRIEF_ACCEPTED (Stage 10 pre-brief/readiness only; conditional blocker carry-forward; no builder appointment; no build start; Build Authorization NOT CLEARED)  
-**Location**: `modules/pit/10-iaa-pre-brief/`  
-**Key Artifacts**:
-- [x] `iaa-pre-brief.md` — Stage 10 IAA Pre-Brief document v1.1 with all 7 required sections (complete Stage 1–9 artifact pack, known delivery risks, visual/rendering controls, route/auth/onboarding controls, denied-path controls, live deployment/PBFAG evidence expectations, IAA challenge questions); **v1.1 repair** (maturion-isms#1694 / PR #1695 — 2026-05-20): Section 1.9 expanded to include full hardened Stage 8 package (10 artifacts); IAA Challenge §7.8 added for 144-vs-147 RED test reconciliation pre-build blocker
-- [x] `iaa-response.md` — Stage 10 IAA response artifact filed; pre-brief accepted for readiness-only scope with explicit conditions/blockers and non-overclaim posture
-- [x] `stage10-gate-pass-review.md` — Stage 10 guardrail verification + additional Stage 10 integrity checks (no builder appointment, no build start, Stage 11/12 NOT_STARTED, Build Authorization NOT CLEARED)
-
-**Functional-Delivery Guardrails (added maturion-isms#1575 — MANDATORY for Stage 10 gate-pass)**:
-
-The IAA Pre-Brief must include:
-
-- [x] Complete Stage 1–9 artifact pack submitted to IAA
-- [x] Known MMM/PIT delivery risks declared (see `modules/pit/_readiness/pit-functional-delivery-gap-register.md`)
-- [x] Visual/rendering risk controls declared: how will app shell completeness and white-screen prevention be verified?
-- [x] Route/auth/onboarding risk controls declared: how will all 27 routes be verified in deployed environment?
-- [x] Denied-path risk controls declared: how will negative-path failures be detected before handover?
-- [x] Live deployment/PBFAG evidence expectations agreed between IAA and Foreman
-- [x] IAA challenge questions for one-time functional delivery: IAA must state what would cause it to issue a REJECTION-PACKAGE
-
-**Completion Date**: 2026-05-20  
-**Notes**: Stage 10 gate-pass review is now filed at `modules/pit/10-iaa-pre-brief/stage10-gate-pass-review.md` with IAA response at `modules/pit/10-iaa-pre-brief/iaa-response.md`. Stage 10 remains strictly pre-brief/readiness scope. The full hardened Stage 8 package (including all 8 hardening artifacts) was reviewed and the RED reconciliation blocker has been closed by CS2 Option B (baseline now 147) with explicit accounting of `PIT-RED-ROUTE-029`, `PIT-RED-TIMELINE-011`, and `PIT-RED-TIMELINE-012`. Stage 11 and Stage 12 remain NOT_STARTED. Build Authorization remains NOT CLEARED.
-
-> **Non-overclaim**: Stage 10 gate-pass does **not** appoint a builder, does **not** start build execution, does **not** clear Build Authorization, does **not** claim tests are GREEN, does **not** claim live deployment proof exists, and does **not** claim FUNCTIONAL_PASS.
-
----
-
-### Stage 11: Builder Appointment
-**Status**: [x] **GATE_PASSED — BUILDER_APPOINTED** (maturion-isms#1729 / PR #1730; 2026-05-21)
-**Appointed Builder**: `pit-specialist` (PIT domain specialist)
-**Appointment Authority**: Foreman v2 agent (`foreman-v2-agent`), under CS2 authorization (issue opened by @APGI-cmy)
-**Appointment Artifact**: `modules/pit/11-builder-appointment/stage11-builder-appointment.md`
-**Location**: `modules/pit/11-builder-appointment/`  
-**Key Artifacts**:
-- [x] `stage11-builder-appointment.md` — formal builder appointment artifact (NEW — this wave; maturion-isms#1729)
-- [x] `builder-readiness-proof-pack.md` — complete execution-readiness evidence (all 8 sections filled with concrete auditable tables; maturion-isms#1729)
-- [x] `red-baseline-reconciliation-decision.md` — CS2 Option B (147 baseline; maturion-isms#1714 / PR #1715)
-- [x] `stage8-hardening-acknowledgement.md` — all 8 Stage 8 hardening artifacts acknowledged with concrete execution use statements (maturion-isms#1729)
-- [x] `wave-definition-of-ready-template.md` — pre-Stage-12 wave DoR template
-- [x] `timeline-engine-readiness-gate.md` — timeline readiness gate (all 13 controls with strategies)
-- [x] `stage11-appointment-preconditions.md` — all preconditions satisfied; all TBD references replaced with actual evidence paths (maturion-isms#1729)
-- [x] Formal appointment issued by Foreman — builder is `pit-specialist`
-- [x] Appointment recorded in module tracker (this update)
-- [x] Builder appointed by FM
-
-**RED baseline acknowledged by builder**: **147 tests** (CS2 Option B; maturion-isms#1714 / PR #1715)  
-**Delta rows confirmed as baseline members**: `PIT-RED-ROUTE-029`, `PIT-RED-TIMELINE-011`, `PIT-RED-TIMELINE-012`
-
-**Functional-Delivery Guardrails (maturion-isms#1575 — all verified SATISFIED)**:
-
-- [x] Stages 1–10 are gate-passed by their respective authorities
-- [x] Builder has acknowledged the full functional scope (all 27 canonical PIT routes plus 2 ROUTE-category resilience RED rows — PIT-RED-ROUTE-028 SPA fallback and PIT-RED-ROUTE-029 global error boundary — covering 29 ROUTE-category test rows in total; all 5 UI states; all role-denied paths)
-- [x] RED tests exist and are understood by the builder (Stage 6 RED suite filed; 147-test baseline acknowledged)
-- [x] PBFAG has passed (Stage 7 PBFAG GATE_PASSED)
-- [x] Handover evidence requirements accepted by the builder (per Stage 12 guardrails and BERM)
-- [x] Build wave scope is frozen: no scope changes after appointment without CS2 approval and new appointment cycle
-- [x] **Build Authorization explicitly cleared by CS2 in this tracker** after Stage 9/10/11 evidence verification; Stage 12 remains `NOT_STARTED` in this PR and must begin only via a separate downstream Stage 12 execution issue/PR
-
-**Completion Date**: 2026-05-21  
-**Notes**: Stage 11 formal builder appointment executed per maturion-isms#1729 / PR #1730. `pit-specialist` is appointed as the PIT Stage 12 builder. All Stage 11 preconditions are satisfied. Builder has confirmed the reconciled 147-test baseline (CS2 Option B) and acknowledged all 8 Stage 8 hardening artifacts with concrete execution use statements, including complete route/screen/state maps, timeline engine strategy, data/API/RLS maps, evidence/audit/notification plans, denied-path plans, LFV evidence collection plan, and top 10 failure modes.
-
-> **CS2 Build Authorization Clearance (explicit tracker statement)**: **CLEARED** by CS2 (`@APGI-cmy`) in this tracker update after confirming the required positive path in `modules/pit/08-implementation-plan/build-authorization-clearance-path.md`:
-> - Stage 9 gate-pass evidence: `modules/pit/09-builder-checklist/stage9-gate-pass-review.md`
-> - Stage 10 IAA pre-brief/gate-pass evidence: `modules/pit/10-iaa-pre-brief/iaa-response.md` and `modules/pit/10-iaa-pre-brief/stage10-gate-pass-review.md`
-> - Stage 11 builder appointment record: `modules/pit/11-builder-appointment/stage11-builder-appointment.md`
-> - Builder acknowledgement/readiness package: `modules/pit/11-builder-appointment/builder-readiness-proof-pack.md`
-> - Stage 8 hardening acknowledgement: `modules/pit/11-builder-appointment/stage8-hardening-acknowledgement.md`
-> - RED baseline reconciliation decision: `modules/pit/11-builder-appointment/red-baseline-reconciliation-decision.md` (**147 baseline is binding**, including `PIT-RED-ROUTE-029`, `PIT-RED-TIMELINE-011`, `PIT-RED-TIMELINE-012`)
-> - Appointed builder confirmed: `pit-specialist`
->
-> **Stage 12**: **NOT_STARTED** — This PR is governance-only clearance. Stage 12 execution must be initiated only in a separate downstream Stage 12 execution issue/PR.
->
-> **Non-overclaim**: The Stage 11 appointment itself does **not** start Stage 12 build execution and does **not** imply automatic authorization; Build Authorization clearance is valid only via the explicit CS2 tracker statement recorded above. This update does **not** claim tests are GREEN, does **not** claim live deployment proof exists, and does **not** claim FUNCTIONAL_PASS.
-
----
-
-### Stage 12: Build Execution & Evidence
-**Status**: [ ] NOT_STARTED  
+## Stage 12: Build Execution & Evidence
+**Status**: [~] AUTHORIZED_TO_START / INCOMPLETE  
 **Location**: `modules/pit/12-build/`  
 **Key Artifacts**:
+- [x] `stage12-kickoff-authorization.md` — CS2 proxy authorization to enter Stage 12 (issue #1767; no functional completion claim)
 - [ ] Implementation code in `apps/` or `packages/`
 - [ ] Test evidence (QA-to-Green per wave)
 - [ ] QA validation results
@@ -489,56 +102,15 @@ Build completion requires ALL of the following evidence categories. Missing any 
 - [ ] No unresolved critical functional gaps: all P0 and P1 FRS requirements verified functional in deployed environment
 
 **Completion Date**: N/A  
-**Notes**: Core build not yet started. Build Authorization is now explicitly CLEARED by CS2 in this tracker update, but Stage 12 execution remains intentionally not started in this PR and must begin in a separate downstream Stage 12 execution issue/PR. However, as an artifact of Wave 9.7 AIMC integration
-(pre-12-stage), `src/services/aimc-wiring.ts` exists as an AIMC integration component and
-`pit-advisor.md` persona exists in `packages/ai-centre/src/agents/`. These are integration
-artifacts, not core PIT module build deliverables. Mapped from old Stage 5.
-
----
-
-## Current Stage Summary
-
-**Current Stage**:
-- Stage 11 Builder Appointment **GATE_PASSED — BUILDER_APPOINTED** (maturion-isms#1729 / PR #1730; 2026-05-21; pit-specialist appointed; Stage 12 NOT_STARTED)
-- Stage 10 IAA Pre-Brief **GATE_PASSED — IAA_PRE_BRIEF_ACCEPTED** (2026-05-20; readiness-only gate; blocker integrity preserved via `iaa-response.md` + `stage10-gate-pass-review.md`)
-- Stage 9 Builder Checklist **GATE_PASSED — BUILDER_CHECKLIST_COMPLETE_AND_APPROVED** (maturion-isms#1687; review 2026-05-19; reconfirmed 2026-05-20 per stage9-post-stage8-hardening-reconfirmation.md)
-- Stage 8 Implementation Plan **GATE_PASSED — IMPLEMENTATION_PLAN_COMPLETE_AND_APPROVED** (maturion-isms#1679; review 2026-05-19; all 9 Functional-Delivery Guardrails verified PASS; builder-executable hardening addendum artifacts filed under `modules/pit/08-implementation-plan/` via PR #1693)
-- Stage 7 PBFAG **GATE_PASSED** — PBFAG_COMPLETE_AND_APPROVED (2026-05-19; pre-build package assessment only)
-- Stage 6 QA-to-Red **GATE_PASSED** — RED suite reviewed and gate-passed by CS2/Foreman (2026-05-18)
-- Stage 5 Architecture **GATE_PASSED** — CS2/Foreman gate-pass recorded (2026-05-18; maturion-isms#1611 package reviewed)
-- Stage 5b LFV Package MERGED (maturion-isms#1623, PR #1624)
-- Stage 4 TRS CS2 APPROVED (maturion-isms#1604)
-- Stage 2 UX CS2 re-confirmed
-- Stage 3 FRS CS2 re-confirmed  
-**Retrofit Status**: COMPLETE — maturion-isms#1575 / PR #1576 (2026-05-08)  
-**Overall Progress**: ~91% complete (Stages 1–11 complete/gate-passed in pre-build scope; Stage 12 not started; Build Authorization CLEARED by CS2 — weighted estimate: Stage 12 represents ~22% of total module effort; completed pre-build stages 1–11 represent ~78% of estimated total)  
-**Build Authorization**: **CLEARED** — explicitly cleared by CS2 (`@APGI-cmy`) in this tracker update per `modules/pit/08-implementation-plan/build-authorization-clearance-path.md` after Stage 9/10/11 evidence verification and 147 RED baseline reconciliation confirmation. Appointed builder is `pit-specialist`.  
-**Blockers**: Stage 12 execution has not started in this governance-only PR and must be initiated in a separate downstream Stage 12 execution issue/PR. `FUNCTIONAL_PASS` remains not claimable until PIT is deployed and LFV workflow evidence is collected.  
-**Next Steps**:
-1. Open/execute a separate downstream Stage 12 issue/PR for PIT build execution (W8.1+), using this tracker-cleared Build Authorization as the entry gate
-2. Keep Stage 12 `NOT_STARTED` in this PR
-3. Preserve governance-only scope in this PR (no runtime/source/test/migration/deployment/workflow changes)
-4. Maintain 147 RED baseline as binding for Stage 12 execution waves
-**MMM-Derived Learning Controls (Carry-Forward)**:
-PIT carries forward 8 build-process improvement controls from the MMM module build. These are
-documented in the App Description (§ MMM Lessons Promoted Into PIT) and the improvement register:
-`modules/pit/_readiness/pit-build-process-improvement-register.md`
-- L-001: L1/L2/L3 closure model (build-complete ≠ operationally closed)
-- L-002: UI rendering completeness (global styles, app shell) must be tested
-- L-003: Post-login pages require all 5 states (loading/empty/permission-denied/network-error/data)
-- L-004: Auth route discoverability must be designed up front in Stage 2
-- L-005: Tests must prove runtime/UI behaviour, not only file existence
-- L-006: Deployment execution must be a first-class contract (filed before PBFAG)
-- L-007: Operational closure requires live evidence (L3 = CS2 verified live E2E)
-- L-008: Continuous improvement must be recorded in the improvement register
+**Notes**: Stage 12 build execution is authorized to start under issue #1767 but remains incomplete. Core build has not yet produced implementation code, tests, deployed runtime evidence, or handover evidence. As an artifact of Wave 9.7 AIMC integration (pre-12-stage), `src/services/aimc-wiring.ts` exists as an AIMC integration component and `pit-advisor.md` persona exists in `packages/ai-centre/src/agents/`. These are integration artifacts, not core PIT module build completion evidence.
 
 ---
 
 ## Governance Compliance
 
 - [x] Stage 1 App Description: CS2_APPROVED_AUTHORITATIVE (2026-05-06) — Functional delivery retrofit review: PASS (no material gaps; retrofit annotation added)
-- [x] Stage 2 UX Workflow & Wiring Spec: STAGE_2_COMPLETE_FOREMAN_REVIEWED (maturion-isms#1548) — ready for CS2 re-confirmation after PR #1594 gap closure
-- [x] Stage 3 FRS: DRAFT_HARDENED_CS2_RECONFIRMED (maturion-isms#1556) — v0.2-hardened, CS2 re-confirmed
+- [x] Stage 2 UX Workflow & Wiring Spec: **CS2_RECONFIRMED** (maturion-isms#1548, PR #1594, maturion-isms#1575) — UX-GAP-001 and UX-GAP-002 resolved; baseline locked for downstream derivation
+- [x] Stage 3 FRS: **DRAFT_HARDENED_CS2_RECONFIRMED** (maturion-isms#1556) — v0.2-hardened, CS2 re-confirmed
 - [x] Stage 4 TRS: **CS2_APPROVED** (maturion-isms#1554 + maturion-isms#1575 + maturion-isms#1604) — v0.2-draft CS2 approved 2026-05-11 by @APGI-cmy
 - [x] Stage 5 Architecture: **GATE_PASSED (CS2/Foreman)** — 2026-05-18 Stage 5 review completed against Stage 1–4 authority chain and architecture completeness canon
 - [x] Stage 5b LFV Package: **MERGED** (maturion-isms#1623 / PR #1624) — 2026-05-12 — all 10 artifacts PIT-specific; merged as Stage 6 input
@@ -547,58 +119,34 @@ documented in the App Description (§ MMM Lessons Promoted Into PIT) and the imp
 - [x] Stage 8 Implementation Plan: **GATE_PASSED — IMPLEMENTATION_PLAN_COMPLETE_AND_APPROVED** (maturion-isms#1679; 2026-05-19) — all 22 issue checklist items PASS; all 9 Functional-Delivery Guardrails PASS; review authority: foreman-v2-agent; review evidence: `modules/pit/08-implementation-plan/stage8-gate-pass-review.md`
 - [x] Stage 9 Builder Checklist: **GATE_PASSED — BUILDER_CHECKLIST_COMPLETE_AND_APPROVED** (maturion-isms#1687; review authority: foreman-v2-agent; 2026-05-19) — `builder-checklist.md` and `stage9-gate-pass-review.md` filed; all 19 criteria PASS; all 8 Functional-Delivery Guardrails PASS; reconfirmed valid after Stage 8 hardening (maturion-isms#1694 / PR #1695 — 2026-05-20 — see `stage9-post-stage8-hardening-reconfirmation.md`)
 - [x] Stage 10 IAA Pre-Brief: **GATE_PASSED — IAA_PRE_BRIEF_ACCEPTED** (maturion-isms#1698 / PR #1701; review authority: foreman-v2-agent + IAA; 2026-05-20) — `iaa-pre-brief.md`, `iaa-response.md`, `stage10-gate-pass-review.md` filed; RED reconciliation 147-test CS2 Option B closure recorded
-- [x] Stage 11 Builder Appointment: **GATE_PASSED — BUILDER_APPOINTED** (maturion-isms#1729 / PR #1730; review authority: foreman-v2-agent; 2026-05-21) — pit-specialist appointed; `stage11-builder-appointment.md`, `builder-readiness-proof-pack.md` (all 8 sections), `stage8-hardening-acknowledgement.md` (all 8 artifacts), `stage11-appointment-preconditions.md` (all TBD resolved) filed; 147-test baseline acknowledged; Stage 12 NOT_STARTED
-- [x] Traceability chain: App Description ✅ → UX Workflow (CS2_RECONFIRMED) → FRS (CS2_RECONFIRMED) → TRS (CS2_APPROVED) → Architecture (GATE_PASSED) → LFV Package (MERGED) → QA-to-Red (GATE_PASSED)
+- [x] Stage 11 Builder Appointment: **GATE_PASSED — BUILDER_APPOINTED** (maturion-isms#1729 / PR #1730; review authority: foreman-v2-agent; 2026-05-21) — pit-specialist appointed; Stage 12 now authorized to start by issue #1767
+- [x] Traceability chain: App Description ✅ → UX Workflow (CS2_RECONFIRMED) → FRS (CS2_RECONFIRMED) → TRS (CS2_APPROVED) → Architecture (GATE_PASSED) → LFV Package (MERGED) → QA-to-Red (GATE_PASSED) → PBFAG (GATE_PASSED) → Implementation Plan (GATE_PASSED) → Builder Checklist (GATE_PASSED) → IAA Pre-Brief (GATE_PASSED) → Builder Appointment (GATE_PASSED)
 - [x] Stage 1 approval obtained — Johan Ras / CS2 approved 2026-05-06 (ref: maturion-isms#1540)
-- [x] Build Authorization: **CLEARED (CS2 explicit tracker statement)** — clearance recorded in this tracker update per `modules/pit/08-implementation-plan/build-authorization-clearance-path.md`; evidence linked: Stage 9 gate-pass (`modules/pit/09-builder-checklist/stage9-gate-pass-review.md`), Stage 10 IAA (`modules/pit/10-iaa-pre-brief/iaa-response.md`, `modules/pit/10-iaa-pre-brief/stage10-gate-pass-review.md`), Stage 11 appointment (`modules/pit/11-builder-appointment/stage11-builder-appointment.md`), builder readiness proof pack (`modules/pit/11-builder-appointment/builder-readiness-proof-pack.md`), Stage 8 hardening acknowledgement (`modules/pit/11-builder-appointment/stage8-hardening-acknowledgement.md`), 147 baseline reconciliation (`modules/pit/11-builder-appointment/red-baseline-reconciliation-decision.md`); appointed builder is pit-specialist; Stage 12 remains NOT_STARTED in this PR and must start in a separate downstream Stage 12 issue/PR
-- [x] Evidence artifacts created for Stage 1 (checklist at `.agent-admin/evidence/app-description-checklist/pit-20260506.md`)
-- [x] Stage 2 completion evidence: `.agent-admin/evidence/stage2-completion-checklist/pit-stage2-20260506.md`
-- [x] Stage 3 FRS artifact updated: `modules/pit/02-frs/functional-requirements.md` (v0.2-hardened per maturion-isms#1556)
-- [x] Stage 4 TRS artifact updated: `modules/pit/03-trs/technical-requirements-specification.md` (v0.2-draft per maturion-isms#1575 / PR #1576 — PIT-TR-116 to PIT-TR-126 added)
-- [x] FRS-to-TRS traceability updated: all 123 FRS requirements now traced (per maturion-isms#1575 / PR #1576)
-- [x] Module manifest updated (module_name corrected to "PIT (Project Implementation Tracker)")
-- [x] Stage 2 upgrade checklist evidence at `.agent-admin/evidence/stage2-upgrade-checklist/pit-stage2-20260506.md`
-- [x] Functional delivery retrofit checklist: `modules/pit/_readiness/functional-delivery-retrofit-checklist.md`
-- [x] Functional delivery gap register: `modules/pit/_readiness/pit-functional-delivery-gap-register.md`
-
-**Re-Confirmation Policy (maturion-isms#1575)**: Stages 2, 3, and 4 were reviewed in the functional delivery retrofit wave (maturion-isms#1575 / PR #1576). Any previously confirmed stage must be re-signed only after the retrofit review confirms it meets the upgraded functional-delivery standard. Specifically:
-- Stage 2: UX-GAP-001 and UX-GAP-002 resolved in PR #1594; ready for CS2 re-confirmation (not yet approved)
-- Stage 3: retrofit verified PASS; DRAFT_HARDENED and ready for CS2 approval after Stage 2 re-confirmation
-- Stage 4: retrofit updated to v0.2-draft; re-confirmation requires CS2 approval of upstream stages first
+- [x] Build Authorization: **CLEARED (CS2 explicit tracker statement)** — clearance recorded in tracker update PR #1738 and reaffirmed in issue #1767; appointed builder is pit-specialist; Stage 12 authorized to start but incomplete
 
 ---
 
-## Notes and Observations
+## Historical Notes and Observations
 
-**Stage 2 Foreman-Reviewed (2026-05-06)**: All 13 Stage 2 completion criteria verified per maturion-isms#1548. UX Workflow & Wiring Spec v0.2-draft satisfies all requirements: derivation statement, L-001–L-008 carry-forward, 23 user journeys including all auth flows, My Work, and Invitation Acceptance, 22 primary screens, 5-state UI matrix, 7 top indicators, app shell, timeline wiring, screen-to-data wiring table, AIMC touchpoints, deployment surface map, and Notification History coverage as a screen/route/global flow rather than a dedicated journey. Status: STAGE_2_COMPLETE_FOREMAN_REVIEWED and ready for CS2 re-confirmation (not yet approved).
+The notes below preserve historical context from earlier PIT readiness waves. Where older text described Stage 2 as awaiting re-confirmation or Stage 3/4 as pending approval, those statements are superseded by the current stage sections and Current Stage Summary above.
 
-**Stage 3 FRS v0.2-hardened (2026-05-07)**: FRS upgraded from v0.1-draft to v0.2-hardened per maturion-isms#1556 (PR #1557). 19 hardening areas applied: domain-based requirement index, table/entity naming caveat, role-scope matrix, PIT-FR-113 permission negative-path contract, PIT-FR-121 lifecycle removal semantics, PIT-FR-054 task status lifecycle (added `cancelled`), PIT-FR-052 evidence completion logic clarified, PIT-FR-114 progress roll-up method, RAG threshold central table (§29), PIT-FR-115–117 notification read/history/preference, PIT-FR-118–119 report permissions/states/history (history now mandatory), PIT-FR-120 QA Dashboard expanded, AIMC candidate wording (§24), Route Coverage Appendix A (all 27 routes), PIT-FR-122 accessibility outcomes, PIT-FR-123 bulk ops non-scope, §33 Build-Completeness Guardrails, §34 QA-to-Red Derivation Requirements, §38 Stage 4 readiness wording aligned. Total: 123 functional requirements. Stage status: DRAFT_HARDENED pending CS2 approval. Build Authorization remains NOT CLEARED.
+**Stage 2 Foreman-Reviewed (2026-05-06)**: All 13 Stage 2 completion criteria verified per maturion-isms#1548. UX Workflow & Wiring Spec v0.2-draft satisfied all requirements and later reached CS2 re-confirmation after retrofit review and PR #1594 gap closure.
 
-**Stage 3 FRS Draft Created (2026-05-06)**: Stage 3 FRS v0.1-draft created per maturion-isms#1548. Derived from App Description v1.0 and UX Workflow & Wiring Spec v0.2-draft. 112 functional requirements (PIT-FR-001 through PIT-FR-112) with acceptance criteria and traceability matrix. PIT-FR-106–109 add admin sub-screen coverage (Role Management, Notification Templates, Task Cluster Templates, Invitation Settings). PIT-FR-110 adds Invitation Acceptance screen (§UX-S-20). PIT-FR-111–112 add My Work screen and task actions (§UX-J-23, §UX-S-21). PIT-FR-088 updated to include `cs2_admin` in audit export permission. PIT-FR-101 updated to use `cs2_admin` for cross-org visibility. Prescriptive Supabase/RLS/Vercel wording softened to functional outcomes; implementation details deferred to TRS. Status: DRAFT_CREATED pending CS2 approval. Stage 4 TRS remains blocked until Stage 3 FRS is approved.
+**Stage 3 FRS v0.2-hardened (2026-05-07)**: FRS upgraded from v0.1-draft to v0.2-hardened per maturion-isms#1556 (PR #1557). The former pending-approval wording is historical only; Stage 3 is now CS2 re-confirmed and baseline-locked for downstream derivation.
 
-**Stage 1 App Description Filed (2026-05-06)**: App Description v1.0-draft created per
-maturion-isms#1534 delegation from Foreman to pit-specialist. Module name corrected from
-"Penetration Intelligence Tool" to "Project Implementation Tracker". Source prepared by
-CS2/Johan + assistant-assisted drafting under Johan Ras direction. MMM Lessons Promoted Into PIT
-section added (L-001–L-008 + Stage 2 carry-forward requirements).
-Improvement register created at `modules/pit/_readiness/pit-build-process-improvement-register.md`.
+**Stage 3 FRS Draft Created (2026-05-06)**: Stage 3 FRS v0.1-draft created per maturion-isms#1548. This was superseded by v0.2-hardened and later CS2 reconfirmation.
 
-**Stage 1 App Description CS2 Approved (2026-05-06)**: CS2/Johan Ras reviewed and approved Stage 1
-App Description per maturion-isms#1540. Status changed from Draft to Authoritative (v1.0). Stage 2
-(UX Workflow & Wiring Spec) authorised. Build Authorization remains NOT CLEARED — implementation
-blocked until Stages 2–11 completed and gate-passed.
+**Stage 1 App Description Filed (2026-05-06)**: App Description v1.0-draft created per maturion-isms#1534 delegation from Foreman to pit-specialist. Module name corrected from "Penetration Intelligence Tool" to "Project Implementation Tracker". Source prepared by CS2/Johan + assistant-assisted drafting under Johan Ras direction. MMM Lessons Promoted Into PIT section added (L-001–L-008 + Stage 2 carry-forward requirements). Improvement register created at `modules/pit/_readiness/pit-build-process-improvement-register.md`.
 
-**Governance Upgrade (2026-04-06)**: Stage model migrated from legacy 6-stage (Stage 0–5) to
-canonical 12-stage per `PRE_BUILD_STAGE_MODEL_CANON.md` v1.1.0. See Stage Migration Note above.
+**Stage 1 App Description CS2 Approved (2026-05-06)**: CS2/Johan Ras reviewed and approved Stage 1 App Description per maturion-isms#1540. Status changed from Draft to Authoritative (v1.0). Stage 2 (UX Workflow & Wiring Spec) authorised.
 
-**Prior Note (2026-02-13)**: TRS stage introduced per governance upgrade "Governance Upgrade:
-Insert Technical Requirements Specification (TRS) Step".
+**Governance Upgrade (2026-04-06)**: Stage model migrated from legacy 6-stage (Stage 0–5) to canonical 12-stage per `PRE_BUILD_STAGE_MODEL_CANON.md` v1.1.0. See Stage Migration Note above.
 
-**PIT Integration Contract**: `PIT_INTEGRATION_CONTRACT_v0.1.md` exists in the module root and
-provides useful context for App Description authoring.
+**Prior Note (2026-02-13)**: TRS stage introduced per governance upgrade "Governance Upgrade: Insert Technical Requirements Specification (TRS) Step".
 
-**AI Integration**: AIMC wiring (Wave 9.7) complete. `pit-advisor.md` persona delivered.
-See `10-governance-notes/` and `20-ai/` for AI integration governance context.
+**PIT Integration Contract**: `PIT_INTEGRATION_CONTRACT_v0.1.md` exists in the module root and provides useful context for App Description authoring.
+
+**AI Integration**: AIMC wiring (Wave 9.7) complete. `pit-advisor.md` persona delivered. See `10-governance-notes/` and `20-ai/` for AI integration governance context.
 
 ---
 

--- a/modules/pit/BUILD_PROGRESS_TRACKER.md
+++ b/modules/pit/BUILD_PROGRESS_TRACKER.md
@@ -2,45 +2,46 @@
 
 **Module**: PIT (Project Implementation Tracker)  
 **Module Slug**: pit  
-**Last Updated**: 2026-06-01
-**Updated By**: CS2 proxy kickoff authorization (issue #1767; appointed builder: pit-specialist; Stage 12 authorized to start, not complete)
-> **Classification**: ACTIVE — STAGE 4 CS2 APPROVED — STAGE 5 ARCHITECTURE GATE-PASSED (CS2/FOREMAN) — STAGE 5b LFV PACKAGE MERGED — STAGE 6 QA-TO-RED GATE-PASSED (CS2/FOREMAN) — STAGE 7 PBFAG GATE-PASSED (PRE-BUILD PACKAGE) — STAGE 8 GATE_PASSED (IMPLEMENTATION PLAN COMPLETE AND APPROVED) — STAGE 9 GATE_PASSED (BUILDER CHECKLIST COMPLETE AND APPROVED) — STAGE 10 GATE_PASSED (IAA PRE-BRIEF ACCEPTED; READINESS ONLY) — STAGE 11 GATE_PASSED (BUILDER APPOINTED — pit-specialist) — BUILD AUTHORIZATION CLEARED BY CS2 (TRACKER-EXPLICIT) — STAGE 12 AUTHORIZED_TO_START / INCOMPLETE  
+**Last Updated**: 2026-06-01  
+**Updated By**: Stage 12 kickoff authorization review follow-up (issue #1767; PR #1768; appointed builder: `pit-specialist`; Stage 12 authorized to start, not complete)  
+> **Classification**: ACTIVE — STAGES 1–11 COMPLETE/GATE-PASSED — BUILD AUTHORIZATION CLEARED BY CS2 — STAGE 12 AUTHORIZED_TO_START / INCOMPLETE  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.1.0 (effective 2026-04-05)  
-> **Governing Issue**: [maturion-isms#1255](https://github.com/APGI-cmy/maturion-isms/issues/1255)
-> **Retrofit Issue**: [maturion-isms#1575](https://github.com/APGI-cmy/maturion-isms/issues/1575) — PIT pre-build functional delivery retrofit (PR #1576)
+> **Governing Issue**: maturion-isms#1255  
+> **Stage 12 Authorization Issue**: maturion-isms#1767  
+> **Retrofit Issue**: maturion-isms#1575 — PIT pre-build functional delivery retrofit (PR #1576)
 
 ---
 
 ## Stage Migration Note
 
-This tracker was migrated from the legacy 6-stage format to the canonical 12-stage format
-per wave `align-12stage-prebuild-20260406` (2026-04-06).
+This tracker was migrated from the legacy 6-stage format to the canonical 12-stage format per wave `align-12stage-prebuild-20260406` (2026-04-06).
 
-**Anomaly Flagged (RESOLVED)**: At migration time (2026-04-06), the `00-app-description/` folder was empty (no `app-description.md` found). This has since been resolved: App Description v1.0 was created per maturion-isms#1534 and approved by CS2/Johan Ras on 2026-05-06 per maturion-isms#1540. The Architecture work (`architecture.md`, `data-contracts/`, `exports`, `integrations`, `qa`, `ui-ux`, `watchdog`, `_legacy`) is preserved and was later superseded/reconciled by the gate-passed canonical Stage 5 Architecture package.
+**Anomaly Flagged (RESOLVED)**: At migration time (2026-04-06), the `00-app-description/` folder was empty. This has since been resolved: App Description v1.0 was created per maturion-isms#1534 and approved by CS2/Johan Ras on 2026-05-06 per maturion-isms#1540. The earlier Architecture work (`architecture.md`, `data-contracts/`, `exports/`, `integrations/`, `qa/`, `ui-ux/`, `watchdog/`, `_legacy/`) is preserved as historical/reference material and was later superseded or reconciled by the gate-passed canonical Stage 5 Architecture package.
 
 **Old → New Stage Mapping**:
-| Old Stage | Old Name | New Stage | New Name | Status |
-|-----------|----------|-----------|----------|--------|
+
+| Old Stage | Old Name | New Stage | New Name | Current Status |
+|-----------|----------|-----------|----------|----------------|
 | Stage 0 | App Description | Stage 1 | App Description | CS2_APPROVED_AUTHORITATIVE |
-| Stage 1 | FRS | Stage 3 | FRS | CS2_RECONFIRMED v0.2-hardened |
-| Stage 1.5 | TRS | Stage 4 | TRS | CS2_APPROVED v0.2-draft |
-| Stage 2 | Architecture | Stage 5 | Architecture | GATE_PASSED — ARCHITECTURE_RECONCILIATION_COMPLETE_AND_APPROVED |
-| Stage 3 | Implementation Plan | Stage 8 | Implementation Plan | GATE_PASSED — IMPLEMENTATION_PLAN_COMPLETE_AND_APPROVED (maturion-isms#1679; 2026-05-19) |
-| Stage 4 | Builder Appointment | Stage 11 | Builder Appointment | GATE_PASSED — BUILDER_APPOINTED (pit-specialist; maturion-isms#1729) |
-| Stage 5 | Build | Stage 12 | Build | AUTHORIZED_TO_START / INCOMPLETE (partial AIMC artifact remains historical only) |
-| — | (new stage) | Stage 2 | UX Workflow & Wiring Spec | CS2_RECONFIRMED |
-| — | (new stage) | Stage 6 | QA-to-Red | GATE_PASSED — QA_TO_RED_DERIVATION_COMPLETE_AND_REVIEWED |
-| — | (new stage) | Stage 7 | PBFAG | GATE_PASSED — PBFAG_COMPLETE_AND_APPROVED (pre-build package; no live execution claim) |
-| — | (new stage) | Stage 9 | Builder Checklist | GATE_PASSED — BUILDER_CHECKLIST_COMPLETE_AND_APPROVED (maturion-isms#1687; 2026-05-19) |
-| — | (new stage) | Stage 10 | IAA Pre-Brief | GATE_PASSED — IAA_PRE_BRIEF_ACCEPTED (readiness-only; blocker carried forward) |
+| Stage 1 | FRS | Stage 3 | FRS | DRAFT_HARDENED_CS2_RECONFIRMED |
+| Stage 1.5 | TRS | Stage 4 | TRS | CS2_APPROVED |
+| Stage 2 | Architecture | Stage 5 | Architecture | GATE_PASSED |
+| Stage 3 | Implementation Plan | Stage 8 | Implementation Plan | GATE_PASSED |
+| Stage 4 | Builder Appointment | Stage 11 | Builder Appointment | GATE_PASSED — `pit-specialist` appointed |
+| Stage 5 | Build | Stage 12 | Build Execution & Evidence | AUTHORIZED_TO_START / INCOMPLETE |
+| — | new stage | Stage 2 | UX Workflow & Wiring Spec | CS2_RECONFIRMED |
+| — | new stage | Stage 6 | QA-to-Red | GATE_PASSED |
+| — | new stage | Stage 7 | PBFAG | GATE_PASSED |
+| — | new stage | Stage 9 | Builder Checklist | GATE_PASSED |
+| — | new stage | Stage 10 | IAA Pre-Brief | GATE_PASSED |
 
 ---
 
 ## Stage 12 Kickoff Authorization Note
 
-PIT is approved to enter Stage 12 under issue [#1767](https://github.com/APGI-cmy/maturion-isms/issues/1767).
+PIT is approved to enter Stage 12 under issue #1767.
 
-This approval means Stage 12 build execution may begin under the appointed builder `pit-specialist` and the 147-test RED baseline. It does **not** mean PIT is built, deployed, functionally complete, or ready for handover. `FUNCTIONAL_PASS` remains not claimable until deployed LFV evidence, CS2 L3 verification, and Stage 12 closure evidence exist.
+This approval means Stage 12 build execution may begin under the appointed builder `pit-specialist` and the reconciled 147-test RED baseline. It does **not** mean PIT is built, deployed, functionally complete, or ready for handover. `FUNCTIONAL_PASS` remains not claimable until deployed LFV evidence, CS2 L3 verification, Stage 12 closure evidence, handover documentation, and zero unresolved P0/P1 functional gaps exist.
 
 Stage 12 kickoff artifact: `modules/pit/12-build/stage12-kickoff-authorization.md`.
 
@@ -49,80 +50,241 @@ Stage 12 kickoff artifact: `modules/pit/12-build/stage12-kickoff-authorization.m
 ## Current Stage Summary
 
 **Current Stage**:
-- Stage 12 Build Execution & Evidence **AUTHORIZED_TO_START / INCOMPLETE** (issue #1767; builder: pit-specialist; 147 RED baseline binding; no FUNCTIONAL_PASS claim)
-- Stage 11 Builder Appointment **GATE_PASSED — BUILDER_APPOINTED** (maturion-isms#1729 / PR #1730; 2026-05-21; pit-specialist appointed)
-- Stage 10 IAA Pre-Brief **GATE_PASSED — IAA_PRE_BRIEF_ACCEPTED** (2026-05-20; readiness-only gate; blocker integrity preserved via `iaa-response.md` + `stage10-gate-pass-review.md`)
-- Stage 9 Builder Checklist **GATE_PASSED — BUILDER_CHECKLIST_COMPLETE_AND_APPROVED** (maturion-isms#1687; review 2026-05-19; reconfirmed 2026-05-20 per `stage9-post-stage8-hardening-reconfirmation.md`)
-- Stage 8 Implementation Plan **GATE_PASSED — IMPLEMENTATION_PLAN_COMPLETE_AND_APPROVED** (maturion-isms#1679; review 2026-05-19; all 9 Functional-Delivery Guardrails verified PASS; builder-executable hardening addendum artifacts filed under `modules/pit/08-implementation-plan/` via PR #1693)
-- Stage 7 PBFAG **GATE_PASSED** — PBFAG_COMPLETE_AND_APPROVED (2026-05-19; pre-build package assessment only)
-- Stage 6 QA-to-Red **GATE_PASSED** — RED suite reviewed and gate-passed by CS2/Foreman (2026-05-18)
-- Stage 5 Architecture **GATE_PASSED** — CS2/Foreman gate-pass recorded (2026-05-18; maturion-isms#1611 package reviewed)
-- Stage 5b LFV Package MERGED (maturion-isms#1623, PR #1624)
-- Stage 4 TRS CS2 APPROVED (maturion-isms#1604)
-- Stage 3 FRS CS2 re-confirmed
-- Stage 2 UX CS2 re-confirmed
-- Stage 1 App Description CS2 approved
+- Stage 12 Build Execution & Evidence **AUTHORIZED_TO_START / INCOMPLETE** (issue #1767; builder: `pit-specialist`; 147 RED baseline binding; no `FUNCTIONAL_PASS` claim)
+- Stage 11 Builder Appointment **GATE_PASSED — BUILDER_APPOINTED** (maturion-isms#1729 / PR #1730; `pit-specialist` appointed)
+- Stage 10 IAA Pre-Brief **GATE_PASSED — IAA_PRE_BRIEF_ACCEPTED**
+- Stage 9 Builder Checklist **GATE_PASSED — BUILDER_CHECKLIST_COMPLETE_AND_APPROVED**
+- Stage 8 Implementation Plan **GATE_PASSED — IMPLEMENTATION_PLAN_COMPLETE_AND_APPROVED**
+- Stage 7 PBFAG **GATE_PASSED — PBFAG_COMPLETE_AND_APPROVED**
+- Stage 6 QA-to-Red **GATE_PASSED — 147 RED baseline binding**
+- Stage 5 Architecture **GATE_PASSED**
+- Stage 5b LFV Package **MERGED**
+- Stage 4 TRS **CS2_APPROVED**
+- Stage 3 FRS **CS2_RECONFIRMED**
+- Stage 2 UX Workflow & Wiring Spec **CS2_RECONFIRMED**
+- Stage 1 App Description **CS2_APPROVED_AUTHORITATIVE**
 
-**Retrofit Status**: COMPLETE — maturion-isms#1575 / PR #1576 (2026-05-08)  
-**Overall Progress**: Pre-build Stages 1–11 complete/gate-passed. Stage 12 is authorized to start but remains incomplete. No percentage-complete claim is made until Stage 12 implementation evidence exists.  
-**Build Authorization**: **CLEARED** — explicitly cleared by CS2 (`@APGI-cmy`) in tracker update PR #1738 and reaffirmed by issue #1767 after Stage 9/10/11 evidence verification and 147 RED baseline reconciliation confirmation. Appointed builder is `pit-specialist`.  
-**Blockers**: No Stage 1–11 governance blocker remains. Stage 12 closure remains blocked until implementation code, tests, deployed LFV evidence, CS2 L3 verification, and handover documentation are complete.  
-**Next Steps**:
-1. Begin Stage 12 execution from the approved Stage 8 implementation plan.
-2. Keep the 147 RED baseline binding for all build waves.
-3. Do not claim FUNCTIONAL_PASS until deployed LFV evidence and CS2 L3 verification exist.
-4. Maintain no-scope-expansion/no-test-debt/no-placeholder rules throughout Stage 12.
+**Retrofit Status**: COMPLETE — maturion-isms#1575 / PR #1576.  
+**Overall Progress**: Pre-build Stages 1–11 are complete/gate-passed. Stage 12 is authorized to start but remains incomplete. No percentage-complete claim is made until Stage 12 implementation evidence exists.  
+**Build Authorization**: **CLEARED** — explicitly cleared by CS2 in tracker update PR #1738 and reaffirmed by issue #1767 after Stage 9/10/11 evidence verification and 147 RED baseline reconciliation confirmation. Appointed builder is `pit-specialist`.  
+**Blockers**: No Stage 1–11 governance blocker remains. Stage 12 closure remains blocked until implementation code, tests, deployed LFV evidence, CS2 L3 verification, handover documentation, and zero unresolved P0/P1 gaps are complete.
 
 ---
 
-## Stage 12: Build Execution & Evidence
-**Status**: [~] AUTHORIZED_TO_START / INCOMPLETE  
+## Module Lifecycle Progress
+
+Track the progression through the canonical module lifecycle stages per `PRE_BUILD_STAGE_MODEL_CANON.md` v1.1.0. These stage sections remain part of the active tracker so downstream auditors/builders can verify recorded guardrails from the tracker, not only from the compressed Current Stage Summary.
+
+### Stage 1: App Description
+**Status**: [x] CS2_APPROVED_AUTHORITATIVE  
+**Location**: `modules/pit/00-app-description/`  
+**Key Artifacts**:
+- [x] `app-description.md` — full App Description v1.0, synchronized with canonical `docs/governance/PIT_APP_DESCRIPTION.md`
+- [x] App Description approved by CS2/Johan Ras — 2026-05-06
+
+---
+
+### Stage 2: UX Workflow & Wiring Spec
+**Status**: [x] CS2_RECONFIRMED  
+**Location**: `modules/pit/01-ux-workflow-wiring-spec/`  
+**Key Artifacts**:
+- [x] `ux-workflow-wiring-spec.md` — user journeys, screens, states, wiring, data flows, and deployment surface
+- [x] 23 user journeys, 22 primary screens, and 5-state UI matrix documented
+- [x] UX-GAP-001 and UX-GAP-002 resolved
+
+---
+
+### Stage 3: Functional Requirements Specification (FRS)
+**Status**: [x] DRAFT_HARDENED_CS2_RECONFIRMED  
+**Location**: `modules/pit/02-frs/`  
+**Key Artifacts**:
+- [x] `functional-requirements.md` — FRS v0.2-hardened
+- [x] PIT-FR-001 through PIT-FR-123 documented and traceable
+- [x] Acceptance criteria and traceability matrix included
+
+---
+
+### Stage 4: Technical Requirements Specification (TRS)
+**Status**: [x] CS2_APPROVED  
+**Location**: `modules/pit/03-trs/`  
+**Key Artifacts**:
+- [x] `technical-requirements-specification.md` — PIT-TR-001 through PIT-TR-126
+- [x] `frs-to-trs-traceability.md` — all FRS requirements traced
+- [x] `timeline-engine-technical-validation.md`
+
+---
+
+### Stage 5: Architecture
+**Status**: [x] GATE_PASSED — ARCHITECTURE_RECONCILIATION_COMPLETE_AND_APPROVED  
+**Location**: `modules/pit/04-architecture/`  
+**Key Artifacts**:
+- [x] `architecture.md`
+- [x] `stage5-architecture-reconciliation.md`
+- [x] `trs-to-architecture-traceability.md`
+- [x] `timeline-engine-architecture-decision.md`
+- [x] `app-description-to-architecture-traceability.md`
+
+**Functional-Delivery Guardrails**:
+- [x] Route coverage for all 27 routes mapped to architecture components
+- [x] RLS/access-control, evidence, report, notification, audit, QA dashboard, deployment, accessibility, progress roll-up, and lifecycle removal semantics mapped
+
+---
+
+### Stage 5b: PIT LFV Package
+**Status**: [x] MERGED — PR #1624  
+**Location**: `modules/pit/05-live-functional-verification/`  
+**Key Artifacts**:
+- [x] Functional user journey, access, deployed verification, CTA/backend, role/test identity, live workflow, dashboard reflection, handover, and CS2 acceptance artifacts filed
+- [ ] CODE_PASS: deferred to Stage 12
+- [ ] FUNCTIONAL_PASS: not claimable until live deployment, LFV evidence, and CS2 sign-off
+
+---
+
+### Stage 6: QA-to-Red
+**Status**: [x] GATE_PASSED — QA_TO_RED_DERIVATION_COMPLETE_AND_REVIEWED  
+**Location**: `modules/pit/06-qa-to-red/`  
+**Key Artifacts**:
+- [x] `red-test-suite-catalog.md` — 147 RED tests across 13 categories
+- [x] FRS/TRS/Architecture/LFV traceability artifacts
+- [x] Route/screen/state and role-denied-path matrices
+
+**Functional-Delivery Guardrails**:
+- [x] Every functional requirement and testable TRS requirement covered
+- [x] Every route, screen, primary journey, five-state UI outcome, and role-denied path covered
+- [x] Evidence, report, notification, audit, AIMC, accessibility, progress roll-up, lifecycle removal, SPA route, and deployed smoke checks defined
+
+**Binding RED Baseline**: 147 tests, including `PIT-RED-ROUTE-029`, `PIT-RED-TIMELINE-011`, and `PIT-RED-TIMELINE-012`.
+
+---
+
+### Stage 7: PBFAG
+**Status**: [x] GATE_PASSED — PBFAG_COMPLETE_AND_APPROVED  
+**Location**: `modules/pit/07-pbfag/`  
+**Key Artifacts**:
+- [x] PBFAG plan/checklist, change-propagation audit, runtime deployment contract, golden-path verification pack, LFV readiness, route render, and role negative-path plans
+
+**Functional-Delivery Guardrails**:
+- [x] Deployed route render, golden path, visual/app-shell, auth/onboarding, denied-path, evidence, report, notification, audit, deployment, and unresolved-assumption checks defined
+- [x] Assessment is pre-build package definition/evidence-contract coverage only; live deployed evidence remains Stage 12 work
+
+---
+
+### Stage 8: Implementation Plan
+**Status**: [x] GATE_PASSED — IMPLEMENTATION_PLAN_COMPLETE_AND_APPROVED  
+**Location**: `modules/pit/08-implementation-plan/`  
+**Key Artifacts**:
+- [x] `implementation-plan.md`
+- [x] `wave-to-red-test-manifest.md`
+- [x] `route-screen-state-acceptance-matrix.md`
+- [x] `wave-definition-of-done-template.md`
+- [x] `builder-execution-responsibility-model.md`
+
+**Functional-Delivery Guardrails**:
+- [x] Work sequenced by functional slices
+- [x] Acceptance evidence, route/page/state coverage, deployed smoke, denied-path, data, notification, audit, report, rollback, and handover expectations defined per wave
+
+---
+
+### Stage 9: Builder Checklist
+**Status**: [x] GATE_PASSED — BUILDER_CHECKLIST_COMPLETE_AND_APPROVED  
+**Location**: `modules/pit/09-builder-checklist/`  
+**Key Artifacts**:
+- [x] `builder-checklist.md`
+- [x] `stage9-gate-pass-review.md`
+- [x] `stage9-post-stage8-hardening-reconfirmation.md`
+
+**Functional-Delivery Guardrails (mandatory and active)**:
+- [x] Stage 1–4 authority chain acknowledged
+- [x] All route/screen/state obligations acknowledged: all 27 routes and all 5 UI states for primary screens
+- [x] RLS/access model acknowledged, including RLS-first enforcement and role hierarchy
+- [x] Visual rendering/app-shell obligations acknowledged, including no-white-screen control
+- [x] Evidence/report/audit/notification obligations acknowledged
+- [x] QA-to-Red expectations acknowledged; RED test suite is the source of truth
+- [x] No direct AIMC provider calls acknowledged
+- [x] No build without Stage 11 appointment and explicit Build Authorization acknowledged
+
+---
+
+### Stage 10: IAA Pre-Brief
+**Status**: [x] GATE_PASSED — IAA_PRE_BRIEF_ACCEPTED  
+**Location**: `modules/pit/10-iaa-pre-brief/`  
+**Key Artifacts**:
+- [x] `iaa-pre-brief.md`
+- [x] `iaa-response.md`
+- [x] `stage10-gate-pass-review.md`
+
+**Functional-Delivery Guardrails (mandatory and active)**:
+- [x] Complete Stage 1–9 artifact pack submitted to IAA
+- [x] Known MMM/PIT delivery risks declared
+- [x] Visual/rendering, route/auth/onboarding, denied-path, and live deployment/PBFAG evidence controls declared
+- [x] IAA challenge questions for one-time functional delivery recorded
+
+---
+
+### Stage 11: Builder Appointment
+**Status**: [x] GATE_PASSED — BUILDER_APPOINTED  
+**Appointed Builder**: `pit-specialist`  
+**Location**: `modules/pit/11-builder-appointment/`  
+**Key Artifacts**:
+- [x] `stage11-builder-appointment.md`
+- [x] `builder-readiness-proof-pack.md`
+- [x] `red-baseline-reconciliation-decision.md`
+- [x] `stage8-hardening-acknowledgement.md`
+
+**Functional-Delivery Guardrails (mandatory and active)**:
+- [x] Stages 1–10 gate-passed by their respective authorities
+- [x] Builder acknowledged full functional scope, all 27 canonical routes, 29 ROUTE-category RED rows, all 5 UI states, and role-denied paths
+- [x] RED tests exist and are understood by the builder
+- [x] PBFAG has passed
+- [x] Handover evidence requirements accepted by the builder
+- [x] Build wave scope is frozen; no scope changes after appointment without CS2 approval and change-propagation audit
+- [x] Build Authorization explicitly cleared by CS2 in tracker update PR #1738 and reaffirmed by issue #1767
+
+---
+
+### Stage 12: Build Execution & Evidence
+**Status**: [ ] AUTHORIZED_TO_START / INCOMPLETE  
 **Location**: `modules/pit/12-build/`  
 **Key Artifacts**:
-- [x] `stage12-kickoff-authorization.md` — CS2 proxy authorization to enter Stage 12 (issue #1767; no functional completion claim)
+- [x] `stage12-kickoff-authorization.md` — authorization to enter Stage 12 (issue #1767; no functional completion claim)
 - [ ] Implementation code in `apps/` or `packages/`
 - [ ] Test evidence (QA-to-Green per wave)
 - [ ] QA validation results
 - [ ] Build completion evidence
 - [ ] Handover documentation
 
-**Functional-Delivery Guardrails (added maturion-isms#1575 — MANDATORY for Stage 12 completion)**:
+**Functional-Delivery Guardrails (mandatory for Stage 12 completion)**:
+- [ ] GREEN test evidence: 100% passing tests with zero failures, zero skipped, zero todo, and no placeholder tests
+- [ ] Visual runtime evidence in deployed environment
+- [ ] Deployed URL evidence
+- [ ] Role/permission evidence
+- [ ] Route coverage evidence for all 27 routes
+- [ ] Evidence/report/notification/audit evidence
+- [ ] Accessibility smoke evidence
+- [ ] CS2 live verification pack
+- [ ] L1/L2/L3 closure status declared
+- [ ] No unresolved critical P0/P1 functional gaps
 
-Build completion requires ALL of the following evidence categories. Missing any category is a build-completion blocker:
-
-- [ ] GREEN test evidence: 100% passing tests (zero failures, zero skipped, zero todo)
-- [ ] Visual runtime evidence: screenshots of key screens in deployed environment confirming no white screens, correct app shell, correct styling
-- [ ] Deployed URL evidence: the app is accessible at its deployed URL from outside the development environment
-- [ ] Role/permission evidence: confirmed that permission-denied state is rendered for at least 3 protected routes/actions in deployed environment
-- [ ] Route coverage evidence: all 27 routes return the correct component in the deployed environment (deployment smoke test)
-- [ ] Evidence/report/notification/audit evidence: demonstrated that each of these features is functional in the deployed environment
-- [ ] Accessibility smoke evidence: axe-core zero violations and Lighthouse accessibility ≥ 90 in deployed environment
-- [ ] CS2 live verification pack: CS2 / Johan Ras has performed live E2E verification in the deployed environment (L3 closure)
-- [ ] L1/L2/L3 closure status declared: L1 (tests GREEN), L2 (builder-verified deployed), L3 (CS2-verified deployed) all confirmed
-- [ ] No unresolved critical functional gaps: all P0 and P1 FRS requirements verified functional in deployed environment
-
-**Completion Date**: N/A  
-**Notes**: Stage 12 build execution is authorized to start under issue #1767 but remains incomplete. Core build has not yet produced implementation code, tests, deployed runtime evidence, or handover evidence. As an artifact of Wave 9.7 AIMC integration (pre-12-stage), `src/services/aimc-wiring.ts` exists as an AIMC integration component and `pit-advisor.md` persona exists in `packages/ai-centre/src/agents/`. These are integration artifacts, not core PIT module build completion evidence.
+**Notes**: Stage 12 is authorized to start under issue #1767 but remains incomplete. Existing AIMC wiring/persona artifacts are integration context only and do not count as Stage 12 build completion evidence.
 
 ---
 
 ## Governance Compliance
 
-- [x] Stage 1 App Description: CS2_APPROVED_AUTHORITATIVE (2026-05-06) — Functional delivery retrofit review: PASS (no material gaps; retrofit annotation added)
-- [x] Stage 2 UX Workflow & Wiring Spec: **CS2_RECONFIRMED** (maturion-isms#1548, PR #1594, maturion-isms#1575) — UX-GAP-001 and UX-GAP-002 resolved; baseline locked for downstream derivation
-- [x] Stage 3 FRS: **DRAFT_HARDENED_CS2_RECONFIRMED** (maturion-isms#1556) — v0.2-hardened, CS2 re-confirmed
-- [x] Stage 4 TRS: **CS2_APPROVED** (maturion-isms#1554 + maturion-isms#1575 + maturion-isms#1604) — v0.2-draft CS2 approved 2026-05-11 by @APGI-cmy
-- [x] Stage 5 Architecture: **GATE_PASSED (CS2/Foreman)** — 2026-05-18 Stage 5 review completed against Stage 1–4 authority chain and architecture completeness canon
-- [x] Stage 5b LFV Package: **MERGED** (maturion-isms#1623 / PR #1624) — 2026-05-12 — all 10 artifacts PIT-specific; merged as Stage 6 input
-- [x] Stage 6 QA-to-Red: **GATE_PASSED (CS2/Foreman)** (maturion-isms#1625 / PR #1626 reviewed 2026-05-18; reconciliation amendment issue #1714 / PR #1715) — 147 RED tests baseline; 0 BLOCKING_GAP; Stage 5 and Stage 5b prerequisites satisfied
-- [x] Stage 7 PBFAG: **GATE_PASSED — PBFAG_COMPLETE_AND_APPROVED** (2026-05-19) — package reviewed against Stage 7 required artifacts and guardrails in pre-build definition/evidence-contract scope (no live execution or FUNCTIONAL_PASS claim)
-- [x] Stage 8 Implementation Plan: **GATE_PASSED — IMPLEMENTATION_PLAN_COMPLETE_AND_APPROVED** (maturion-isms#1679; 2026-05-19) — all 22 issue checklist items PASS; all 9 Functional-Delivery Guardrails PASS; review authority: foreman-v2-agent; review evidence: `modules/pit/08-implementation-plan/stage8-gate-pass-review.md`
-- [x] Stage 9 Builder Checklist: **GATE_PASSED — BUILDER_CHECKLIST_COMPLETE_AND_APPROVED** (maturion-isms#1687; review authority: foreman-v2-agent; 2026-05-19) — `builder-checklist.md` and `stage9-gate-pass-review.md` filed; all 19 criteria PASS; all 8 Functional-Delivery Guardrails PASS; reconfirmed valid after Stage 8 hardening (maturion-isms#1694 / PR #1695 — 2026-05-20 — see `stage9-post-stage8-hardening-reconfirmation.md`)
-- [x] Stage 10 IAA Pre-Brief: **GATE_PASSED — IAA_PRE_BRIEF_ACCEPTED** (maturion-isms#1698 / PR #1701; review authority: foreman-v2-agent + IAA; 2026-05-20) — `iaa-pre-brief.md`, `iaa-response.md`, `stage10-gate-pass-review.md` filed; RED reconciliation 147-test CS2 Option B closure recorded
-- [x] Stage 11 Builder Appointment: **GATE_PASSED — BUILDER_APPOINTED** (maturion-isms#1729 / PR #1730; review authority: foreman-v2-agent; 2026-05-21) — pit-specialist appointed; Stage 12 now authorized to start by issue #1767
-- [x] Traceability chain: App Description ✅ → UX Workflow (CS2_RECONFIRMED) → FRS (CS2_RECONFIRMED) → TRS (CS2_APPROVED) → Architecture (GATE_PASSED) → LFV Package (MERGED) → QA-to-Red (GATE_PASSED) → PBFAG (GATE_PASSED) → Implementation Plan (GATE_PASSED) → Builder Checklist (GATE_PASSED) → IAA Pre-Brief (GATE_PASSED) → Builder Appointment (GATE_PASSED)
-- [x] Stage 1 approval obtained — Johan Ras / CS2 approved 2026-05-06 (ref: maturion-isms#1540)
-- [x] Build Authorization: **CLEARED (CS2 explicit tracker statement)** — clearance recorded in tracker update PR #1738 and reaffirmed in issue #1767; appointed builder is pit-specialist; Stage 12 authorized to start but incomplete
+- [x] Stage 1 App Description: CS2_APPROVED_AUTHORITATIVE
+- [x] Stage 2 UX Workflow & Wiring Spec: CS2_RECONFIRMED
+- [x] Stage 3 FRS: DRAFT_HARDENED_CS2_RECONFIRMED
+- [x] Stage 4 TRS: CS2_APPROVED
+- [x] Stage 5 Architecture: GATE_PASSED
+- [x] Stage 5b LFV Package: MERGED
+- [x] Stage 6 QA-to-Red: GATE_PASSED; 147 RED baseline binding
+- [x] Stage 7 PBFAG: GATE_PASSED
+- [x] Stage 8 Implementation Plan: GATE_PASSED
+- [x] Stage 9 Builder Checklist: GATE_PASSED
+- [x] Stage 10 IAA Pre-Brief: GATE_PASSED
+- [x] Stage 11 Builder Appointment: GATE_PASSED; `pit-specialist` appointed
+- [x] Build Authorization: CLEARED by CS2 tracker statement and reaffirmed in issue #1767
+- [x] Stage 12: AUTHORIZED_TO_START / INCOMPLETE; no `FUNCTIONAL_PASS` claim
 
 ---
 
@@ -132,24 +294,14 @@ The notes below preserve historical context from earlier PIT readiness waves. Wh
 
 **Stage 2 Foreman-Reviewed (2026-05-06)**: All 13 Stage 2 completion criteria verified per maturion-isms#1548. UX Workflow & Wiring Spec v0.2-draft satisfied all requirements and later reached CS2 re-confirmation after retrofit review and PR #1594 gap closure.
 
-**Stage 3 FRS v0.2-hardened (2026-05-07)**: FRS upgraded from v0.1-draft to v0.2-hardened per maturion-isms#1556 (PR #1557). The former pending-approval wording is historical only; Stage 3 is now CS2 re-confirmed and baseline-locked for downstream derivation.
+**Stage 3 FRS v0.2-hardened (2026-05-07)**: FRS upgraded from v0.1-draft to v0.2-hardened per maturion-isms#1556. Former pending-approval wording is historical only; Stage 3 is now CS2 re-confirmed and baseline-locked for downstream derivation.
 
-**Stage 3 FRS Draft Created (2026-05-06)**: Stage 3 FRS v0.1-draft created per maturion-isms#1548. This was superseded by v0.2-hardened and later CS2 reconfirmation.
+**Stage 1 App Description CS2 Approved (2026-05-06)**: CS2/Johan Ras reviewed and approved Stage 1 App Description per maturion-isms#1540.
 
-**Stage 1 App Description Filed (2026-05-06)**: App Description v1.0-draft created per maturion-isms#1534 delegation from Foreman to pit-specialist. Module name corrected from "Penetration Intelligence Tool" to "Project Implementation Tracker". Source prepared by CS2/Johan + assistant-assisted drafting under Johan Ras direction. MMM Lessons Promoted Into PIT section added (L-001–L-008 + Stage 2 carry-forward requirements). Improvement register created at `modules/pit/_readiness/pit-build-process-improvement-register.md`.
-
-**Stage 1 App Description CS2 Approved (2026-05-06)**: CS2/Johan Ras reviewed and approved Stage 1 App Description per maturion-isms#1540. Status changed from Draft to Authoritative (v1.0). Stage 2 (UX Workflow & Wiring Spec) authorised.
-
-**Governance Upgrade (2026-04-06)**: Stage model migrated from legacy 6-stage (Stage 0–5) to canonical 12-stage per `PRE_BUILD_STAGE_MODEL_CANON.md` v1.1.0. See Stage Migration Note above.
-
-**Prior Note (2026-02-13)**: TRS stage introduced per governance upgrade "Governance Upgrade: Insert Technical Requirements Specification (TRS) Step".
-
-**PIT Integration Contract**: `PIT_INTEGRATION_CONTRACT_v0.1.md` exists in the module root and provides useful context for App Description authoring.
-
-**AI Integration**: AIMC wiring (Wave 9.7) complete. `pit-advisor.md` persona delivered. See `10-governance-notes/` and `20-ai/` for AI integration governance context.
+**AI Integration**: AIMC wiring and the `pit-advisor.md` persona were delivered before the canonical Stage 12 build wave. Those artifacts remain integration context only and do not count as Stage 12 build completion evidence.
 
 ---
 
-**Template Version**: 1.0.0 (12-stage model per PRE_BUILD_STAGE_MODEL_CANON.md v1.1.0)  
+**Template Version**: 1.0.0 (12-stage model per `PRE_BUILD_STAGE_MODEL_CANON.md` v1.1.0)  
 **Template Authority**: `governance/templates/BUILD_PROGRESS_TRACKER_TEMPLATE.md`  
 **Last Template Update**: 2026-04-06


### PR DESCRIPTION
## Summary

Authorizes PIT to enter Stage 12 Build Execution & Evidence and cleans the tracker hygiene issues identified during CS2 proxy review.

## Scope

This PR is a Stage 12 kickoff / governance authorization PR. It does **not** implement PIT runtime code and does **not** claim `FUNCTIONAL_PASS`.

Changes:

- Updates `modules/pit/BUILD_PROGRESS_TRACKER.md`
  - marks Stage 12 as `AUTHORIZED_TO_START / INCOMPLETE`
  - removes stale pending/reconfirmation wording from the active tracker state
  - normalizes progress wording to avoid percentage overclaiming
  - preserves historical notes as superseded context
- Adds `modules/pit/12-build/stage12-kickoff-authorization.md`
  - records issue #1767 as the Stage 12 authorization path
  - binds Stage 12 to the appointed builder `pit-specialist`
  - binds the 147-test RED baseline
  - restates no `FUNCTIONAL_PASS` until deployed LFV evidence and CS2 L3 verification exist

## Governance decision

PIT Stages 1–11 were reviewed against the pre-build and fully functional delivery canons. They satisfy the pre-build readiness standard for entering Stage 12.

Stage 12 remains incomplete until implementation code, tests, deployed evidence, CS2 L3 verification, and handover evidence are filed.

## References

- Stage 12 authorization issue: #1767
- Builder appointment / build authorization tracker clearance: PR #1738
- Appointed builder: `pit-specialist`
- RED baseline: 147 tests, including `PIT-RED-ROUTE-029`, `PIT-RED-TIMELINE-011`, and `PIT-RED-TIMELINE-012`

## CS2 proxy statement

As CS2 proxy, I approve PIT to enter Stage 12 build execution under the constraints recorded here. This PR intentionally starts the Stage 12 authorization path without claiming build completion or functional delivery.