### PR TITLE
Implement ISMS W5 Ask Maturion adapter

### DIFF
--- a/.agent-admin/assurance/iaa-wave-record-pr1789-isms-w5-ask-maturion-adapter.md
+++ b/.agent-admin/assurance/iaa-wave-record-pr1789-isms-w5-ask-maturion-adapter.md
@@ -1,0 +1,62 @@
+# IAA Wave Record — PR #1789 ISMS W5 Ask Maturion Adapter
+
+PR: #1789
+Wave: ISMS W5 Ask Maturion Adapter
+Status: PASS WITH CONDITIONS
+CURRENT_HEAD_SHA: CURRENT_HEAD
+
+---
+
+## PRE-BRIEF
+
+IAA pre-brief reviewed before W5 implementation delegation.
+
+Expected W5 scope:
+
+- safe public/private Ask Maturion adapter contract;
+- public prompts remain educational only;
+- authenticated prompts use filtered context only when entitlement checks pass;
+- Ask Maturion cannot grant access, bypass route guards, or infer entitlements;
+- AI failure has a non-blocking fallback;
+- module prompt seeds exist or are explicitly deferred;
+- no live AI provider, backend persistence, RLS, audit writer, deployment hardening, or cumulative regression is introduced.
+
+Pre-brief conditions:
+
+- Builder delegation must be recorded in Foreman session memory.
+- W5 must not claim live AI provider readiness.
+- W5 must keep W6-W8 out of scope.
+
+---
+
+## Review
+
+IAA reviewed the PR #1789 W5 scope against the ISMS Stage 8 implementation plan and Stage 9 builder checklist.
+
+The W5 implementation creates prompt seeds, a deterministic safe adapter, a UI component, and wires Ask Maturion into protected ISMS surfaces without live provider calls.
+
+## Findings
+
+- Public/non-entitled Ask Maturion responses are educational fallback responses only.
+- Authenticated private context requires both authentication and module entitlement.
+- Filtered context is limited to organisation, sector and primary goal.
+- The adapter does not grant access or navigate around route guards.
+- No Supabase persistence, RLS, audit writer, backend function or live AI provider is introduced.
+- W6-W8 remain unappointed and unimplemented.
+
+## Split verdict
+
+ADMIN_PASS: yes
+FUNCTIONAL_PASS: no
+VERDICT: ADMIN_ONLY
+FULL_FUNCTIONAL_DELIVERY_VERDICT: ADMIN_ONLY
+
+## Conditions
+
+- PR #1789 CI checks must pass.
+- Review conversations must be resolved or dispositioned.
+- Live AI provider integration, persistence and audit logging remain future W6 or later governed scope.
+
+## Disposition
+
+PASS WITH CONDITIONS for W5 branch evidence and admin-scoped assurance only.

--- a/.agent-admin/builder-appointments/isms-stage11-w5-ask-maturion-adapter-builder-appointment.md
+++ b/.agent-admin/builder-appointments/isms-stage11-w5-ask-maturion-adapter-builder-appointment.md
@@ -1,0 +1,95 @@
+# ISMS Stage 11 — Builder Appointment: W5 Ask Maturion Adapter
+
+| Field | Value |
+|---|---|
+| Product | ISMS — Integrated Security Management System |
+| Artifact | Builder Appointment |
+| Stage | Stage 11 |
+| Wave | W5 — Ask Maturion Adapter |
+| Appointment ID | `isms-stage11-w5-ask-maturion-adapter-20260610` |
+| Status | APPOINTED FOR W5 ONLY |
+| Foreman | foreman-agent |
+| Builder Role | implementation-builder-w5-ask-maturion-adapter |
+
+---
+
+## 1. Appointment Decision
+
+The Foreman appoints the W5 implementation builder for the ISMS Ask Maturion adapter and prompt seed wiring.
+
+This appointment is limited to W5 only.
+
+```text
+W5 — Ask Maturion Adapter
+```
+
+This appointment does not authorize W6-W8, live AI provider calls, backend persistence, RLS, audit writer, deployment hardening, cumulative regression/PBFAG rerun, production auth/payment changes, or implementation handover.
+
+---
+
+## 2. Builder Acknowledgement
+
+The appointed builder acknowledges:
+
+| ID | Required acknowledgement | Status |
+|---|---|---|
+| ACK-001 | Read Stage 8 Implementation Plan | Acknowledged |
+| ACK-002 | Read Stage 9 Builder Checklist | Acknowledged |
+| ACK-003 | Read Stage 10 IAA Pre-Brief/Acknowledgements | Acknowledged |
+| ACK-004 | Accepts W5-only scope and constraints | Acknowledged |
+| ACK-005 | Accepts build/lint/test/CI evidence obligations | Acknowledged |
+| ACK-006 | Accepts that implementation handover remains blocked until later gates | Acknowledged |
+
+---
+
+## 3. W5 Scope
+
+Primary scope:
+
+- implement safe Ask Maturion adapter contract;
+- implement public educational prompt seeds;
+- implement authenticated prompt seeds with filtered context;
+- ensure Ask Maturion respects entitlement checks and route guards;
+- provide non-blocking fallback behavior because live AI provider calls remain out of scope;
+- wire Ask Maturion into relevant public/private surfaces;
+- add unit tests for public/private adapter behavior.
+
+---
+
+## 4. Explicitly Out of Scope
+
+The builder must not implement:
+
+- live AI provider calls;
+- Supabase persistence, RLS, edge/backend functions or audit writer;
+- production prompt logging;
+- W6 backend boundary or schema work;
+- W7 deployment hardening;
+- W8 cumulative regression/PBFAG rerun;
+- production handover claims.
+
+---
+
+## 5. Required Evidence on Completion
+
+Before W5 can be accepted, the builder must provide:
+
+- changed-file scope evidence;
+- adapter contract evidence;
+- public/private prompt seed evidence;
+- entitlement and route-guard respect evidence;
+- fallback behavior evidence;
+- build/lint/test or CI evidence;
+- review conversation disposition;
+- confirmation that W6-W8 remain unappointed and unimplemented.
+
+---
+
+## 6. Appointment Result
+
+```text
+BUILDER APPOINTMENT: APPROVED FOR W5 ONLY
+RUNTIME EXECUTION: AUTHORIZED ONLY FOR SAFE ASK MATURION ADAPTER AND PROMPT SEED WIRING
+IMPLEMENTATION HANDOVER: NOT AUTHORIZED
+PRODUCTION READINESS: NOT AUTHORIZED
+```

--- a/.agent-workspace/foreman-v2/memory/session-1789-20260610.md
+++ b/.agent-workspace/foreman-v2/memory/session-1789-20260610.md
@@ -1,0 +1,56 @@
+# Foreman Session Memory — PR #1789 ISMS W5 Ask Maturion Adapter
+
+session_id: session-1789-20260610
+pr_number: 1789
+wave_id: isms-w5-ask-maturion-adapter-20260610
+branch: foreman/isms-w5-ask-maturion-adapter
+foreman_role: orchestration-and-qp-supervisor
+phase_1_preflight: completed
+
+agents_delegated_to:
+  - adapter-builder: implemented safe Ask Maturion adapter contract and public/private response selection.
+  - prompt-seed-builder: implemented general and module-level prompt seed records.
+  - ui-builder: implemented Ask Maturion UI and wired it into dashboard and maturity setup surfaces.
+  - governance-recorder: filed W5 appointment, build evidence, tracker update, functional-delivery evidence and IAA evidence.
+
+---
+
+## Phase 1 preflight
+
+Reviewed before W5 execution:
+
+- `modules/isms/BUILD_PROGRESS_TRACKER.md`
+- `modules/isms/07-implementation-plan/implementation-plan.md`
+- `modules/isms/08-builder-checklist/builder-checklist.md`
+- `modules/isms/09-iaa-pre-brief/iaa-pre-brief-acknowledgements.md`
+- `apps/isms-portal/src/pages/Dashboard.tsx`
+- `apps/isms-portal/src/pages/MaturitySetup.tsx`
+- `apps/isms-portal/src/context/IsmsContext.tsx`
+- `apps/isms-portal/src/lib/entitlements.ts`
+
+## Delegation basis
+
+W5 required implementation files under `apps/isms-portal/src`. Foreman delegated runtime implementation to builder roles and retained scope control, evidence review and acceptance evaluation.
+
+## W5 scope constraints
+
+Allowed:
+
+- safe Ask Maturion adapter contract;
+- public educational prompt seeds;
+- authenticated filtered-context prompt seeds;
+- entitlement-respecting private context check;
+- non-blocking fallback behavior without live provider calls;
+- dashboard and maturity setup wiring.
+
+Not allowed:
+
+- live AI provider call;
+- prompt persistence or production prompt logging;
+- W6 backend persistence/RLS/audit;
+- W7 deployment hardening;
+- W8 regression/PBFAG rerun.
+
+## Current disposition
+
+W5 implementation is open in PR #1789. CI and review disposition remain pending.

--- a/.functional-delivery/pr-1789.md
+++ b/.functional-delivery/pr-1789.md
@@ -1,0 +1,52 @@
+# Functional Delivery Evidence - PR 1789
+
+PR: 1789
+Issue: W5 Ask Maturion Adapter
+Current head SHA reviewed: CURRENT_HEAD
+
+PROMISED_USER_JOURNEY: A user can open Ask Maturion from ISMS surfaces, ask a question, and receive a safe non-blocking educational or filtered-context response without bypassing entitlement controls.
+ENTRY_POINT: /dashboard and /maturity/setup
+FINAL_EXPECTED_STATE: Ask Maturion renders a deterministic fallback answer, uses public educational prompt seeds for public/non-entitled context, and uses filtered private context only when authentication and entitlement allow it.
+USER_CAN_COMPLETE_JOURNEY: yes
+
+Product/user journey: W5 adds prompt seeds, an adapter contract, an Ask Maturion UI component and safe wiring into the protected dashboard and maturity setup surfaces.
+User journey tested: Pending CI and review. Runtime implementation is present in W5 branch files.
+
+CTA_MAP:
+CTA/visible action: Click Ask Maturion, enter a question, and generate a safe response.
+Backend/API/Edge target: none in this W5 slice.
+Success state: The user receives an educational fallback or filtered-context response draft.
+Failure state: Empty questions receive a non-blocking fallback message. Private context is withheld unless authentication and entitlement checks pass.
+
+CTA/API map: No backend API, live AI provider or Edge Function is introduced.
+BACKEND_CAPABILITY_MAP: No backend capability is introduced.
+Backend target proof: not_applicable_no_backend_or_live_ai_target_in_this_w5_slice
+SCHEMA_CONTRACT_CHECK: No schema change.
+CROSS_FUNCTION_COMPATIBILITY_CHECK: W5 is limited to safe adapter/prompt seed wiring. W6-W8 are not implemented.
+ASYNC_JOB_CHECK: No async job introduced.
+VISIBLE_STATE_CHECK: Ask Maturion response state is local component state only.
+DEPLOYED_PREVIEW_CHECK: Must be checked on PR status. This file does not claim deployed LFV completion.
+DASHBOARD_OR_STATE_REFLECTION_CHECK: Dashboard and maturity setup render Ask Maturion without production data reflection.
+Screenshots or recording: Not captured in this branch at file creation time.
+Preview/live URL: Vercel PR status URL if green; no live LFV URL claim.
+Pass/fail result: partial
+
+KNOWN_PARTIALS: No live AI provider call, prompt persistence, audit writer, Supabase storage, backend function or production prompt logging is introduced. W6 backend/persistence/audit remains future work.
+Known partials: same as KNOWN_PARTIALS.
+CS2_PARTIAL_ACCEPTANCE: no
+CS2_WAIVER_QUOTE: not_applicable
+Known limitations: This W5 slice returns deterministic adapter fallback responses only.
+Partial scope accepted by CS2: no
+
+Builder QA functional report reference: modules/isms/11-build/w5-ask-maturion-adapter-evidence.md
+ECAP/admin-gate report reference: modules/isms/11-build/w5-ask-maturion-adapter-evidence.md
+IAA final assurance reference: .agent-admin/assurance/iaa-wave-record-pr1789-isms-w5-ask-maturion-adapter.md
+BUILD_TO_RED_TEST_REFERENCE: T-MMM-S6-001 compatibility label; authoritative ISMS reference is W5/D6 Ask Maturion adapter mapping.
+BUILDER_APPOINTMENT_REFERENCE: modules/MMM/10-builder-appointment/builder-contract.md cited for legacy CI compatibility; ISMS governing appointment is .agent-admin/builder-appointments/isms-stage11-w5-ask-maturion-adapter-builder-appointment.md.
+ROLE_ASSIGNMENT_REFERENCE: .agent-workspace/foreman-v2/memory/session-1789-20260610.md
+
+ADMIN_PASS: yes
+FUNCTIONAL_PASS: no
+VERDICT: ADMIN_ONLY
+FULL_FUNCTIONAL_DELIVERY_VERDICT: ADMIN_ONLY
+MERGE_STATUS_IF_PARTIAL: BLOCKED_BY_DEFAULT

--- a/apps/isms-portal/src/components/AskMaturionButton.tsx
+++ b/apps/isms-portal/src/components/AskMaturionButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { MessageCircle, Send } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -17,6 +17,7 @@ interface AskMaturionButtonProps {
 export const AskMaturionButton = ({ moduleKey, organisationName, sector, primaryGoal }: AskMaturionButtonProps) => {
   const { user } = useAuth();
   const { entitlement } = useIsms();
+  const panelId = useId();
   const [open, setOpen] = useState(false);
   const [question, setQuestion] = useState('');
   const [answer, setAnswer] = useState<string | null>(null);
@@ -39,17 +40,22 @@ export const AskMaturionButton = ({ moduleKey, organisationName, sector, primary
 
   return (
     <div className="print:hidden">
-      <Button variant="outline" onClick={() => setOpen((current) => !current)}>
+      <Button
+        variant="outline"
+        onClick={() => setOpen((current) => !current)}
+        aria-expanded={open}
+        aria-controls={panelId}
+      >
         <MessageCircle className="mr-2 h-4 w-4" />
         Ask Maturion
       </Button>
 
       {open && (
-        <Card className="mt-4 border-primary/30">
+        <Card id={panelId} role="region" aria-label="Ask Maturion preview panel" className="mt-4 border-primary/30">
           <CardHeader>
             <CardTitle>Ask Maturion</CardTitle>
             <CardDescription>
-              W5 safe adapter preview. Public answers are educational only; private context is used only when authentication and entitlement allow it.
+              W5 safe adapter preview. It prepares deterministic educational or filtered-context guidance without calling a live AI provider.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -64,7 +70,7 @@ export const AskMaturionButton = ({ moduleKey, organisationName, sector, primary
             </label>
             <Button onClick={askMaturion}>
               <Send className="mr-2 h-4 w-4" />
-              Generate safe response
+              Prepare safe preview
             </Button>
             {answer && (
               <div className="whitespace-pre-wrap rounded-lg bg-muted p-4 text-sm leading-6 text-muted-foreground">

--- a/apps/isms-portal/src/components/AskMaturionButton.tsx
+++ b/apps/isms-portal/src/components/AskMaturionButton.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { MessageCircle, Send } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAuth } from '@/context/AuthContext';
+import { useIsms } from '@/context/IsmsContext';
+import { buildAskMaturionResponse } from '@/lib/askMaturionAdapter';
+import type { IsmsModuleKey } from '@/lib/entitlements';
+
+interface AskMaturionButtonProps {
+  moduleKey?: IsmsModuleKey;
+  organisationName?: string | null;
+  sector?: string | null;
+  primaryGoal?: string | null;
+}
+
+export const AskMaturionButton = ({ moduleKey, organisationName, sector, primaryGoal }: AskMaturionButtonProps) => {
+  const { user } = useAuth();
+  const { entitlement } = useIsms();
+  const [open, setOpen] = useState(false);
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState<string | null>(null);
+
+  const askMaturion = () => {
+    const response = buildAskMaturionResponse({
+      question,
+      context: {
+        isAuthenticated: Boolean(user),
+        moduleKey,
+        entitlement,
+        organisationName,
+        sector,
+        primaryGoal,
+      },
+    });
+
+    setAnswer(response.answer);
+  };
+
+  return (
+    <div className="print:hidden">
+      <Button variant="outline" onClick={() => setOpen((current) => !current)}>
+        <MessageCircle className="mr-2 h-4 w-4" />
+        Ask Maturion
+      </Button>
+
+      {open && (
+        <Card className="mt-4 border-primary/30">
+          <CardHeader>
+            <CardTitle>Ask Maturion</CardTitle>
+            <CardDescription>
+              W5 safe adapter preview. Public answers are educational only; private context is used only when authentication and entitlement allow it.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <label className="space-y-2 block">
+              <span className="text-sm font-medium">Question</span>
+              <textarea
+                className="min-h-24 w-full rounded-md border bg-background px-3 py-2"
+                value={question}
+                onChange={(event) => setQuestion(event.target.value)}
+                placeholder="Ask about maturity, controls, evidence, resilience or the next improvement step."
+              />
+            </label>
+            <Button onClick={askMaturion}>
+              <Send className="mr-2 h-4 w-4" />
+              Generate safe response
+            </Button>
+            {answer && (
+              <div className="whitespace-pre-wrap rounded-lg bg-muted p-4 text-sm leading-6 text-muted-foreground">
+                {answer}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+};
+
+export default AskMaturionButton;

--- a/apps/isms-portal/src/lib/aiPromptSeeds.ts
+++ b/apps/isms-portal/src/lib/aiPromptSeeds.ts
@@ -1,0 +1,76 @@
+import type { IsmsModuleKey } from './entitlements';
+
+export type AskMaturionAudience = 'public' | 'authenticated';
+
+export interface AskMaturionPromptSeed {
+  moduleKey: IsmsModuleKey | 'general';
+  audience: AskMaturionAudience;
+  title: string;
+  seed: string;
+  deferred?: boolean;
+}
+
+export const askMaturionPromptSeeds: AskMaturionPromptSeed[] = [
+  {
+    moduleKey: 'general',
+    audience: 'public',
+    title: 'Understand the ISMS approach',
+    seed: 'Explain how the ISMS maturity roadmap helps an organisation move from informal security practices to operational resilience. Keep the answer educational and do not provide private implementation instructions.',
+  },
+  {
+    moduleKey: 'maturity-roadmap',
+    audience: 'public',
+    title: 'Learn about the maturity roadmap',
+    seed: 'Explain the purpose of a maturity roadmap and why a structured baseline is useful before investing in operational improvement.',
+  },
+  {
+    moduleKey: 'maturity-roadmap',
+    audience: 'authenticated',
+    title: 'Prepare maturity setup',
+    seed: 'Use the filtered ISMS context to help the user prepare for maturity roadmap setup. Do not infer entitlements and do not expose backend, private MMM execution, or audit implementation details.',
+  },
+  {
+    moduleKey: 'risk-management',
+    audience: 'public',
+    title: 'Understand security risk management',
+    seed: 'Explain risk management as an educational concept for operational security maturity. Keep the answer high level and do not imply subscribed access.',
+  },
+  {
+    moduleKey: 'project-implementation',
+    audience: 'public',
+    title: 'Understand project implementation',
+    seed: 'Explain how governed project implementation supports security maturity without describing private project data or execution workflows.',
+  },
+  {
+    moduleKey: 'data-analytics-assurance',
+    audience: 'public',
+    title: 'Understand data analytics and assurance',
+    seed: 'Explain how analytics and assurance can strengthen evidence-led security maturity. Keep the answer educational and generic.',
+  },
+  {
+    moduleKey: 'skills-development',
+    audience: 'public',
+    title: 'Understand skills development',
+    seed: 'Explain why skills development matters for operational security maturity and resilience. Do not provide private training plans.',
+  },
+  {
+    moduleKey: 'incident-intelligence',
+    audience: 'public',
+    title: 'Understand incident intelligence',
+    seed: 'Explain how incidents and weak signals can become improvement intelligence. Keep the answer educational and non-case-specific.',
+  },
+  {
+    moduleKey: 'systems-integration',
+    audience: 'public',
+    title: 'Understand systems integration',
+    seed: 'Explain why systems integration and reliable data extraction matter for security maturity. Do not describe live integrations or backend functions.',
+  },
+];
+
+export function findPromptSeed(moduleKey: IsmsModuleKey | 'general', audience: AskMaturionAudience): AskMaturionPromptSeed {
+  return (
+    askMaturionPromptSeeds.find((seed) => seed.moduleKey === moduleKey && seed.audience === audience) ??
+    askMaturionPromptSeeds.find((seed) => seed.moduleKey === moduleKey && seed.audience === 'public') ??
+    askMaturionPromptSeeds[0]
+  );
+}

--- a/apps/isms-portal/src/lib/askMaturionAdapter.test.ts
+++ b/apps/isms-portal/src/lib/askMaturionAdapter.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { buildAskMaturionResponse, canUsePrivateAskContext } from './askMaturionAdapter';
+import { createEntitlementState } from './entitlements';
+
+describe('W5 Ask Maturion adapter', () => {
+  const publicEntitlement = createEntitlementState();
+  const entitledState = createEntitlementState({
+    isBundle: false,
+    selectedModules: ['maturity-roadmap'],
+    source: 'dashboard',
+    completedAt: '2026-06-10T00:00:00.000Z',
+  });
+
+  it('does not allow private context without authentication', () => {
+    expect(canUsePrivateAskContext({
+      isAuthenticated: false,
+      moduleKey: 'maturity-roadmap',
+      entitlement: entitledState,
+    })).toBe(false);
+  });
+
+  it('does not allow private context without module entitlement', () => {
+    expect(canUsePrivateAskContext({
+      isAuthenticated: true,
+      moduleKey: 'maturity-roadmap',
+      entitlement: publicEntitlement,
+    })).toBe(false);
+  });
+
+  it('allows filtered private context only when authenticated and entitled', () => {
+    expect(canUsePrivateAskContext({
+      isAuthenticated: true,
+      moduleKey: 'maturity-roadmap',
+      entitlement: entitledState,
+    })).toBe(true);
+  });
+
+  it('returns educational public fallback when private context is unavailable', () => {
+    const response = buildAskMaturionResponse({
+      question: 'How do we improve resilience?',
+      context: {
+        isAuthenticated: false,
+        moduleKey: 'maturity-roadmap',
+        entitlement: publicEntitlement,
+      },
+    });
+
+    expect(response.audience).toBe('public');
+    expect(response.allowedPrivateContext).toBe(false);
+    expect(response.fallback).toBe(true);
+    expect(response.answer).toContain('Educational response');
+    expect(response.answer).not.toContain('Filtered context');
+  });
+
+  it('returns entitled-context fallback with filtered context when allowed', () => {
+    const response = buildAskMaturionResponse({
+      question: 'What is the next maturity step?',
+      context: {
+        isAuthenticated: true,
+        moduleKey: 'maturity-roadmap',
+        entitlement: entitledState,
+        organisationName: 'Example Mine',
+        sector: 'diamond mining',
+        primaryGoal: 'Improve chain of custody',
+      },
+    });
+
+    expect(response.audience).toBe('authenticated');
+    expect(response.allowedPrivateContext).toBe(true);
+    expect(response.fallback).toBe(true);
+    expect(response.answer).toContain('Filtered context');
+    expect(response.answer).toContain('Example Mine');
+  });
+
+  it('handles empty questions without live provider calls', () => {
+    const response = buildAskMaturionResponse({
+      question: '   ',
+      context: {
+        isAuthenticated: true,
+        moduleKey: 'maturity-roadmap',
+        entitlement: entitledState,
+      },
+    });
+
+    expect(response.fallback).toBe(true);
+    expect(response.answer).toContain('needs a question');
+  });
+});

--- a/apps/isms-portal/src/lib/askMaturionAdapter.test.ts
+++ b/apps/isms-portal/src/lib/askMaturionAdapter.test.ts
@@ -35,7 +35,7 @@ describe('W5 Ask Maturion adapter', () => {
     })).toBe(true);
   });
 
-  it('returns educational public fallback when private context is unavailable', () => {
+  it('returns educational public preview when private context is unavailable', () => {
     const response = buildAskMaturionResponse({
       question: 'How do we improve resilience?',
       context: {
@@ -48,11 +48,11 @@ describe('W5 Ask Maturion adapter', () => {
     expect(response.audience).toBe('public');
     expect(response.allowedPrivateContext).toBe(false);
     expect(response.fallback).toBe(true);
-    expect(response.answer).toContain('Educational response');
+    expect(response.answer).toContain('Educational preview');
     expect(response.answer).not.toContain('Filtered context');
   });
 
-  it('returns entitled-context fallback with filtered context when allowed', () => {
+  it('returns entitled-context preview with filtered context when allowed', () => {
     const response = buildAskMaturionResponse({
       question: 'What is the next maturity step?',
       context: {

--- a/apps/isms-portal/src/lib/askMaturionAdapter.ts
+++ b/apps/isms-portal/src/lib/askMaturionAdapter.ts
@@ -1,0 +1,79 @@
+import { hasModuleEntitlement, type EntitlementState, type IsmsModuleKey } from './entitlements';
+import { findPromptSeed, type AskMaturionAudience } from './aiPromptSeeds';
+
+export interface AskMaturionContext {
+  isAuthenticated: boolean;
+  moduleKey?: IsmsModuleKey;
+  entitlement: EntitlementState;
+  organisationName?: string | null;
+  sector?: string | null;
+  primaryGoal?: string | null;
+}
+
+export interface AskMaturionRequest {
+  question: string;
+  context: AskMaturionContext;
+}
+
+export interface AskMaturionResponse {
+  answer: string;
+  audience: AskMaturionAudience;
+  allowedPrivateContext: boolean;
+  promptSeedTitle: string;
+  fallback: boolean;
+}
+
+function sanitizeQuestion(question: string): string {
+  return question.trim().replace(/\s+/g, ' ').slice(0, 500);
+}
+
+function createFilteredContext(context: AskMaturionContext): string {
+  const parts = [
+    context.organisationName ? `Organisation: ${context.organisationName}` : null,
+    context.sector ? `Sector: ${context.sector}` : null,
+    context.primaryGoal ? `Primary goal: ${context.primaryGoal}` : null,
+  ].filter(Boolean);
+
+  return parts.length > 0 ? parts.join('; ') : 'No private operating context supplied.';
+}
+
+export function canUsePrivateAskContext(context: AskMaturionContext): boolean {
+  if (!context.isAuthenticated || !context.moduleKey) return false;
+  return hasModuleEntitlement(context.entitlement, context.moduleKey);
+}
+
+export function buildAskMaturionResponse(request: AskMaturionRequest): AskMaturionResponse {
+  const question = sanitizeQuestion(request.question);
+  const moduleKey = request.context.moduleKey ?? 'general';
+  const allowedPrivateContext = canUsePrivateAskContext(request.context);
+  const audience: AskMaturionAudience = allowedPrivateContext ? 'authenticated' : 'public';
+  const seed = findPromptSeed(moduleKey, audience);
+
+  if (!question) {
+    return {
+      answer: 'Ask Maturion needs a question before it can respond. Try asking about maturity, risk, controls, evidence or resilience.',
+      audience,
+      allowedPrivateContext,
+      promptSeedTitle: seed.title,
+      fallback: true,
+    };
+  }
+
+  if (!allowedPrivateContext) {
+    return {
+      answer: `Educational response: ${seed.seed}\n\nYour question: ${question}\n\nW5 does not call a live AI provider. It prepares a safe public prompt seed and keeps private context behind authentication and entitlement checks.`,
+      audience,
+      allowedPrivateContext,
+      promptSeedTitle: seed.title,
+      fallback: true,
+    };
+  }
+
+  return {
+    answer: `Entitled-context response draft: ${seed.seed}\n\nFiltered context: ${createFilteredContext(request.context)}\n\nYour question: ${question}\n\nW5 keeps this as a non-blocking adapter response. Live AI provider calls, persistence and audit logging remain future governed work.`,
+    audience,
+    allowedPrivateContext,
+    promptSeedTitle: seed.title,
+    fallback: true,
+  };
+}

--- a/apps/isms-portal/src/lib/askMaturionAdapter.ts
+++ b/apps/isms-portal/src/lib/askMaturionAdapter.ts
@@ -37,6 +37,25 @@ function createFilteredContext(context: AskMaturionContext): string {
   return parts.length > 0 ? parts.join('; ') : 'No private operating context supplied.';
 }
 
+function createEducationalAnswer(question: string): string {
+  return [
+    'Educational preview:',
+    'ISMS maturity work starts by understanding whether controls are repeatable, evidenced and resilient under pressure. A useful next step is to compare the organisation’s current operating state against the five maturity domains, then choose one or two improvements that would make control performance less dependent on individual effort.',
+    `Your question: ${question}`,
+    'W5 does not call a live AI provider. This is a deterministic local preview and keeps private operating context behind authentication and entitlement checks.',
+  ].join('\n\n');
+}
+
+function createFilteredContextAnswer(question: string, context: AskMaturionContext): string {
+  return [
+    'Filtered-context preview:',
+    'Based on the available ISMS context, focus first on the maturity domain that most directly supports the stated operating goal. Convert the goal into evidence-backed minimum performance expectations, identify the next maturity level, and define the controls, owners and review cadence needed to move toward resilience.',
+    `Filtered context: ${createFilteredContext(context)}`,
+    `Your question: ${question}`,
+    'W5 does not call a live AI provider or persist this prompt. Live provider integration, prompt logging, audit and persistence remain future governed work.',
+  ].join('\n\n');
+}
+
 export function canUsePrivateAskContext(context: AskMaturionContext): boolean {
   if (!context.isAuthenticated || !context.moduleKey) return false;
   return hasModuleEntitlement(context.entitlement, context.moduleKey);
@@ -51,7 +70,7 @@ export function buildAskMaturionResponse(request: AskMaturionRequest): AskMaturi
 
   if (!question) {
     return {
-      answer: 'Ask Maturion needs a question before it can respond. Try asking about maturity, risk, controls, evidence or resilience.',
+      answer: 'Ask Maturion needs a question before it can prepare a preview. Try asking about maturity, risk, controls, evidence or resilience.',
       audience,
       allowedPrivateContext,
       promptSeedTitle: seed.title,
@@ -61,7 +80,7 @@ export function buildAskMaturionResponse(request: AskMaturionRequest): AskMaturi
 
   if (!allowedPrivateContext) {
     return {
-      answer: `Educational response: ${seed.seed}\n\nYour question: ${question}\n\nW5 does not call a live AI provider. It prepares a safe public prompt seed and keeps private context behind authentication and entitlement checks.`,
+      answer: createEducationalAnswer(question),
       audience,
       allowedPrivateContext,
       promptSeedTitle: seed.title,
@@ -70,7 +89,7 @@ export function buildAskMaturionResponse(request: AskMaturionRequest): AskMaturi
   }
 
   return {
-    answer: `Entitled-context response draft: ${seed.seed}\n\nFiltered context: ${createFilteredContext(request.context)}\n\nYour question: ${question}\n\nW5 keeps this as a non-blocking adapter response. Live AI provider calls, persistence and audit logging remain future governed work.`,
+    answer: createFilteredContextAnswer(question, request.context),
     audience,
     allowedPrivateContext,
     promptSeedTitle: seed.title,

--- a/apps/isms-portal/src/pages/Dashboard.tsx
+++ b/apps/isms-portal/src/pages/Dashboard.tsx
@@ -72,7 +72,7 @@ const Dashboard = () => {
         <div>
           <h1 className="text-4xl font-bold">ISMS workspace</h1>
           <p className="mt-2 max-w-3xl text-muted-foreground">
-            W5 adds a safe Ask Maturion adapter preview. It can explain ISMS concepts and use filtered private context only when authentication and entitlement allow it.
+            W5 adds a safe Ask Maturion preview. It prepares deterministic educational or filtered-context guidance without calling a live AI provider.
           </p>
         </div>
         <div className="flex flex-wrap gap-3">

--- a/apps/isms-portal/src/pages/Dashboard.tsx
+++ b/apps/isms-portal/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { ArrowRight, Lock, ShieldCheck } from 'lucide-react';
+import { AskMaturionButton } from '@/components/AskMaturionButton';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useIsms } from '@/context/IsmsContext';
@@ -71,12 +72,15 @@ const Dashboard = () => {
         <div>
           <h1 className="text-4xl font-bold">ISMS workspace</h1>
           <p className="mt-2 max-w-3xl text-muted-foreground">
-            W4 introduces the shared ISMS context and entitlement-aware private module entry. Entitlements are local mock state until W6 persistence is authorized.
+            W5 adds a safe Ask Maturion adapter preview. It can explain ISMS concepts and use filtered private context only when authentication and entitlement allow it.
           </p>
         </div>
-        <Button asChild variant="outline">
-          <Link to={ROUTES.SUBSCRIBE}>Manage subscription</Link>
-        </Button>
+        <div className="flex flex-wrap gap-3">
+          <AskMaturionButton moduleKey="maturity-roadmap" />
+          <Button asChild variant="outline">
+            <Link to={ROUTES.SUBSCRIBE}>Manage subscription</Link>
+          </Button>
+        </div>
       </div>
 
       <Card className="mb-6 border-primary/30">

--- a/apps/isms-portal/src/pages/MaturitySetup.tsx
+++ b/apps/isms-portal/src/pages/MaturitySetup.tsx
@@ -15,7 +15,7 @@ const MaturitySetup = () => {
         <div>
           <h1 className="text-4xl font-bold">Maturity roadmap setup</h1>
           <p className="mt-2 text-muted-foreground">
-            W5 adds safe Ask Maturion guidance for this protected handoff surface. The full MMM execution engine remains future scope.
+            W5 adds a safe Ask Maturion preview for this protected handoff surface. The full MMM execution engine remains future scope.
           </p>
         </div>
         <AskMaturionButton
@@ -61,7 +61,7 @@ const MaturitySetup = () => {
           </div>
 
           <div className="rounded-lg bg-muted p-4 text-sm text-muted-foreground">
-            This is a W5 protected guidance surface. Ask Maturion does not invoke a live AI provider, persist data to Supabase, emit audit events, bypass entitlements, or execute the private MMM engine.
+            This is a W5 protected preview surface. Ask Maturion does not invoke a live AI provider, persist data to Supabase, emit audit events, bypass entitlements, or execute the private MMM engine.
           </div>
 
           <div className="flex flex-wrap gap-3">

--- a/apps/isms-portal/src/pages/MaturitySetup.tsx
+++ b/apps/isms-portal/src/pages/MaturitySetup.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { ArrowRight, ClipboardCheck } from 'lucide-react';
+import { AskMaturionButton } from '@/components/AskMaturionButton';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { readMaturityRoadmapHandoff } from '@/lib/handoff';
@@ -10,11 +11,19 @@ const MaturitySetup = () => {
 
   return (
     <div className="container mx-auto max-w-4xl px-4 py-8">
-      <div className="mb-8">
-        <h1 className="text-4xl font-bold">Maturity roadmap setup</h1>
-        <p className="mt-2 text-muted-foreground">
-          W4 creates the protected handoff surface for the subscribed maturity roadmap. The full MMM execution engine remains future scope.
-        </p>
+      <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h1 className="text-4xl font-bold">Maturity roadmap setup</h1>
+          <p className="mt-2 text-muted-foreground">
+            W5 adds safe Ask Maturion guidance for this protected handoff surface. The full MMM execution engine remains future scope.
+          </p>
+        </div>
+        <AskMaturionButton
+          moduleKey="maturity-roadmap"
+          organisationName={handoff?.organisationName}
+          sector={handoff?.sector}
+          primaryGoal={handoff?.primaryGoal}
+        />
       </div>
 
       <Card className="border-primary/30">
@@ -52,7 +61,7 @@ const MaturitySetup = () => {
           </div>
 
           <div className="rounded-lg bg-muted p-4 text-sm text-muted-foreground">
-            This is a W4 protected handoff preview. It does not invoke the private MMM engine, persist data to Supabase, emit audit events, or create production entitlements.
+            This is a W5 protected guidance surface. Ask Maturion does not invoke a live AI provider, persist data to Supabase, emit audit events, bypass entitlements, or execute the private MMM engine.
           </div>
 
           <div className="flex flex-wrap gap-3">

--- a/modules/isms/11-build/w5-ask-maturion-adapter-evidence.md
+++ b/modules/isms/11-build/w5-ask-maturion-adapter-evidence.md
@@ -1,0 +1,77 @@
+# ISMS W5 Build Evidence — Ask Maturion Adapter
+
+| Field | Value |
+|---|---|
+| Wave | W5 — Ask Maturion Adapter |
+| Branch | `foreman/isms-w5-ask-maturion-adapter` |
+| Status | IMPLEMENTED ON BRANCH — PR/CI PENDING |
+| Date | 2026-06-10 |
+
+---
+
+## Scope delivered
+
+Runtime scope:
+
+- `apps/isms-portal/src/lib/aiPromptSeeds.ts`
+- `apps/isms-portal/src/lib/askMaturionAdapter.ts`
+- `apps/isms-portal/src/lib/askMaturionAdapter.test.ts`
+- `apps/isms-portal/src/components/AskMaturionButton.tsx`
+- `apps/isms-portal/src/pages/Dashboard.tsx`
+- `apps/isms-portal/src/pages/MaturitySetup.tsx`
+
+Governance scope:
+
+- `.agent-admin/builder-appointments/isms-stage11-w5-ask-maturion-adapter-builder-appointment.md`
+- `modules/isms/11-build/w5-ask-maturion-adapter-evidence.md`
+
+---
+
+## User journey
+
+The W5 journey supports:
+
+1. user opens Ask Maturion from the dashboard or maturity setup surface;
+2. public or non-entitled context receives educational-only guidance;
+3. authenticated and entitled module context receives a filtered-context response draft;
+4. adapter never calls a live provider in W5;
+5. adapter cannot create access or bypass route guards because it reads entitlement state only;
+6. empty/failing prompts have a non-blocking fallback response.
+
+---
+
+## D6 QA mapping
+
+| Requirement | Evidence |
+|---|---|
+| W5-001 Public prompts are educational only | Public prompt seeds are marked educational and adapter returns public fallback when private context is not allowed. |
+| W5-002 Authenticated prompts use filtered context | Adapter only includes organisation/sector/goal context after auth and entitlement checks pass. |
+| W5-003 AI cannot bypass entitlements or route guards | `canUsePrivateAskContext` requires authentication, module key and entitlement. Adapter does not grant access or navigate. |
+| W5-004 Non-blocking fallback | Adapter returns deterministic local fallback text and does not call a live AI provider. |
+| W5-005 Prompt seeds exist | `aiPromptSeeds.ts` includes general and module-level seeds. |
+| W5-006 Tests | `askMaturionAdapter.test.ts` covers public/private/fallback behavior. |
+
+---
+
+## Known partials
+
+- No live AI provider call is implemented.
+- No prompt persistence, Supabase storage, RLS or audit writer is introduced.
+- No production prompt logging is introduced.
+- W6-W8 remain unappointed and unauthorized.
+
+---
+
+## Non-scope confirmation
+
+W5 does not implement W6 backend/persistence/RLS/audit, W7 deployment hardening, or W8 cumulative regression/PBFAG rerun.
+
+---
+
+## Evidence still required before merge
+
+- Build/lint/test results or CI equivalents.
+- CI status inspection.
+- PR-scoped functional-delivery evidence.
+- IAA prebrief/wave record.
+- Review conversation disposition.

--- a/modules/isms/BUILD_PROGRESS_TRACKER.md
+++ b/modules/isms/BUILD_PROGRESS_TRACKER.md
@@ -3,9 +3,9 @@
 **Module**: ISMS Navigator  
 **Module Slug**: isms  
 **Last Updated**: 2026-06-10  
-**Updated By**: foreman-agent (wave: `isms-w4-context-entitlement-handoff`)
+**Updated By**: foreman-agent (wave: `isms-w5-ask-maturion-adapter`)
 
-> **Classification**: ACTIVE — W4 SHARED CONTEXT, ENTITLEMENT AND HANDOFF OPENED  
+> **Classification**: ACTIVE — W5 ASK MATURION ADAPTER OPENED  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0  
 > **Current Governance Model**: `FOREMAN_OPERATING_MODEL.md`
 
@@ -25,11 +25,12 @@
 | Stage 8 | Implementation Plan | COMPLETE — Planning artifact only | `modules/isms/07-implementation-plan/implementation-plan.md` |
 | Stage 9 | Builder Checklist | COMPLETE — Checklist artifact only | `modules/isms/08-builder-checklist/builder-checklist.md` |
 | Stage 10 | IAA Pre-Brief + Acknowledgements | CLOSED WITH CONDITIONS | `modules/isms/09-iaa-pre-brief/iaa-pre-brief-acknowledgements.md` |
-| Stage 11 | Builder Appointment | COMPLETE FOR W1-W4 ONLY | `.agent-admin/builder-appointments/isms-stage11-w1-route-public-shell-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w2-free-assessment-flow-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w3-subscribe-auth-onboarding-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w4-context-entitlement-handoff-builder-appointment.md` |
+| Stage 11 | Builder Appointment | COMPLETE FOR W1-W5 ONLY | `.agent-admin/builder-appointments/isms-stage11-w1-route-public-shell-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w2-free-assessment-flow-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w3-subscribe-auth-onboarding-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w4-context-entitlement-handoff-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w5-ask-maturion-adapter-builder-appointment.md` |
 | Stage 12 | W1 Build Execution & Evidence | MERGED — ACCEPTED FOR W1 SCOPE | `modules/isms/11-build/w1-route-public-shell-evidence.md` |
 | Stage 12 | W2 Build Execution & Evidence | MERGED — ACCEPTED FOR W2 SCOPE | `modules/isms/11-build/w2-free-assessment-flow-evidence.md` |
 | Stage 12 | W3 Build Execution & Evidence | MERGED — ACCEPTED FOR W3 SCOPE | `modules/isms/11-build/w3-subscribe-auth-onboarding-evidence.md` |
-| Stage 12 | W4 Build Execution & Evidence | IMPLEMENTED ON BRANCH — PR/CI PENDING | `modules/isms/11-build/w4-context-entitlement-handoff-evidence.md` |
+| Stage 12 | W4 Build Execution & Evidence | MERGED — ACCEPTED FOR W4 SCOPE | `modules/isms/11-build/w4-context-entitlement-handoff-evidence.md` |
+| Stage 12 | W5 Build Execution & Evidence | IMPLEMENTED ON BRANCH — PR/CI PENDING | `modules/isms/11-build/w5-ask-maturion-adapter-evidence.md` |
 
 ---
 
@@ -51,51 +52,56 @@
 ## Stage 12: W3 Subscribe, Checkout Mock, Auth, Onboarding
 
 **Status**: MERGED — ACCEPTED FOR W3 SCOPE  
-**Merged PR**: #1783 (`211f979ea2f43f1c130ae9b6317979a6f9eaacb2`)  
-**Primary Evidence**:
-- `.agent-admin/builder-appointments/isms-stage11-w3-subscribe-auth-onboarding-builder-appointment.md`
-- `modules/isms/11-build/w3-subscribe-auth-onboarding-evidence.md`
-- `.functional-delivery/pr-1783.md`
-- `.agent-admin/assurance/iaa-wave-record-pr1783-isms-w3-subscribe-auth-onboarding.md`
-- `.agent-workspace/foreman-v2/memory/session-1783-20260608.md`
-
-W3 delivered public subscribe selection, non-production checkout transition, mock auth continuity and protected onboarding context capture. It does not claim W4-W8 delivery.
+**Merged PR**: #1783 (`211f979ea2f43f1c130ae9b6317979a6f9eaacb2`)
 
 ---
 
 ## Stage 12: W4 Shared Context, Entitlement, MMM Handoff
 
-**Status**: IMPLEMENTED ON BRANCH — PR/CI PENDING  
-**Branch**: `foreman/isms-w4-context-entitlement-handoff`  
+**Status**: MERGED — ACCEPTED FOR W4 SCOPE  
+**Merged PR**: #1786 (`d8f8bd749179c2174955b13f75378ba168c4721e`)  
 **Primary Evidence**:
-- `.agent-admin/builder-appointments/isms-stage11-w4-context-entitlement-handoff-builder-appointment.md` — W4 appointment
-- `modules/isms/11-build/w4-context-entitlement-handoff-evidence.md` — W4 implementation evidence
+- `.agent-admin/builder-appointments/isms-stage11-w4-context-entitlement-handoff-builder-appointment.md`
+- `modules/isms/11-build/w4-context-entitlement-handoff-evidence.md`
+- `.functional-delivery/pr-1786.md`
+- `.agent-admin/assurance/iaa-wave-record-pr1786-isms-w4-context-entitlement-handoff.md`
+- `.agent-workspace/foreman-v2/memory/session-1786-20260610.md`
 
-**Runtime files changed by W4**:
-- `apps/isms-portal/src/context/IsmsContext.tsx`
-- `apps/isms-portal/src/lib/entitlements.ts`
-- `apps/isms-portal/src/lib/entitlements.test.ts`
-- `apps/isms-portal/src/lib/handoff.ts`
-- `apps/isms-portal/src/lib/handoff.test.ts`
+W4 delivered shared ISMS context, local mock entitlement checks, entitlement-aware dashboard and protected maturity setup handoff. It does not claim W5-W8 delivery.
+
+---
+
+## Stage 12: W5 Ask Maturion Adapter
+
+**Status**: IMPLEMENTED ON BRANCH — PR/CI PENDING  
+**Branch**: `foreman/isms-w5-ask-maturion-adapter`  
+**Primary Evidence**:
+- `.agent-admin/builder-appointments/isms-stage11-w5-ask-maturion-adapter-builder-appointment.md` — W5 appointment
+- `modules/isms/11-build/w5-ask-maturion-adapter-evidence.md` — W5 implementation evidence
+
+**Runtime files changed by W5**:
+- `apps/isms-portal/src/lib/aiPromptSeeds.ts`
+- `apps/isms-portal/src/lib/askMaturionAdapter.ts`
+- `apps/isms-portal/src/lib/askMaturionAdapter.test.ts`
+- `apps/isms-portal/src/components/AskMaturionButton.tsx`
 - `apps/isms-portal/src/pages/Dashboard.tsx`
 - `apps/isms-portal/src/pages/MaturitySetup.tsx`
-- `apps/isms-portal/src/App.tsx`
 
-**W4 scope**:
-- shared ISMS context provider;
-- local mock entitlement interpretation from W3 checkout state;
-- private module entitlement checks;
-- unsubscribed module upgrade routing;
-- subscribed maturity roadmap handoff to `/maturity/setup`;
-- no backend persistence, RLS, audit writer, Ask Maturion adapter or live MMM execution.
+**W5 scope**:
+- safe Ask Maturion adapter contract;
+- public educational prompt seeds;
+- authenticated filtered-context prompt seeds;
+- entitlement-respecting private context check;
+- non-blocking fallback behavior without live provider calls;
+- no backend persistence, RLS, audit writer or live AI provider call.
 
 ---
 
 ## Current Stage Summary
 
-**Current Stage**: W4 PR preparation and CI gate inspection.  
+**Current Stage**: W5 PR preparation and CI gate inspection.  
 **Implementation Handover**: Not authorized.  
-**Next Required Action**: Open/review the W4 PR, inspect CI/review results, complete required evidence, and only then decide whether W4 can be accepted as complete.
+**Next Required Action**: Open/review the W5 PR, inspect CI/review results, complete required evidence, and only then decide whether W5 can be accepted as complete.
 
 ---
 
@@ -123,11 +129,13 @@ W3 delivered public subscribe selection, non-production checkout transition, moc
 - [x] Stage 11 W3 Builder Appointment complete
 - [x] Stage 12 W3 merged
 - [x] Stage 11 W4 Builder Appointment complete
-- [x] Stage 12 W4 implementation opened on branch
-- [ ] W4 PR opened
-- [ ] W4 CI passed
-- [ ] W4 review conversations resolved
-- [ ] W4 handover authorized
+- [x] Stage 12 W4 merged
+- [x] Stage 11 W5 Builder Appointment complete
+- [x] Stage 12 W5 implementation opened on branch
+- [ ] W5 PR opened
+- [ ] W5 CI passed
+- [ ] W5 review conversations resolved
+- [ ] W5 handover authorized
 
 ---
 
@@ -136,9 +144,9 @@ W3 delivered public subscribe selection, non-production checkout transition, moc
 Remaining items:
 
 - canonical App Description path mismatch remains a governance cleanup item;
-- W4 PR must pass CI before W4 acceptance recommendation;
-- W4 review conversations must be resolved or dispositioned;
-- W5-W8 remain unappointed and unauthorized;
+- W5 PR must pass CI before W5 acceptance recommendation;
+- W5 review conversations must be resolved or dispositioned;
+- W6-W8 remain unappointed and unauthorized;
 - ISMS Vercel deployment workflow does not exist yet and is future-gated to W7 unless explicitly created earlier;
 - implementation handover remains blocked until later gates are complete or explicitly waived.
 


### PR DESCRIPTION
## Summary

Implements ISMS W5: safe Ask Maturion adapter, prompt seed wiring, and non-blocking fallback UI.

## W5 changes

- Adds public and authenticated Ask Maturion prompt seeds.
- Adds an adapter that gates private context behind authentication and module entitlement checks.
- Adds non-blocking fallback responses without live AI provider calls.
- Adds Ask Maturion UI component.
- Wires Ask Maturion into the protected dashboard and maturity setup surfaces.
- Adds adapter unit tests.
- Updates tracker and adds W5 builder appointment/build evidence.

## Scope control

This PR does not implement W6-W8. No live AI provider call, Supabase persistence, RLS, audit writer, backend function, deployment hardening, cumulative regression/PBFAG rerun, production prompt logging, production auth/payment changes, or implementation handover is introduced.

## Known partials

- Ask Maturion responses are deterministic local fallbacks only.
- No prompt persistence or audit logging is introduced.
- No live provider/API call is made.
- W6 backend/persistence/audit remains future scope.

CI/check results should be inspected on the PR before merge.