### PR TITLE
PIT W8.2 protected operational route

### DIFF
--- a/apps/isms-portal/src/App.tsx
+++ b/apps/isms-portal/src/App.tsx
@@ -183,6 +183,14 @@ const App = () => {
                 <Route path={ROUTES.MATURITY_SETUP} element={protectedMaturitySetupRoute} />
 
                 {/* PIT Stage 12 Slice 1 protected runtime routes */}
+                <Route path={ROUTES.PIT} element={<Navigate to={ROUTES.PIT_TRACKER} replace />} />
+                <Route
+                  path={ROUTES.PIT_TRACKER}
+                  element={privateShellRoute(
+                    'PIT tracker',
+                    'Protected Process Integrity Testing operational entry for CS2/admin verification without billing or subscription fixture records.',
+                  )}
+                />
                 <Route
                   path={ROUTES.PROJECTS}
                   element={privateShellRoute(

--- a/apps/isms-portal/src/lib/routes.ts
+++ b/apps/isms-portal/src/lib/routes.ts
@@ -14,6 +14,8 @@ export const ROUTES = {
   DASHBOARD: '/dashboard',
   PROJECTS: '/projects',
   PROJECTS_NEW: '/projects/new',
+  PIT: '/pit',
+  PIT_TRACKER: '/pit/tracker',
   ONBOARDING: '/onboarding',
   ADMIN_ORG: '/admin/org',
   ADMIN_USERS: '/admin/users',


### PR DESCRIPTION
## Summary

Adds a small protected PIT operational entry route so W8.2 deployed-route evidence can proceed without fake subscription or billing records.

## Changes

- Adds `ROUTES.PIT = /pit`.
- Adds `ROUTES.PIT_TRACKER = /pit/tracker`.
- Adds `/pit` redirect to `/pit/tracker`.
- Adds protected `/pit/tracker` shell route using the existing `ProtectedRoute`, `PitErrorBoundary`, and `PitShell` pattern.
- Preserves `/subscribe` and `/subscribe/checkout` as commercial subscription routes.

## CS2 authorization

Authorized by CS2 instruction in issue #1810: create a small implementation PR for PIT W8.2 protected operational access without creating fake subscription or billing records.

## Boundaries

- No Supabase writes.
- No auth user creation.
- No fake subscription state.
- No billing fixtures.
- No W8.2 completion claim.
- W8.2 remains `NOT_READY` until route evidence, Foreman/QP, ECAP, IAA, and gates pass.

Closes #1810 only after evidence and final review are complete; this PR alone should not close it.