### PR TITLE
Stabilize IAA prebrief alignment gate

### DIFF
--- a/.github/workflows/iaa-prebrief-contract-alignment.yml
+++ b/.github/workflows/iaa-prebrief-contract-alignment.yml
@@ -37,17 +37,22 @@ jobs:
 
           SELF_WORKFLOW=".github/workflows/iaa-prebrief-contract-alignment.yml"
 
-          if grep -RIn "Generate the Pre-Brief artifact at: .*iaa-prebrief" .github/workflows .agent-admin/control 2>/dev/null | grep -v "${SELF_WORKFLOW}"; then
+          legacy_generation_matches=$(grep -RIn "Generate the Pre-Brief artifact at: .*iaa-prebrief" .github/workflows .agent-admin/control 2>/dev/null | grep -v "${SELF_WORKFLOW}" || true)
+          if [ -n "${legacy_generation_matches}" ]; then
+            printf '%s\n' "${legacy_generation_matches}"
             echo "::error::Legacy standalone iaa-prebrief generation instruction found in active Wave 1 workflow/control guidance."
             exit 1
           fi
 
-          if grep -RIn "commit.*iaa-prebrief" .github/workflows .agent-admin/control 2>/dev/null | grep -v "${SELF_WORKFLOW}"; then
+          legacy_commit_matches=$(grep -RIn "commit.*iaa-prebrief" .github/workflows .agent-admin/control 2>/dev/null | grep -v "${SELF_WORKFLOW}" || true)
+          if [ -n "${legacy_commit_matches}" ]; then
+            printf '%s\n' "${legacy_commit_matches}"
             echo "::error::Legacy standalone iaa-prebrief commit instruction found in active Wave 1 workflow/control guidance."
             exit 1
           fi
 
-          if grep -RIn "IAA_PREFLIGHT_BRIEF" .agent-admin/control .github/workflows 2>/dev/null | grep -v "${SELF_WORKFLOW}" | grep -q .; then
+          canonical_matches=$(grep -RIn "IAA_PREFLIGHT_BRIEF" .agent-admin/control .github/workflows 2>/dev/null | grep -v "${SELF_WORKFLOW}" || true)
+          if [ -n "${canonical_matches}" ]; then
             echo "Canonical IAA_PREFLIGHT_BRIEF references found."
           else
             echo "::error::No canonical IAA_PREFLIGHT_BRIEF references found in Wave 1 control guidance (excluding this workflow)."


### PR DESCRIPTION
## Summary

Stabilizes the repo-wide `preflight/iaa-prebrief-contract-alignment` workflow.

## Change

- Keeps the same policy checks.
- Stores grep results in variables before testing them.
- Preserves hard failures for legacy standalone `iaa-prebrief` instructions.
- Preserves hard failure when canonical `IAA_PREFLIGHT_BRIEF` control references are missing.

## Scope control

Governance workflow repair only. No ISMS app, runtime, or deployment behavior changes. No handover or completion posture is asserted.