### PR TITLE
PIT W8.2 role-aware route authorization

### DIFF
--- a/.agent-admin/assurance/iaa-wave-record-pit-w82-role-aware-route-authorization.md
+++ b/.agent-admin/assurance/iaa-wave-record-pit-w82-role-aware-route-authorization.md
@@ -1,0 +1,58 @@
+# IAA Wave Record — PIT W8.2 Role-Aware Route Authorization
+
+| Field | Value |
+|---|---|
+| Wave ID | `pit-w82-role-aware-route-authorization` |
+| Governing issue | `#1810` |
+| Scope | Role-aware route authorization for PIT/admin/QA shells |
+| Posture | `IMPLEMENTATION_FOR_REVIEW` |
+
+## PRE-BRIEF
+
+```yaml
+IAA_PREFLIGHT_BRIEF:
+  schema_version: "1.0.0"
+  wave: "pit-w82-role-aware-route-authorization"
+  pr: "PENDING"
+  issue: "#1810"
+  branch: "pit-w82-role-aware-route-authorization"
+  qualifying_tasks:
+    - task_id: "pit-w82-route-authorization"
+      summary: "Add role-aware authorization around PIT, admin, and QA route shells without Supabase or billing fixture changes."
+      assurance_category: "route-authorization-boundary"
+  required_build_gates:
+    - "Routing Governance Check"
+    - "Deploy PIT to Vercel"
+    - "POLC Boundary Validation"
+    - "Builder Delegation Order Gate"
+  expected_qa_scope:
+    - "Unauthenticated users redirect from protected PIT/admin/QA routes to login."
+    - "Authenticated PIT workspace users can access /pit and /pit/tracker."
+    - "Non-admin roles are denied /admin/org, /admin/users, /admin/settings, and /admin/audit-log."
+    - "org_admin can access admin routes but is denied /qa-dashboard."
+    - "cs2_admin can access admin routes and /qa-dashboard."
+    - "Public marketing/subscription routes remain public."
+  high_risk_failure_modes:
+    - "Admin/QA routes remain auth-only and allow non-admin roles."
+    - "Public marketing/subscription flow becomes gated."
+    - "Mock role mapping overclaims real Supabase/RLS enforcement."
+  required_builder_evidence:
+    - "Role-aware route guard is implemented in the ISMS portal route layer."
+    - "Auth shell can represent deterministic mock roles for deployed evidence capture."
+    - "No Supabase seed, billing, or subscription fixture files are changed."
+  required_foreman_qp_checks:
+    - "Verify /pit and /pit/tracker remain accessible to authenticated mock users."
+    - "Verify admin routes require org_admin or cs2_admin."
+    - "Verify /qa-dashboard requires cs2_admin."
+    - "Verify public marketing/subscription routes remain public."
+  ecap_required: false
+  ecap_expected_artifacts: []
+  final_iaa_focus:
+    - "Confirm route authorization behavior is described as mock-route-shell authorization, not final RLS completion."
+    - "Confirm W8.2 remains not complete until deployed evidence is captured."
+  result: PREFLIGHT_BRIEF_COMPLETE
+```
+
+## FINAL ASSURANCE
+
+PENDING. No final assurance, completion, or merge-readiness claim is made by this artifact.

--- a/.agent-admin/builder-appointments/pit-w82-role-aware-route-authorization-builder.md
+++ b/.agent-admin/builder-appointments/pit-w82-role-aware-route-authorization-builder.md
@@ -1,0 +1,38 @@
+# Builder Appointment — PIT W8.2 Role-Aware Route Authorization
+
+| Field | Value |
+|---|---|
+| Wave ID | `pit-w82-role-aware-route-authorization` |
+| Governing issue | `#1810` |
+| Appointed builder | `pit-specialist` |
+| Builder resource | `copilot-builder-resource` |
+| Appointment status | `APPOINTED` |
+| Posture | `IMPLEMENTATION_FOR_REVIEW` |
+
+## Preconditions
+
+IAA pre-brief is recorded in:
+
+```text
+.agent-admin/assurance/iaa-wave-record-pit-w82-role-aware-route-authorization.md
+```
+
+## Builder task
+
+Implement role-aware route authorization for the current PIT shell routes:
+
+- Keep `/pit` and `/pit/tracker` available to authenticated PIT workspace users.
+- Deny `/admin/org`, `/admin/users`, `/admin/settings`, `/admin/audit-log` to non-admin roles.
+- Allow `org_admin` for org-admin routes.
+- Deny `/qa-dashboard` to `org_admin` unless intentionally changed later.
+- Allow `cs2_admin` for `/qa-dashboard` and admin routes.
+- Preserve public marketing/subscription flow.
+
+## Boundaries
+
+- No Supabase seed changes.
+- No billing or subscription fixture changes.
+- No claim that this completes W8.2 RLS.
+- No claim that W8.2 route evidence is complete before deployed browser evidence is captured.
+
+RESULT: BUILDER_APPOINTED

--- a/.agent-admin/control/delegation-order.json
+++ b/.agent-admin/control/delegation-order.json
@@ -1,13 +1,11 @@
 {
   "schema_version": "1.0.0",
-  "wave_id": "wave-mmm-descriptor-runtime-2026-06-17",
-  "pr_number": 1825,
-  "prebrief_commit_sha": "ed9c3bb161b53796b2e760952bfa30ffdb844aac",
-  "builder_appointment_timestamp": "2026-06-17T14:48:00Z",
-  "builder_appointment_commit_sha": "2c560837069c4963517cad86725947fc5403abed",
-  "builder_agent": "bounded-implementation-builder",
-  "builder_task_ref": ".agent-admin/builder-appointments/wave-mmm-descriptor-runtime-2026-06-17.md",
-  "first_implementation_commit_sha": "adbd65ee789777f6720eedf429bfacd2985eb9b8",
-  "qp_review_timestamp": "2026-06-17T14:51:00Z",
+  "wave_id": "pit-w82-role-aware-route-authorization",
+  "pr_number": "PENDING",
+  "prebrief_commit_sha": "6ac2fb8b70f334005c45b6c619f1d74cc04ff78b",
+  "builder_appointment_commit_sha": "70c04a8a5777fb20435a59da1e3252e32c3cce33",
+  "builder_agent": "pit-specialist",
+  "builder_task_ref": "#1810",
+  "first_implementation_commit_sha": "2882f5cb8b4ff10e1792384fef7b2ccd8fafcc5d",
   "result": "DELEGATION_ORDER_VERIFIED"
 }

--- a/.agent-admin/control/delegation-order.json
+++ b/.agent-admin/control/delegation-order.json
@@ -1,11 +1,13 @@
 {
   "schema_version": "1.0.0",
   "wave_id": "pit-w82-role-aware-route-authorization",
-  "pr_number": "PENDING",
+  "pr_number": 1829,
   "prebrief_commit_sha": "6ac2fb8b70f334005c45b6c619f1d74cc04ff78b",
+  "builder_appointment_timestamp": "2026-06-19T12:36:00Z",
   "builder_appointment_commit_sha": "70c04a8a5777fb20435a59da1e3252e32c3cce33",
   "builder_agent": "pit-specialist",
-  "builder_task_ref": "#1810",
+  "builder_task_ref": "pit-w82-route-authorization",
   "first_implementation_commit_sha": "2882f5cb8b4ff10e1792384fef7b2ccd8fafcc5d",
+  "qp_review_timestamp": "2026-06-22T07:40:00Z",
   "result": "DELEGATION_ORDER_VERIFIED"
 }

--- a/.agent-workspace/foreman-v2/memory/session-pit-w82-role-aware-route-authorization.md
+++ b/.agent-workspace/foreman-v2/memory/session-pit-w82-role-aware-route-authorization.md
@@ -1,0 +1,41 @@
+# Foreman Session Memory — PIT W8.2 Role-Aware Route Authorization
+
+session_id: pit-w82-role-aware-route-authorization
+wave_id: pit-w82-role-aware-route-authorization
+governing_issue: #1810
+implementation_pr: #1829
+governed_role: FOREMAN
+execution_mode: implementation_wave_supervision
+
+agents_delegated_to:
+  - pit-specialist: implement role-aware authorization guard and route wiring for PIT/admin/QA shell routes
+  - copilot-builder-resource: execute bounded code patch under pit-specialist delegation if direct specialist execution is unavailable
+
+## Gate model
+
+Implementation-only work is not handover. Handover, completion, release, and merge-readiness language remain gated.
+
+## Delegation order
+
+1. IAA pre-brief recorded in `.agent-admin/assurance/iaa-wave-record-pit-w82-role-aware-route-authorization.md`.
+2. Builder appointment recorded in `.agent-admin/builder-appointments/pit-w82-role-aware-route-authorization-builder.md`.
+3. Builder implementation commits follow the pre-brief and appointment.
+4. Foreman/QP review follows implementation and checks.
+
+## Implementation scope
+
+- Keep `/pit` and `/pit/tracker` available to authenticated PIT workspace users.
+- Deny `/admin/org`, `/admin/users`, `/admin/settings`, `/admin/audit-log` to non-admin mock roles.
+- Allow `org_admin` and `cs2_admin` for org-admin routes.
+- Deny `/qa-dashboard` to `org_admin`.
+- Allow `cs2_admin` for `/qa-dashboard` and admin routes.
+- Preserve public marketing/subscription flow.
+
+## Explicit exclusions
+
+- No Supabase seed changes.
+- No billing or subscription fixture changes.
+- No W8.2 completion claim.
+- No final route-evidence claim until deployed browser evidence is captured.
+
+Current posture: IMPLEMENTATION_FOR_REVIEW; W8.2_NOT_READY.

--- a/apps/isms-portal/src/App.tsx
+++ b/apps/isms-portal/src/App.tsx
@@ -30,6 +30,9 @@ import { PitShell } from './pages/pit/PitShell';
 
 const queryClient = new QueryClient();
 
+const ADMIN_ROUTE_ROLES = ['org_admin', 'cs2_admin'] as const;
+const QA_ROUTE_ROLES = ['cs2_admin'] as const;
+
 const privateShellRoute = (title: string, description: string) => (
   <ProtectedRoute>
     <PitErrorBoundary>
@@ -62,8 +65,38 @@ const protectedMaturitySetupRoute = (
   </ProtectedRoute>
 );
 
+const roleAwareShellRoute = (
+  title: string,
+  description: string,
+  allowedRoles: ReadonlyArray<'org_admin' | 'cs2_admin'>,
+  deniedDescription: string,
+) => (
+  <ProtectedRoute
+    allowedRoles={[...allowedRoles]}
+    deniedTitle="Access denied"
+    deniedDescription={deniedDescription}
+  >
+    <PitErrorBoundary>
+      <PitShell title={title} description={description} />
+    </PitErrorBoundary>
+  </ProtectedRoute>
+);
+
 const adminShellRoute = (title: string, description: string) =>
-  privateShellRoute(title, `${description} Access policy: W8.2 admin/RLS-first denied-path foundation.`);
+  roleAwareShellRoute(
+    title,
+    `${description} Access policy: org_admin or cs2_admin required.`,
+    ADMIN_ROUTE_ROLES,
+    'This W8.2 admin route requires the org_admin or cs2_admin mock role.',
+  );
+
+const qaShellRoute = (title: string, description: string) =>
+  roleAwareShellRoute(
+    title,
+    `${description} Access policy: cs2_admin required.`,
+    QA_ROUTE_ROLES,
+    'This W8.2 QA dashboard route requires the cs2_admin mock role.',
+  );
 
 const App = () => {
   return (
@@ -237,7 +270,7 @@ const App = () => {
                 />
                 <Route
                   path={ROUTES.QA_DASHBOARD}
-                  element={adminShellRoute(
+                  element={qaShellRoute(
                     'QA dashboard',
                     'Protected QA dashboard shell for W8.2 admin visibility foundations.',
                   )}

--- a/apps/isms-portal/src/components/auth/ProtectedRoute.tsx
+++ b/apps/isms-portal/src/components/auth/ProtectedRoute.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { useAuth } from '@/context/AuthContext';
+import { useAuth, type MockRouteRole } from '@/context/AuthContext';
 import { ROUTES } from '@/lib/routes';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
+  allowedRoles?: MockRouteRole[];
+  deniedTitle?: string;
+  deniedDescription?: string;
 }
 
 type RouteLocationParts = {
@@ -18,13 +21,34 @@ export const getAuthRedirectTarget = (parts: RouteLocationParts) => ({
   from: `${parts.pathname}${parts.search}${parts.hash}`,
 });
 
-export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+const AccessDenied = ({ title, description }: { title: string; description: string }) => (
+  <div className="min-h-screen bg-muted/30 px-4 py-16">
+    <main className="mx-auto max-w-3xl rounded-2xl border bg-background p-8 shadow-sm">
+      <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+        PIT Stage 12 W8.2 route authorization
+      </p>
+      <h1 className="mt-4 text-3xl font-bold">{title}</h1>
+      <p className="mt-4 text-muted-foreground">{description}</p>
+    </main>
+  </div>
+);
+
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
+  children,
+  allowedRoles,
+  deniedTitle = 'Access denied',
+  deniedDescription = 'Your current mock role is not authorized for this protected PIT route.',
+}) => {
   const { user } = useAuth();
   const location = useLocation();
 
   if (!user) {
     const redirect = getAuthRedirectTarget(location);
     return <Navigate to={redirect.to} replace state={{ from: redirect.from }} />;
+  }
+
+  if (allowedRoles && !allowedRoles.includes(user.role)) {
+    return <AccessDenied title={deniedTitle} description={deniedDescription} />;
   }
 
   return <>{children}</>;

--- a/apps/isms-portal/src/context/AuthContext.tsx
+++ b/apps/isms-portal/src/context/AuthContext.tsx
@@ -1,6 +1,14 @@
 import React, { createContext, useContext, useMemo, useState } from 'react';
 
-export type User = { id: string; email: string } | null;
+export type MockRouteRole =
+  | 'viewer'
+  | 'contributor'
+  | 'team_leader'
+  | 'project_manager'
+  | 'org_admin'
+  | 'cs2_admin';
+
+export type User = { id: string; email: string; role: MockRouteRole } | null;
 
 interface AuthContextValue {
   user: User;
@@ -10,6 +18,27 @@ interface AuthContextValue {
 
 const AUTH_STORAGE_KEY = 'isms_mock_user';
 
+const TEST_ROLE_EMAIL_PREFIXES: Array<[MockRouteRole, string[]]> = [
+  ['cs2_admin', ['cs2-admin', 'cs2_admin', 'cs2admin']],
+  ['org_admin', ['org-admin', 'org_admin', 'orgadmin']],
+  ['project_manager', ['project-manager', 'project_manager', 'projectmanager']],
+  ['team_leader', ['team-leader', 'team_leader', 'teamleader']],
+  ['contributor', ['contributor']],
+  ['viewer', ['viewer']],
+];
+
+export function resolveMockRouteRole(email: string): MockRouteRole {
+  const localPart = email.trim().toLowerCase().split('@')[0] || '';
+
+  for (const [role, prefixes] of TEST_ROLE_EMAIL_PREFIXES) {
+    if (prefixes.some((prefix) => localPart.startsWith(prefix))) {
+      return role;
+    }
+  }
+
+  return 'project_manager';
+}
+
 function readStoredUser(): User {
   if (typeof window === 'undefined') return null;
 
@@ -17,7 +46,15 @@ function readStoredUser(): User {
   if (!stored) return null;
 
   try {
-    return JSON.parse(stored) as User;
+    const parsed = JSON.parse(stored) as Partial<NonNullable<User>>;
+
+    if (!parsed.email) return null;
+
+    return {
+      id: parsed.id || 'mock-user',
+      email: parsed.email,
+      role: parsed.role || resolveMockRouteRole(parsed.email),
+    };
   } catch {
     window.localStorage.removeItem(AUTH_STORAGE_KEY);
     return null;
@@ -36,7 +73,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const value = useMemo<AuthContextValue>(() => ({
     user,
     signIn: (email: string) => {
-      const nextUser = { id: 'mock-user', email };
+      const trimmedEmail = email.trim();
+      const nextUser = {
+        id: 'mock-user',
+        email: trimmedEmail,
+        role: resolveMockRouteRole(trimmedEmail),
+      };
       window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(nextUser));
       setUser(nextUser);
     },


### PR DESCRIPTION
Adds role-aware route authorization for PIT W8.2 shell routes.

Scope:
- keep /pit and /pit/tracker available to authenticated PIT workspace users
- deny /admin/org, /admin/users, /admin/settings, /admin/audit-log to non-admin mock roles
- allow org_admin and cs2_admin for org admin routes
- deny /qa-dashboard to org_admin
- allow cs2_admin for /qa-dashboard and admin routes
- preserve public marketing/subscription routes
- no Supabase seed changes
- no billing or subscription fixture changes

Mock route role mapping for deployed evidence:
- cs2-admin*@... or cs2_admin*@... => cs2_admin
- org-admin*@... or org_admin*@... => org_admin
- project-manager*@... or project_manager*@... => project_manager
- team-leader*@... or team_leader*@... => team_leader
- contributor*@... => contributor
- viewer*@... => viewer
- any other authenticated email defaults to project_manager

Current posture: implementation for review; W8.2 remains NOT_READY until deployed route evidence is captured and reviewed.