### PR TITLE
PIT W8.2 role matrix verification ledger

### DIFF
--- a/.agent-admin/assurance/iaa-prebrief-pit-w82-role-matrix.md
+++ b/.agent-admin/assurance/iaa-prebrief-pit-w82-role-matrix.md
@@ -7,29 +7,33 @@ WAVE: PIT_W8_2_ROLE_MATRIX
 WAVE_TASKS_PATH: modules/pit/12-build/w82-role-matrix-denied-path-verification.md
 CURRENT_HEAD_SHA: CURRENT_HEAD
 
-## PRE-BRIEF
+PRE-BRIEF:
 
 Scope is limited to documenting the current W8.2 actor-verification blocker and required role-matrix evidence path.
 
-## EXPECTED_QA_SCOPE
+EXPECTED_QA_SCOPE:
 
 - Verify current data discovery is recorded.
 - Verify actor-level proof is not claimed without role assignments.
 - Verify remaining denied-path evidence stays open.
 - Verify no full W8.2 exit claim.
 
-## EXPECTED_FAILURE_MODES
+EXPECTED_FAILURE_MODES:
 
 - Actor behavior claimed without test actors.
-- Deployed denied-path proof claimed without browser evidence.
+- Browser evidence claimed without proof.
 - W8.2 completion or FUNCTIONAL_PASS claimed prematurely.
 
-## FOREMAN_INSTRUCTIONS
+FOREMAN_INSTRUCTIONS:
 
-Keep this PR evidence/planning only unless CS2 authorises seeded test actor creation.
+- Keep this PR evidence and planning only.
+- Report CI and Vercel status honestly.
+- Preserve the no-FUNCTIONAL_PASS posture.
 
-## IAA_WILL_QA
+IAA_WILL_QA:
 
-IAA will review the role matrix ledger and non-overclaim posture.
+- IAA will review the role matrix ledger.
+- IAA will verify non-overclaim posture.
+- IAA will verify all W8.2 role identifiers are canonical.
 
 RESULT: PREFLIGHT_BRIEF_COMPLETE

--- a/.agent-admin/assurance/iaa-prebrief-pit-w82-role-matrix.md
+++ b/.agent-admin/assurance/iaa-prebrief-pit-w82-role-matrix.md
@@ -1,7 +1,7 @@
 # IAA Prebrief - PIT W8.2 Role Matrix
 
 IAA_PREFLIGHT_BRIEF: true
-PR: TBD
+PR: 1791
 ISSUE: 1774
 WAVE: PIT_W8_2_ROLE_MATRIX
 WAVE_TASKS_PATH: modules/pit/12-build/w82-role-matrix-denied-path-verification.md

--- a/.agent-admin/assurance/iaa-prebrief-pit-w82-role-matrix.md
+++ b/.agent-admin/assurance/iaa-prebrief-pit-w82-role-matrix.md
@@ -1,0 +1,35 @@
+# IAA Prebrief - PIT W8.2 Role Matrix
+
+IAA_PREFLIGHT_BRIEF: true
+PR: TBD
+ISSUE: 1774
+WAVE: PIT_W8_2_ROLE_MATRIX
+WAVE_TASKS_PATH: modules/pit/12-build/w82-role-matrix-denied-path-verification.md
+CURRENT_HEAD_SHA: CURRENT_HEAD
+
+## PRE-BRIEF
+
+Scope is limited to documenting the current W8.2 actor-verification blocker and required role-matrix evidence path.
+
+## EXPECTED_QA_SCOPE
+
+- Verify current data discovery is recorded.
+- Verify actor-level proof is not claimed without role assignments.
+- Verify remaining denied-path evidence stays open.
+- Verify no full W8.2 exit claim.
+
+## EXPECTED_FAILURE_MODES
+
+- Actor behavior claimed without test actors.
+- Deployed denied-path proof claimed without browser evidence.
+- W8.2 completion or FUNCTIONAL_PASS claimed prematurely.
+
+## FOREMAN_INSTRUCTIONS
+
+Keep this PR evidence/planning only unless CS2 authorises seeded test actor creation.
+
+## IAA_WILL_QA
+
+IAA will review the role matrix ledger and non-overclaim posture.
+
+RESULT: PREFLIGHT_BRIEF_COMPLETE

--- a/.agent-workspace/foreman-v2/memory/PREHANDOVER-pit-w82-role-matrix.md
+++ b/.agent-workspace/foreman-v2/memory/PREHANDOVER-pit-w82-role-matrix.md
@@ -1,6 +1,6 @@
 # PREHANDOVER - PIT W8.2 Role Matrix
 
-PR: TBD
+PR: 1791
 Issue: 1774
 Builder: pit-specialist
 

--- a/.agent-workspace/foreman-v2/memory/PREHANDOVER-pit-w82-role-matrix.md
+++ b/.agent-workspace/foreman-v2/memory/PREHANDOVER-pit-w82-role-matrix.md
@@ -1,0 +1,17 @@
+# PREHANDOVER - PIT W8.2 Role Matrix
+
+PR: TBD
+Issue: 1774
+Builder: pit-specialist
+
+## Scope
+
+Evidence/planning follow-up after W8.2 Supabase inventory evidence.
+
+## Evidence
+
+- modules/pit/12-build/w82-role-matrix-denied-path-verification.md
+
+## Non-overclaim
+
+This handover does not claim full W8.2 exit, Stage 12 completion, or FUNCTIONAL_PASS.

--- a/modules/pit/12-build/w82-role-matrix-denied-path-verification.md
+++ b/modules/pit/12-build/w82-role-matrix-denied-path-verification.md
@@ -1,0 +1,93 @@
+# PIT Stage 12 W8.2 Role Matrix and Denied-Path Verification
+
+Issue: maturion-isms#1774
+Related PRs: #1782, #1785, #1790
+Supabase project checked: `ujucvyyspfxlxlfdamda`
+
+## Purpose
+
+Continue W8.2 after the schema/RLS foundation and Supabase inventory evidence by defining the role-matrix and denied-path verification package.
+
+## Current Supabase data discovery
+
+The connected Supabase project was checked before role-matrix execution.
+
+```sql
+select count(*)::int as auth_user_count from auth.users;
+```
+
+Result:
+
+| auth_user_count |
+|---:|
+| 3 |
+
+```sql
+select
+  (select count(*)::int from public.organisations) as organisations_count,
+  (select count(*)::int from public.user_org_memberships) as memberships_count,
+  (select count(*)::int from public.user_roles) as roles_count,
+  (select count(*)::int from public.audit_log) as audit_log_count,
+  (select count(*)::int from public.qa_runs) as qa_runs_count;
+```
+
+Result:
+
+| organisations_count | memberships_count | roles_count | audit_log_count | qa_runs_count |
+|---:|---:|---:|---:|---:|
+| 3 | 0 | 0 | 0 | 0 |
+
+## Finding
+
+The W8.2 schema/RLS migration is applied and policy inventory exists, but actor-based RLS behavior cannot yet be proven because `user_org_memberships` and `user_roles` contain no assignments.
+
+## Verification matrix required before W8.2 full exit
+
+| Actor | Setup requirement | Expected allowed behavior | Expected denied behavior |
+|---|---|---|---|
+| unauthenticated | no session/JWT | public-only routes | `/admin/*`, `/qa-dashboard` redirect to login or deny |
+| viewer | active membership + `viewer` role | own-org non-admin reads where future screens allow | admin surfaces, role writes, QA runs |
+| contributor | active membership + `contributor` role | own-org non-admin writes where future W8.3+ allows | admin surfaces, role writes, QA runs |
+| org_admin | active membership + `org_admin` role | own-org membership/role admin and audit read | cross-org role/membership access, QA runs unless cs2_admin |
+| cs2_admin | global role grant with `org_id is null` | cross-org admin/QA visibility | spoofed actor/created_by writes remain denied by constraints |
+
+## Denied-path verification required
+
+Routes:
+
+- `/admin/org`
+- `/admin/users`
+- `/admin/settings`
+- `/admin/audit-log`
+- `/qa-dashboard`
+
+Evidence required:
+
+- unauthenticated deployed direct-load outcome;
+- authenticated non-admin denied outcome;
+- org-admin QA dashboard denied outcome;
+- cs2-admin QA dashboard allowed outcome;
+- screenshot/HAR/trace or equivalent browser output;
+- no protected data visible in denied DOM.
+
+## Current status
+
+| Evidence item | Status | Notes |
+|---|---|---|
+| Schema/RLS inventory | PASS | Filed in `modules/pit/12-build/w82-supabase-rls-verification-evidence.md`. |
+| Actor seed availability | BLOCKED | Membership and role tables are empty. |
+| Positive actor behavior under RLS | NOT_CAPTURED | Requires seeded test assignments. |
+| Negative actor behavior under RLS | NOT_CAPTURED | Requires seeded test assignments or verified JWT actors. |
+| Deployed denied-path browser evidence | NOT_CAPTURED | Requires test credentials/actors or unauthenticated spot checks only. |
+| Admin-nav visibility evidence | NOT_CAPTURED | Requires authenticated role-specific sessions. |
+| Final W8.2 exit | NOT_READY | Role-matrix and denied-path evidence remain open. |
+
+## Seeded actor execution requirement
+
+Before full W8.2 exit, CS2 must approve creation of test-only membership and role rows, or provide existing test users/organisations that may be used for actor verification.
+
+The test seed must be reversible and must not grant production users broader access outside the verification window.
+
+## Non-overclaim
+
+This artifact does not claim W8.2 full functional delivery. It records the role-matrix verification plan and the current data blocker after Supabase inventory evidence.

--- a/modules/pit/12-build/w82-role-matrix-denied-path-verification.md
+++ b/modules/pit/12-build/w82-role-matrix-denied-path-verification.md
@@ -48,7 +48,9 @@ The W8.2 schema/RLS migration is applied and policy inventory exists, but actor-
 | unauthenticated | no session/JWT | public-only routes | `/admin/*`, `/qa-dashboard` redirect to login or deny |
 | viewer | active membership + `viewer` role | own-org non-admin reads where future screens allow | admin surfaces, role writes, QA runs |
 | contributor | active membership + `contributor` role | own-org non-admin writes where future W8.3+ allows | admin surfaces, role writes, QA runs |
-| org_admin | active membership + `org_admin` role | own-org membership/role admin and audit read | cross-org role/membership access, QA runs unless cs2_admin |
+| team_leader | active membership + `team_leader` role | own-org team-scoped work where future W8.3+ allows | admin surfaces, role writes, QA runs |
+| project_manager | active membership + `project_manager` role | own-org project-scoped work where future W8.3+ allows | admin surfaces, role writes, QA runs |
+| org_admin | active membership + `org_admin` role | own-org membership/role admin and audit read | cross-org role/membership access, QA runs unless `cs2_admin` |
 | cs2_admin | global role grant with `org_id is null` | cross-org admin/QA visibility | spoofed actor/created_by writes remain denied by constraints |
 
 ## Denied-path verification required
@@ -64,9 +66,9 @@ Routes:
 Evidence required:
 
 - unauthenticated deployed direct-load outcome;
-- authenticated non-admin denied outcome;
-- org-admin QA dashboard denied outcome;
-- cs2-admin QA dashboard allowed outcome;
+- authenticated non-admin denied outcome for `viewer`, `contributor`, `team_leader`, and `project_manager`;
+- `org_admin` QA dashboard denied outcome;
+- `cs2_admin` QA dashboard allowed outcome;
 - screenshot/HAR/trace or equivalent browser output;
 - no protected data visible in denied DOM.
 


### PR DESCRIPTION
## Summary

Adds the W8.2 role-matrix and denied-path verification ledger after PR #1790.

This PR records the current actor-verification state and does not claim W8.2 completion.

## Evidence recorded

- Supabase currently has 3 auth users and 3 organisations.
- W8.2 membership/role/audit/QA tables are empty for actor-based verification.
- Actor-level positive/negative RLS behavior remains blocked until CS2 authorises test assignments or provides test actors.
- Deployed denied-path and admin-nav evidence remain open.

## File added

- `modules/pit/12-build/w82-role-matrix-denied-path-verification.md`

## Non-overclaim

No full W8.2 exit, Stage 12 completion, or FUNCTIONAL_PASS is claimed.