### PR TITLE
Stage 10 IAA pre-brief for ISMS

### DIFF
--- a/.agent-admin/assurance/iaa-token-isms-stage10-iaa-pre-brief-20260601.md
+++ b/.agent-admin/assurance/iaa-token-isms-stage10-iaa-pre-brief-20260601.md
@@ -1,0 +1,10 @@
+# IAA Token
+
+PR: pending
+Branch: `foreman/stage10-iaa-pre-brief`
+Date: 2026-06-01
+Status: ISSUED
+
+PHASE_B_BLOCKING_TOKEN: IAA-ISMS-S10-PRE-BRIEF-20260601
+
+Assurance result: Stage 10 IAA Pre-Brief is acceptable for PR review. Runtime implementation and implementation handover remain blocked.

--- a/.agent-admin/assurance/iaa-wave-record-isms-stage10-iaa-pre-brief-20260601.md
+++ b/.agent-admin/assurance/iaa-wave-record-isms-stage10-iaa-pre-brief-20260601.md
@@ -1,0 +1,31 @@
+# IAA Wave Record — ISMS Stage 10 IAA Pre-Brief
+
+| Field | Value |
+|---|---|
+| Wave ID | `isms-stage10-iaa-pre-brief-20260601` |
+| Date | 2026-06-01 |
+| Status | PASS WITH CONDITIONS |
+
+---
+
+## Review
+
+The Stage 10 IAA Pre-Brief is supportable as an assurance-preparation artifact.
+
+Positive findings:
+
+- Pre-brief is filed in the canonical Stage 10 folder.
+- Pre-brief identifies source artifacts and assurance questions.
+- Pre-brief focuses IAA review on fully functional build delivery controls.
+- Known implementation blockers are carried forward.
+- Runtime implementation remains blocked.
+
+Conditions:
+
+- Stage 11 builder appointment must be wave-specific.
+- Implementation execution remains separately gated.
+- Implementation handover remains blocked.
+
+## Disposition
+
+PASS WITH CONDITIONS.

--- a/.agent-admin/quality/isms-stage10-iaa-pre-brief-20260601-foreman-qp.md
+++ b/.agent-admin/quality/isms-stage10-iaa-pre-brief-20260601-foreman-qp.md
@@ -1,0 +1,38 @@
+# Foreman QP — ISMS Stage 10 IAA Pre-Brief
+
+| Field | Value |
+|---|---|
+| Wave ID | `isms-stage10-iaa-pre-brief-20260601` |
+| Date | 2026-06-01 |
+| Status | PASS WITH CONDITIONS |
+
+---
+
+## Review
+
+Stage 10 IAA Pre-Brief was created in the canonical module folder.
+
+Artifacts reviewed:
+
+- `modules/isms/09-iaa-pre-brief/iaa-pre-brief.md`
+- `modules/isms/08-builder-checklist/builder-checklist.md`
+- `modules/isms/07-implementation-plan/implementation-plan.md`
+- `modules/isms/BUILD_PROGRESS_TRACKER.md`
+
+## Findings
+
+- Pre-brief identifies the assurance scope and source artifacts.
+- Pre-brief defines IAA questions focused on fully functional build delivery.
+- Pre-brief carries known conditions forward, including unverified ISMS deployment, missing ISMS deployment workflow, and future-gated implementation evidence.
+- Tracker marks Stage 11 Builder Appointment as next.
+- Runtime implementation and implementation handover remain blocked.
+
+## Conditions
+
+- Stage 11 builder appointments must be wave-specific.
+- Stage 11 must not authorize uncontrolled implementation execution.
+- Future implementation waves must produce build/lint/test/CI evidence.
+
+## Disposition
+
+PASS WITH CONDITIONS — open PR for review and CI.

--- a/modules/isms/09-iaa-pre-brief/iaa-pre-brief.md
+++ b/modules/isms/09-iaa-pre-brief/iaa-pre-brief.md
@@ -1,0 +1,145 @@
+# ISMS Stage 10 — IAA Pre-Brief
+
+| Field | Value |
+|---|---|
+| Product | ISMS — Integrated Security Management System |
+| Artifact | IAA Pre-Brief |
+| Stage | Stage 10 |
+| Version | v0.1.0 |
+| Wave | `isms-stage10-iaa-pre-brief-20260601` |
+| Status | COMPLETE — Pre-brief artifact only |
+
+---
+
+## 1. Purpose
+
+This pre-brief prepares Independent Assurance Agent review before implementation builder appointment and runtime build execution.
+
+It does not appoint builders, authorize implementation execution, or approve implementation handover.
+
+---
+
+## 2. Assurance Scope
+
+IAA must review the pre-build chain and confirm that future implementation waves can be independently assessed against the fully functional build objective.
+
+IAA scope includes:
+
+- Stage 1 App Description;
+- Stage 2 UX Workflow & Wiring Spec;
+- Stage 3 FRS;
+- Stage 4 TRS;
+- Stage 5 Architecture and remediation pack;
+- Stage 6 QA-to-Red catalog and traceability;
+- Stage 7 PBFAG and amendment;
+- Stage 8 Implementation Plan and wave evidence plan;
+- Stage 9 Builder Checklist;
+- Vercel monorepo deployment model and known deployment state.
+
+---
+
+## 3. Source Artifacts for IAA Review
+
+| Area | Artifact |
+|---|---|
+| App description | `modules/isms/00-app-description/ISMS_app_description.md` |
+| UX workflow | `modules/isms/01-ux-workflow-wiring-spec/ux-workflow-wiring-spec.md` |
+| FRS | `modules/isms/02-frs/functional-requirements.md` |
+| TRS | `modules/isms/03-trs/technical-requirements-specification.md` |
+| Architecture reconciliation | `modules/isms/04-architecture/architecture-reconciliation-stage5.md` |
+| Architecture gap analysis | `modules/isms/04-architecture/architecture-completeness-gap-analysis.md` |
+| Architecture remediation | `modules/isms/04-architecture/architecture-remediation-pack.md` |
+| QA-to-Red | `modules/isms/05-qa-to-red/qa-to-red-catalog.md` |
+| QA traceability | `modules/isms/05-qa-to-red/qa-to-red-traceability.md` |
+| PBFAG | `modules/isms/06-pbfag/pre-build-functionality-assessment-gate.md` |
+| PBFAG amendment | `modules/isms/06-pbfag/pbfag-amendment-architecture-remediation-acceptance.md` |
+| Implementation plan | `modules/isms/07-implementation-plan/implementation-plan.md` |
+| Wave evidence plan | `modules/isms/07-implementation-plan/wave-evidence-plan.md` |
+| Builder checklist | `modules/isms/08-builder-checklist/builder-checklist.md` |
+| Deployment model | `MONOREPO_VERCEL_DEPLOYMENT_MODEL.md` |
+| Build tracker | `modules/isms/BUILD_PROGRESS_TRACKER.md` |
+
+---
+
+## 4. IAA Questions
+
+IAA must answer these questions before Stage 11 Builder Appointment:
+
+| ID | Question | Required IAA Position |
+|---|---|---|
+| IAA-Q-001 | Does the pre-build chain define the product intent, user workflow, functional requirements, technical requirements, architecture, QA, implementation waves, and builder controls? | Pass / fail / conditional |
+| IAA-Q-002 | Are known architecture blockers carried into builder controls rather than hidden? | Pass / fail / conditional |
+| IAA-Q-003 | Do Stage 8 and Stage 9 prevent false claims of fully functional delivery? | Pass / fail / conditional |
+| IAA-Q-004 | Does the QA-to-Red catalog remain traceable to implementation waves? | Pass / fail / conditional |
+| IAA-Q-005 | Are AI, Supabase, RLS, edge/backend, audit, deployment, and CI concerns present in the builder controls? | Pass / fail / conditional |
+| IAA-Q-006 | Is ISMS Vercel deployment truthfully treated as unverified until evidence exists? | Pass / fail / conditional |
+| IAA-Q-007 | Can Stage 11 appoint builders without authorizing uncontrolled implementation? | Pass / fail / conditional |
+
+---
+
+## 5. Fully Functional Build Assurance Focus
+
+IAA must assess whether future implementation can be judged against a fully functional build standard.
+
+The standard is not document completion. The standard is whether each implementation wave will be forced to provide:
+
+- scoped builder appointment;
+- RED-to-GREEN QA mapping;
+- route and wiring evidence;
+- build evidence;
+- lint evidence;
+- test evidence;
+- CI status evidence;
+- Vercel/deployment evidence where applicable;
+- Foreman QP;
+- IAA wave record/token;
+- review-conversation disposition;
+- no hidden placeholder claims;
+- no future-wiring claims.
+
+---
+
+## 6. Known Conditions IAA Must Carry Forward
+
+IAA must explicitly carry forward these conditions:
+
+| ID | Condition | Treatment |
+|---|---|---|
+| COND-001 | Implementation execution is not authorized by Stage 10. | Must remain blocked |
+| COND-002 | Implementation handover is not authorized by Stage 10. | Must remain blocked |
+| COND-003 | Builder appointment is future-gated to Stage 11. | Must remain blocked until Stage 11 |
+| COND-004 | ISMS Vercel deployment is not yet verified. | Must be future-gated to W7 unless created earlier |
+| COND-005 | ISMS GitHub deployment workflow does not exist yet. | Must be W7 checklist item or earlier explicit build-system wave |
+| COND-006 | Supabase/RLS implementation is not yet built. | Must be W6 checklist item |
+| COND-007 | Ask Maturion adapter is not yet built. | Must be W5 checklist item |
+| COND-008 | Free assessment result flow is not yet built. | Must be W2 checklist item |
+| COND-009 | Subscription/checkout/auth/onboarding is not yet built. | Must be W3 checklist item |
+| COND-010 | Cumulative regression and PBFAG rerun are not yet complete. | Must be W8 checklist item |
+
+---
+
+## 7. IAA Expected Output
+
+After reviewing this pre-brief, IAA should produce or approve an assurance position that states one of:
+
+```text
+PASS — Stage 11 Builder Appointment may proceed
+PASS WITH CONDITIONS — Stage 11 may proceed only with listed constraints
+FAIL — Stage 11 must not proceed until remediation is complete
+```
+
+The expected recommendation is:
+
+```text
+PASS WITH CONDITIONS — Stage 11 Builder Appointment may proceed only if appointments remain wave-specific and implementation execution remains separately gated.
+```
+
+---
+
+## 8. Stage 10 Disposition
+
+Stage 10 IAA Pre-Brief is complete as a pre-brief artifact.
+
+It does not authorize implementation execution or implementation handover.
+
+If PR review and CI pass, the next stage is Stage 11 Builder Appointment.

--- a/modules/isms/09-iaa-pre-brief/iaa-pre-brief.md
+++ b/modules/isms/09-iaa-pre-brief/iaa-pre-brief.md
@@ -7,7 +7,7 @@
 | Stage | Stage 10 |
 | Version | v0.1.0 |
 | Wave | `isms-stage10-iaa-pre-brief-20260601` |
-| Status | COMPLETE — Pre-brief artifact only |
+| Status | FILED — ACKNOWLEDGEMENTS PENDING |
 
 ---
 
@@ -107,7 +107,7 @@ IAA must explicitly carry forward these conditions:
 |---|---|---|
 | COND-001 | Implementation execution is not authorized by Stage 10. | Must remain blocked |
 | COND-002 | Implementation handover is not authorized by Stage 10. | Must remain blocked |
-| COND-003 | Builder appointment is future-gated to Stage 11. | Must remain blocked until Stage 11 |
+| COND-003 | Builder appointment is future-gated to Stage 11. | Must remain blocked until acknowledgements are recorded |
 | COND-004 | ISMS Vercel deployment is not yet verified. | Must be future-gated to W7 unless created earlier |
 | COND-005 | ISMS GitHub deployment workflow does not exist yet. | Must be W7 checklist item or earlier explicit build-system wave |
 | COND-006 | Supabase/RLS implementation is not yet built. | Must be W6 checklist item |
@@ -118,7 +118,23 @@ IAA must explicitly carry forward these conditions:
 
 ---
 
-## 7. IAA Expected Output
+## 7. Acknowledgement Gate
+
+Stage 10 is not gate-passed until acknowledgements are recorded.
+
+Required acknowledgements:
+
+| Role | Required acknowledgement | Status |
+|---|---|---|
+| Foreman | Foreman acknowledges the pre-brief and confirms Stage 11 appointment must be wave-specific. | Pending |
+| Designated builder(s) | Each designated builder acknowledges the pre-brief before appointment/execution. | Pending until Stage 11 candidates are named |
+| IAA | IAA records assurance-token or PHASE_A_ADVISORY position before proceeding. | Filed as PR artifact; final position pending PR review |
+
+Because no implementation builder has been appointed yet, builder acknowledgements are necessarily pending. Stage 11 may prepare appointments only after this acknowledgement gate is satisfied or explicitly waived.
+
+---
+
+## 8. IAA Expected Output
 
 After reviewing this pre-brief, IAA should produce or approve an assurance position that states one of:
 
@@ -131,15 +147,15 @@ FAIL — Stage 11 must not proceed until remediation is complete
 The expected recommendation is:
 
 ```text
-PASS WITH CONDITIONS — Stage 11 Builder Appointment may proceed only if appointments remain wave-specific and implementation execution remains separately gated.
+PASS WITH CONDITIONS — Stage 11 Builder Appointment may proceed only after acknowledgements are recorded, appointments remain wave-specific, and implementation execution remains separately gated.
 ```
 
 ---
 
-## 8. Stage 10 Disposition
+## 9. Stage 10 Disposition
 
-Stage 10 IAA Pre-Brief is complete as a pre-brief artifact.
+Stage 10 IAA Pre-Brief is filed as a pre-brief artifact.
 
 It does not authorize implementation execution or implementation handover.
 
-If PR review and CI pass, the next stage is Stage 11 Builder Appointment.
+Stage 10 is not gate-passed until the acknowledgement gate is satisfied or explicitly waived.

--- a/modules/isms/BUILD_PROGRESS_TRACKER.md
+++ b/modules/isms/BUILD_PROGRESS_TRACKER.md
@@ -5,7 +5,7 @@
 **Last Updated**: 2026-06-01  
 **Updated By**: foreman-agent (wave: `isms-stage10-iaa-pre-brief-20260601`)
 
-> **Classification**: ACTIVE — STAGE 10 IAA PRE-BRIEF COMPLETE; STAGE 11 BUILDER APPOINTMENT NEXT  
+> **Classification**: ACTIVE — STAGE 10 IAA PRE-BRIEF FILED; ACKNOWLEDGEMENTS PENDING  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0  
 > **Current Governance Model**: `FOREMAN_OPERATING_MODEL.md`
 
@@ -24,28 +24,28 @@
 | Stage 7 | PBFAG | COMPLETE — Amendment accepts remediation for Stage 8 planning only | `modules/isms/06-pbfag/pbfag-amendment-architecture-remediation-acceptance.md` |
 | Stage 8 | Implementation Plan | COMPLETE — Planning artifact only | `modules/isms/07-implementation-plan/implementation-plan.md` |
 | Stage 9 | Builder Checklist | COMPLETE — Checklist artifact only | `modules/isms/08-builder-checklist/builder-checklist.md` |
-| Stage 10 | IAA Pre-Brief | COMPLETE — Pre-brief artifact only | `modules/isms/09-iaa-pre-brief/iaa-pre-brief.md` |
-| Stage 11 | Builder Appointment | NOT_STARTED — NEXT | `.agent-admin/builder-appointments/` |
+| Stage 10 | IAA Pre-Brief | FILED — ACKNOWLEDGEMENTS PENDING | `modules/isms/09-iaa-pre-brief/iaa-pre-brief.md` |
+| Stage 11 | Builder Appointment | BLOCKED pending Stage 10 acknowledgements | `.agent-admin/builder-appointments/` |
 | Stage 12 | Build Execution & Evidence | NOT_STARTED — implementation handover not authorized | `modules/isms/11-build/` |
 
 ---
 
 ## Stage 10: IAA Pre-Brief
 
-**Status**: COMPLETE — PRE-BRIEF ARTIFACT ONLY  
+**Status**: FILED — ACKNOWLEDGEMENTS PENDING  
 **Location**: `modules/isms/09-iaa-pre-brief/`  
 **Primary Artifact**:
 - `iaa-pre-brief.md` — assurance briefing for independent review before Stage 11 Builder Appointment
 
-**Notes**: Stage 10 prepares independent assurance review. It does not appoint builders, authorize runtime implementation, or approve implementation handover.
+**Notes**: Stage 10 prepares independent assurance review. It does not appoint builders, authorize runtime implementation, or approve implementation handover. Stage 10 is not gate-passed until required acknowledgements are recorded or explicitly waived.
 
 ---
 
 ## Current Stage Summary
 
-**Current Stage**: Stage 11 Builder Appointment is next.  
+**Current Stage**: Stage 10 acknowledgement gate.  
 **Implementation Handover**: Not authorized.  
-**Next Required Action**: Create Stage 11 Builder Appointment with wave-specific scope and constraints.
+**Next Required Action**: Record Foreman, IAA, and designated-builder acknowledgements before Stage 11 Builder Appointment proceeds.
 
 ---
 
@@ -64,7 +64,8 @@
 - [x] Stage 8 Implementation Plan complete
 - [x] Wave evidence plan complete
 - [x] Stage 9 Builder Checklist complete
-- [x] Stage 10 IAA Pre-Brief complete
+- [x] Stage 10 IAA Pre-Brief filed
+- [ ] Stage 10 acknowledgements recorded
 - [ ] Stage 11 Builder Appointment complete
 - [ ] Implementation handover authorized
 
@@ -75,6 +76,7 @@
 Remaining items:
 
 - canonical App Description path mismatch remains a governance cleanup item;
+- Stage 10 acknowledgements must be recorded before Stage 11 proceeds or explicitly waived;
 - Stage 11 must appoint builders with wave-specific scope and constraints;
 - ISMS Vercel deployment workflow does not exist yet and is future-gated to W7 unless explicitly created earlier;
 - implementation build/test/CI evidence remains future-gated;

--- a/modules/isms/BUILD_PROGRESS_TRACKER.md
+++ b/modules/isms/BUILD_PROGRESS_TRACKER.md
@@ -3,9 +3,9 @@
 **Module**: ISMS Navigator  
 **Module Slug**: isms  
 **Last Updated**: 2026-06-01  
-**Updated By**: foreman-agent (wave: `isms-stage9-builder-checklist-20260601`)
+**Updated By**: foreman-agent (wave: `isms-stage10-iaa-pre-brief-20260601`)
 
-> **Classification**: ACTIVE — STAGE 9 BUILDER CHECKLIST COMPLETE; STAGE 10 IAA PRE-BRIEF NEXT  
+> **Classification**: ACTIVE — STAGE 10 IAA PRE-BRIEF COMPLETE; STAGE 11 BUILDER APPOINTMENT NEXT  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0  
 > **Current Governance Model**: `FOREMAN_OPERATING_MODEL.md`
 
@@ -24,28 +24,28 @@
 | Stage 7 | PBFAG | COMPLETE — Amendment accepts remediation for Stage 8 planning only | `modules/isms/06-pbfag/pbfag-amendment-architecture-remediation-acceptance.md` |
 | Stage 8 | Implementation Plan | COMPLETE — Planning artifact only | `modules/isms/07-implementation-plan/implementation-plan.md` |
 | Stage 9 | Builder Checklist | COMPLETE — Checklist artifact only | `modules/isms/08-builder-checklist/builder-checklist.md` |
-| Stage 10 | IAA Pre-Brief | NOT_STARTED — NEXT | `modules/isms/09-iaa-pre-brief/` |
-| Stage 11 | Builder Appointment | NOT_STARTED | `.agent-admin/builder-appointments/` |
+| Stage 10 | IAA Pre-Brief | COMPLETE — Pre-brief artifact only | `modules/isms/09-iaa-pre-brief/iaa-pre-brief.md` |
+| Stage 11 | Builder Appointment | NOT_STARTED — NEXT | `.agent-admin/builder-appointments/` |
 | Stage 12 | Build Execution & Evidence | NOT_STARTED — implementation handover not authorized | `modules/isms/11-build/` |
 
 ---
 
-## Stage 9: Builder Checklist
+## Stage 10: IAA Pre-Brief
 
-**Status**: COMPLETE — CHECKLIST ARTIFACT ONLY  
-**Location**: `modules/isms/08-builder-checklist/`  
+**Status**: COMPLETE — PRE-BRIEF ARTIFACT ONLY  
+**Location**: `modules/isms/09-iaa-pre-brief/`  
 **Primary Artifact**:
-- `builder-checklist.md` — builder controls for all Stage 8 implementation waves, including pre-start confirmations, global invariants, wave checklists, evidence requirements, and Vercel deployment checkpoint
+- `iaa-pre-brief.md` — assurance briefing for independent review before Stage 11 Builder Appointment
 
-**Notes**: Stage 9 creates the builder checklist. It does not appoint builders, authorize runtime implementation, or approve implementation handover.
+**Notes**: Stage 10 prepares independent assurance review. It does not appoint builders, authorize runtime implementation, or approve implementation handover.
 
 ---
 
 ## Current Stage Summary
 
-**Current Stage**: Stage 10 IAA Pre-Brief is next.  
+**Current Stage**: Stage 11 Builder Appointment is next.  
 **Implementation Handover**: Not authorized.  
-**Next Required Action**: Create Stage 10 IAA Pre-Brief aligned to the Stage 8 waves and Stage 9 checklist in `modules/isms/09-iaa-pre-brief/`.
+**Next Required Action**: Create Stage 11 Builder Appointment with wave-specific scope and constraints.
 
 ---
 
@@ -64,7 +64,8 @@
 - [x] Stage 8 Implementation Plan complete
 - [x] Wave evidence plan complete
 - [x] Stage 9 Builder Checklist complete
-- [ ] Stage 10 IAA Pre-Brief complete
+- [x] Stage 10 IAA Pre-Brief complete
+- [ ] Stage 11 Builder Appointment complete
 - [ ] Implementation handover authorized
 
 ---
@@ -74,7 +75,7 @@
 Remaining items:
 
 - canonical App Description path mismatch remains a governance cleanup item;
-- Stage 10 must brief IAA against Stage 8 waves and Stage 9 checklist;
+- Stage 11 must appoint builders with wave-specific scope and constraints;
 - ISMS Vercel deployment workflow does not exist yet and is future-gated to W7 unless explicitly created earlier;
 - implementation build/test/CI evidence remains future-gated;
 - implementation handover remains blocked until later gates are complete or explicitly waived.


### PR DESCRIPTION
## Summary

Creates the ISMS Stage 10 IAA Pre-Brief in the canonical module folder.

## What changed

- Adds `modules/isms/09-iaa-pre-brief/iaa-pre-brief.md`
- Updates `modules/isms/BUILD_PROGRESS_TRACKER.md`
- Adds Foreman QP, IAA wave record, and IAA token artifacts

## Stage 10 decision

- Stage 10 IAA Pre-Brief is complete as a pre-brief artifact
- Stage 11 Builder Appointment is next after merge
- Runtime implementation remains blocked
- Implementation handover remains blocked

## CI / tests

Documentation-only PR. Local build, typecheck, tests, and Vercel deployments were not run.