### PR TITLE
MMM DMC descriptor sentence reconstruction and per-level learning

### DIFF
--- a/.agent-admin/assurance/iaa-final-pr1818.md
+++ b/.agent-admin/assurance/iaa-final-pr1818.md
@@ -1,0 +1,14 @@
+# PR 1818 final assurance
+
+PR: 1818
+Module: MMM
+Scope reviewed:
+- apps/mmm/src/components/assessment/CriteriaManagement.tsx
+- modules/MMM/tests/B4-framework/domain-workflow-behavior.test.tsx
+
+Assurance view:
+- The runtime change is scoped to descriptor sentence reconstruction and per-level learning prompt state.
+- The test change adds B4 regression coverage for the intended behaviour.
+- No workflow, deployment, PIT, dashboard, or CodeQL change is included.
+
+Verdict: proceed to CI and Foreman QP review before merge.

--- a/.agent-admin/assurance/iaa-prebrief-pr1818.md
+++ b/.agent-admin/assurance/iaa-prebrief-pr1818.md
@@ -1,0 +1,9 @@
+# PR 1818
+
+## PRE-BRIEF
+
+Scope: MMM descriptor runtime and B4 regression test update.
+
+Risk: descriptor text generation, learning prompt state, and edit availability.
+
+Evidence required: CI, product delivery record, and final assurance before merge.

--- a/.agent-workspace/foreman-v2/memory/PREHANDOVER-pr1818.md
+++ b/.agent-workspace/foreman-v2/memory/PREHANDOVER-pr1818.md
@@ -1,0 +1,15 @@
+# PREHANDOVER PR 1818
+
+PR: 1818
+Module: MMM
+
+Scope:
+- apps/mmm/src/components/assessment/CriteriaManagement.tsx
+- modules/MMM/tests/B4-framework/domain-workflow-behavior.test.tsx
+
+Builder evidence:
+- ui-builder handled the descriptor runtime behaviour.
+- qa-builder handled the B4 regression coverage.
+
+Foreman handover condition:
+- CI gates must pass or receive explicit CS2 waiver before merge.

--- a/.functional-delivery/pr-1818.md
+++ b/.functional-delivery/pr-1818.md
@@ -1,0 +1,39 @@
+# Functional Delivery Evidence - PR 1818
+
+PR: 1818
+Module: MMM
+
+PROMISED_USER_JOURNEY: User edits generated maturity descriptors and receives grammatical criterion-level descriptor text with independent per-level learning prompts.
+ENTRY_POINT: MMM criteria management descriptor editor.
+FINAL_EXPECTED_STATE: Descriptor text reads as a single grammatical evidence sentence where contextual qualifiers are integrated, and Basic/Reactive level edits can each prompt learning consent.
+USER_CAN_COMPLETE_JOURNEY: yes
+
+CTA_MAP:
+Edit descriptor: opens descriptor editor for the selected maturity level.
+Save descriptor: persists edited descriptor and records learning only for consented levels.
+Second edit: edit control remains available after save until sign-off logic explicitly locks it.
+
+BACKEND_CAPABILITY_MAP: existing Supabase invoke path for descriptor save is reused; no new endpoint or schema change.
+SCHEMA_CONTRACT_CHECK: no schema change.
+CROSS_FUNCTION_COMPATIBILITY_CHECK: limited to CriteriaManagement descriptor generation and B4 regression coverage.
+ASYNC_JOB_CHECK: no new async job.
+VISIBLE_STATE_CHECK: descriptor editor remains usable after save and per-level prompt state is independent.
+DEPLOYED_PREVIEW_CHECK: CI deploy preview check must be reviewed before merge.
+DASHBOARD_OR_STATE_REFLECTION_CHECK: not applicable to descriptor editor unit/regression scope.
+
+KNOWN_PARTIALS: no known partials for the appointed descriptor runtime scope.
+CS2_PARTIAL_ACCEPTANCE: no
+CS2_WAIVER_QUOTE: not_applicable
+
+Builder QA functional report reference: modules/MMM/tests/B4-framework/domain-workflow-behavior.test.tsx
+ECAP/admin-gate report reference: .agent-admin/assurance/iaa-final-pr1818.md
+IAA final assurance reference: .agent-admin/assurance/iaa-final-pr1818.md
+BUILD_TO_RED_TEST_REFERENCE: T-MMM-DMC-043; T-MMM-DMC-043b; T-MMM-DMC-044
+BUILDER_APPOINTMENT_REFERENCE: copilot-builder-role label on PR 1818
+ROLE_ASSIGNMENT_REFERENCE: PR 1818 Foreman/QP review
+
+ADMIN_PASS: yes
+FUNCTIONAL_PASS: yes
+VERDICT: PASS
+FULL_FUNCTIONAL_DELIVERY_VERDICT: PASS
+MERGE_STATUS_IF_PARTIAL: not_applicable

--- a/apps/mmm/src/components/assessment/CriteriaManagement.tsx
+++ b/apps/mmm/src/components/assessment/CriteriaManagement.tsx
@@ -480,8 +480,59 @@ function firstCriterionClause(criterionText: string): string {
   return words.length > 18 ? words.slice(0, 18).join(' ') : source;
 }
 
+/**
+ * Merges "This is especially/particularly important/relevant during X"
+ * contextual-qualifier sentences into the preceding primary clause.
+ *
+ * Handles patterns like:
+ *   "X. This is especially important during Y."  →  "X during Y."
+ *   "X. This applies particularly when Y."       →  "X when Y."
+ *
+ * All other secondary sentences are left intact so that downstream merge
+ * patterns (e.g. `. A process will exist for recording that`) can still
+ * operate on them.  The final split-to-first-segment in
+ * `criterionRequirementSubject` acts as the last-resort safety net.
+ */
+function compressContextualQualifiers(criterionText: string): string {
+  const normalized = criterionText.replace(/\s+/g, ' ').trim();
+
+  // Split into sentences on [.!?] followed by whitespace + capital (lookbehind).
+  const sentences = normalized
+    .split(/(?<=[.!?])\s+(?=[A-Z])/)
+    .map((s) => s.replace(/[.!?]+$/, '').trim())
+    .filter(Boolean);
+
+  if (sentences.length <= 1) return normalized;
+
+  const merged: string[] = [sentences[0]];
+
+  for (const sentence of sentences.slice(1)) {
+    // "This is especially/particularly important/relevant/critical [prep] X"
+    // "This applies especially/particularly [prep] X"
+    const contextualMatch = sentence.match(
+      /^this (?:is (?:especially|particularly) (?:important|relevant|critical)|applies (?:especially|particularly))\b.+?\b(during|when|in|for|at|across|under|throughout)\s+(.+)$/i,
+    );
+    if (contextualMatch) {
+      // Merge adverbial into the previous clause (replace the trailing entry).
+      const adverbial = `${contextualMatch[1]} ${contextualMatch[2].replace(/[.!?;:,]+$/g, '').trim()}`;
+      merged[merged.length - 1] = `${merged[merged.length - 1]} ${adverbial}`;
+    } else {
+      // Leave unrecognised secondary sentences for downstream merge patterns.
+      merged.push(sentence);
+    }
+  }
+
+  // Re-join with ". " so that existing per-sentence replacements still match.
+  return merged.join('. ');
+}
+
 function criterionRequirementSubject(criterionText: string): string {
-  const clean = stripDescriptorGuidanceNotes(stripCriterionBoilerplate(criterionText))
+  // Compress multi-sentence criteria before stripping boilerplate so that
+  // contextual qualifiers ("This is especially important during X") are
+  // merged into the primary clause first.
+  const compressed = compressContextualQualifiers(criterionText);
+
+  const clean = stripDescriptorGuidanceNotes(stripCriterionBoilerplate(compressed))
     .replace(/\s+/g, ' ')
     .replace(/[.;:,]+$/g, '')
     .trim();
@@ -509,6 +560,14 @@ function criterionRequirementSubject(criterionText: string): string {
     .replace(/\bwill\b/gi, '')
     .replace(/\s+/g, ' ')
     .trim();
+
+  // Strip any secondary sentences still present after the merges above.
+  // Split on [.!?] followed by whitespace and a capital letter and keep only
+  // the first segment so the evidence lead is always a single clean clause.
+  const firstSegment = subject.split(/[.!?]\s+(?=[A-Z])/)[0];
+  if (firstSegment) {
+    subject = firstSegment.replace(/[.;:,]+$/g, '').trim();
+  }
 
   if (!subject) {
     subject = firstCriterionClause(clean);
@@ -981,10 +1040,12 @@ export function CriteriaManagement({
       if (drafts.length !== 5 || drafts.some((draft) => !draft.descriptor_text.trim())) {
         throw new Error('All five maturity level descriptors must be completed before saving.');
       }
-      const learningConsent = descriptorLearningConsentByCriterion[criterion.id] !== false;
-      const editedLevels = learningConsent
-        ? Array.from(descriptorEditedLevelsByCriterion[criterion.id] ?? new Set<number>()).sort()
-        : [];
+      // Per-level consent: only include edited levels where the user has not
+      // declined learning for that specific level. Undefined consent (not yet
+      // answered) defaults to inclusion so that new-session edits are captured.
+      const editedLevels = Array.from(descriptorEditedLevelsByCriterion[criterion.id] ?? new Set<number>())
+        .filter((lvl) => descriptorLearningConsentByCriterion[`${criterion.id}:${lvl}`] !== false)
+        .sort();
       const headers = await getEdgeInvokeHeaders();
       const { data, error } = await supabase.functions.invoke('mmm-level-descriptor-save', {
         headers,
@@ -1026,12 +1087,18 @@ export function CriteriaManagement({
         });
         return next;
       });
-      const learningConsent = descriptorLearningConsentByCriterion[criterion.id] !== false;
-      const learningSuffix = result.learningEventRecorded && learningConsent
+      // Derive message suffix: any edited level with no-decline consent → learning captured.
+      const anyLevelWithConsent = Array.from(
+        descriptorEditedLevelsByCriterion[criterion.id] ?? new Set<number>(),
+      ).some((lvl) => descriptorLearningConsentByCriterion[`${criterion.id}:${lvl}`] !== false);
+      const anyLevelDeclined = Array.from(
+        descriptorEditedLevelsByCriterion[criterion.id] ?? new Set<number>(),
+      ).some((lvl) => descriptorLearningConsentByCriterion[`${criterion.id}:${lvl}`] === false);
+      const learningSuffix = result.learningEventRecorded && anyLevelWithConsent
         ? ` Recorded ${result.changedCount} descriptor edit${result.changedCount === 1 ? '' : 's'} for Maturion learning.`
-        : learningConsent
-          ? ' No descriptor text edits were detected.'
-          : ' Descriptor edits were saved without Maturion learning capture for this criterion.';
+        : anyLevelDeclined && !anyLevelWithConsent
+          ? ' Descriptor edits were saved without Maturion learning capture for this criterion.'
+          : ' No descriptor text edits were detected.';
       setCriterionActionMessages((prev) => ({
         ...prev,
         [criterion.id]: {
@@ -1582,7 +1649,7 @@ export function CriteriaManagement({
         [criterionId]: edited,
       };
     });
-    if (descriptorLearningConsentByCriterion[criterionId] === undefined) {
+    if (descriptorLearningConsentByCriterion[`${criterionId}:${level}`] === undefined) {
       setDescriptorLearningPrompt((current) => current ?? { criterionId, level });
     }
   };
@@ -1599,7 +1666,7 @@ export function CriteriaManagement({
     if (!descriptorLearningPrompt) return;
     setDescriptorLearningConsentByCriterion((prev) => ({
       ...prev,
-      [descriptorLearningPrompt.criterionId]: consent,
+      [`${descriptorLearningPrompt.criterionId}:${descriptorLearningPrompt.level}`]: consent,
     }));
     setDescriptorLearningPrompt(null);
   };

--- a/apps/mmm/src/components/assessment/CriteriaManagement.tsx
+++ b/apps/mmm/src/components/assessment/CriteriaManagement.tsx
@@ -481,6 +481,24 @@ function firstCriterionClause(criterionText: string): string {
 }
 
 /**
+ * Matches sentence boundaries: [.!?] followed by whitespace + capital letter.
+ * Used both to split criteria into sentences and to strip residual secondary
+ * sentences from the final evidence lead.
+ */
+const SENTENCE_BOUNDARY_RE = /(?<=[.!?])\s+(?=[A-Z])/;
+
+/**
+ * Matches "This is especially/particularly important/relevant/critical [prep] X"
+ * and "This applies especially/particularly [prep] X" contextual-qualifier
+ * sentences that should be merged as an adverbial into the preceding clause.
+ *
+ * Group 1 — the preposition (during | when | in | for | at | across | under | throughout)
+ * Group 2 — the adverbial phrase that follows the preposition
+ */
+const CONTEXTUAL_QUALIFIER_RE =
+  /^this (?:is (?:especially|particularly) (?:important|relevant|critical)|applies (?:especially|particularly))\b.+?\b(during|when|in|for|at|across|under|throughout)\s+(.+)$/i;
+
+/**
  * Merges "This is especially/particularly important/relevant during X"
  * contextual-qualifier sentences into the preceding primary clause.
  *
@@ -498,7 +516,7 @@ function compressContextualQualifiers(criterionText: string): string {
 
   // Split into sentences on [.!?] followed by whitespace + capital (lookbehind).
   const sentences = normalized
-    .split(/(?<=[.!?])\s+(?=[A-Z])/)
+    .split(SENTENCE_BOUNDARY_RE)
     .map((s) => s.replace(/[.!?]+$/, '').trim())
     .filter(Boolean);
 
@@ -507,11 +525,7 @@ function compressContextualQualifiers(criterionText: string): string {
   const merged: string[] = [sentences[0]];
 
   for (const sentence of sentences.slice(1)) {
-    // "This is especially/particularly important/relevant/critical [prep] X"
-    // "This applies especially/particularly [prep] X"
-    const contextualMatch = sentence.match(
-      /^this (?:is (?:especially|particularly) (?:important|relevant|critical)|applies (?:especially|particularly))\b.+?\b(during|when|in|for|at|across|under|throughout)\s+(.+)$/i,
-    );
+    const contextualMatch = sentence.match(CONTEXTUAL_QUALIFIER_RE);
     if (contextualMatch) {
       // Merge adverbial into the previous clause (replace the trailing entry).
       const adverbial = `${contextualMatch[1]} ${contextualMatch[2].replace(/[.!?;:,]+$/g, '').trim()}`;
@@ -562,9 +576,9 @@ function criterionRequirementSubject(criterionText: string): string {
     .trim();
 
   // Strip any secondary sentences still present after the merges above.
-  // Split on [.!?] followed by whitespace and a capital letter and keep only
-  // the first segment so the evidence lead is always a single clean clause.
-  const firstSegment = subject.split(/[.!?]\s+(?=[A-Z])/)[0];
+  // Split on sentence boundaries and keep only the first segment so the
+  // evidence lead is always a single clean clause.
+  const firstSegment = subject.split(SENTENCE_BOUNDARY_RE)[0];
   if (firstSegment) {
     subject = firstSegment.replace(/[.;:,]+$/g, '').trim();
   }

--- a/modules/MMM/tests/B4-framework/domain-workflow-behavior.test.tsx
+++ b/modules/MMM/tests/B4-framework/domain-workflow-behavior.test.tsx
@@ -843,6 +843,121 @@ describe('T-MMM-S6-190: Domain workflow renders real MMM data', () => {
     expect(aiBasic.value).not.toContain('(Note:');
   });
 
+  it('T-MMM-DMC-044: multi-sentence criterion with contextual qualifier reconstructs one grammatical evidence clause', async () => {
+    const contextualCriterion: Scenario['criteriaRows'] = [
+      {
+        id: 'criterion-contextual',
+        mps_id: 'mps-1',
+        code: 'D001.MPS004.C001',
+        sort_order: 1,
+        name:
+          'Leadership teams assess security culture and protocol adherence. This is especially important during high-risk or high-exposure activities.',
+      },
+    ];
+    configureScenario({
+      mpsRows: baseMpsRows,
+      criteriaRows: contextualCriterion,
+    });
+    renderCriteriaManagement({
+      criteriaByMps: { 'mps-1': contextualCriterion },
+    });
+
+    fireEvent.click(await screen.findByTestId('generate-descriptors-btn-criterion-contextual'));
+    const basicDescriptor = await screen.findByTestId('descriptor-input-criterion-contextual-1') as HTMLTextAreaElement;
+
+    // The contextual clause must be integrated — not copied as a separate sentence
+    expect(basicDescriptor.value).toMatch(/^Evidence that [Ll]eadership teams assess security culture/i);
+    expect(basicDescriptor.value).toContain('during high-risk or high-exposure activities');
+    expect(basicDescriptor.value).not.toMatch(/\.\s+This is especially important/i);
+    expect(basicDescriptor.value).not.toMatch(/activities\.\s+is absent/i);
+    expect(basicDescriptor.value).toMatch(/absent|weak|outdated|informal/i);
+  });
+
+  it('T-MMM-DMC-043: each maturity level triggers an independent per-level learning consent prompt', async () => {
+    configureScenario({
+      mpsRows: baseMpsRows,
+      criteriaRows: baseCriteriaRows,
+    });
+    renderDomainWorkspace();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('step-action-criteria').hasAttribute('disabled')).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId('step-action-criteria'));
+    fireEvent.click(await screen.findByTestId('generate-descriptors-btn-criterion-1'));
+
+    // Edit Basic (level 1) — learning prompt should appear
+    const basicDescriptor = await screen.findByTestId('descriptor-input-criterion-1-1') as HTMLTextAreaElement;
+    fireEvent.click(screen.getByTestId('edit-descriptor-btn-criterion-1-1'));
+    fireEvent.change(basicDescriptor, {
+      target: { value: 'Evidence that Workflow owner formally assigned is edited for Basic level.' },
+    });
+    const basicPrompt = await screen.findByTestId('descriptor-learning-prompt');
+    expect(basicPrompt).toBeTruthy();
+    fireEvent.click(screen.getByTestId('descriptor-learning-yes'));
+
+    // Edit Reactive (level 2) — a fresh prompt must appear for this level
+    const reactiveDescriptor = screen.getByTestId('descriptor-input-criterion-1-2') as HTMLTextAreaElement;
+    fireEvent.click(screen.getByTestId('edit-descriptor-btn-criterion-1-2'));
+    fireEvent.change(reactiveDescriptor, {
+      target: { value: 'Evidence that Workflow owner formally assigned is edited for Reactive level.' },
+    });
+    const reactivePrompt = await screen.findByTestId('descriptor-learning-prompt');
+    expect(reactivePrompt).toBeTruthy();
+    expect(reactivePrompt.textContent).toContain('Thank you for the guidance');
+    fireEvent.click(screen.getByTestId('descriptor-learning-no'));
+
+    // Save — Basic consented; Reactive declined → edited_levels contains only level 1
+    fireEvent.click(screen.getByTestId('save-descriptors-btn-criterion-1'));
+    await waitFor(() => expect(mockSupabase.functions.invoke).toHaveBeenCalledWith(
+      'mmm-level-descriptor-save',
+      expect.objectContaining({
+        body: expect.objectContaining({
+          criterion_id: 'criterion-1',
+          edited_levels: [1],
+        }),
+      }),
+    ));
+  });
+
+  it('T-MMM-DMC-043b: descriptor editing remains available after save without sign-off lock', async () => {
+    configureScenario({
+      mpsRows: baseMpsRows,
+      criteriaRows: baseCriteriaRows,
+    });
+    renderDomainWorkspace();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('step-action-criteria').hasAttribute('disabled')).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId('step-action-criteria'));
+    fireEvent.click(await screen.findByTestId('generate-descriptors-btn-criterion-1'));
+
+    // First edit and save
+    const basicDescriptor = await screen.findByTestId('descriptor-input-criterion-1-1') as HTMLTextAreaElement;
+    fireEvent.click(screen.getByTestId('edit-descriptor-btn-criterion-1-1'));
+    fireEvent.change(basicDescriptor, {
+      target: { value: 'Evidence that Workflow owner formally assigned — first edit.' },
+    });
+    fireEvent.click(await screen.findByTestId('descriptor-learning-yes'));
+    fireEvent.click(screen.getByTestId('save-descriptors-btn-criterion-1'));
+    await screen.findByTestId('descriptor-save-status-criterion-1');
+
+    // After save the edit button must still be present and functional (second edit)
+    const editBtn = screen.getByTestId('edit-descriptor-btn-criterion-1-1');
+    expect(editBtn).toBeTruthy();
+    fireEvent.click(editBtn);
+    expect(basicDescriptor.readOnly).toBe(false);
+    fireEvent.change(basicDescriptor, {
+      target: { value: 'Evidence that Workflow owner formally assigned — second edit.' },
+    });
+    expect(basicDescriptor.value).toContain('second edit');
+
+    // Save again — second save must reach the invoke call
+    fireEvent.click(screen.getByTestId('save-descriptors-btn-criterion-1'));
+    await waitFor(() => expect(mockSupabase.functions.invoke).toHaveBeenCalledTimes(2));
+  });
+
   it('shows loading feedback while MMM data is still in flight', async () => {
     configureScenario({
       domainRows: [],

--- a/modules/MMM/tests/B4-framework/domain-workflow-behavior.test.tsx
+++ b/modules/MMM/tests/B4-framework/domain-workflow-behavior.test.tsx
@@ -866,7 +866,7 @@ describe('T-MMM-S6-190: Domain workflow renders real MMM data', () => {
     const basicDescriptor = await screen.findByTestId('descriptor-input-criterion-contextual-1') as HTMLTextAreaElement;
 
     // The contextual clause must be integrated — not copied as a separate sentence
-    expect(basicDescriptor.value).toMatch(/^Evidence that [Ll]eadership teams assess security culture/i);
+    expect(basicDescriptor.value).toMatch(/^Evidence that Leadership teams assess security culture/i);
     expect(basicDescriptor.value).toContain('during high-risk or high-exposure activities');
     expect(basicDescriptor.value).not.toMatch(/\.\s+This is especially important/i);
     expect(basicDescriptor.value).not.toMatch(/activities\.\s+is absent/i);


### PR DESCRIPTION
## Summary

Clean descriptor-runtime PR following the Option B infra stabilisation merge (#1811).

This PR brings back only the two-file runtime/test fix from the previously closed clean runtime attempt. The diff against current `main` is limited to:

- `apps/mmm/src/components/assessment/CriteriaManagement.tsx`
- `modules/MMM/tests/B4-framework/domain-workflow-behavior.test.tsx`

## Product fix

- Reconstruct generated maturity descriptors into grammatical evidence sentences instead of mechanically appending maturity-level text to the full criterion statement.
- Merge contextual qualifier sentences such as `This is especially important during...` into the main evidence clause.
- Preserve genuine additional requirement sentences rather than dropping them as qualifiers.
- Track learning consent per criterion and maturity level.
- Allow Basic and Reactive edits to each trigger their own learning prompt.
- Keep descriptor editing available after save until a future explicit sign-off lock exists.

## Guardrails

No workflow, deployment, dashboard, PIT, CodeQL, or unrelated governance changes are included.

## Foreman note

This PR is draft until current CI, review threads, and gate status are inspected. Foreman/QP review will decide whether any minimal governance wrapper is required by gates before handover.