### PR TITLE
Fix residual Vercel workflow ownership risks

### DIFF
--- a/.github/workflows/deploy-pit-vercel.yml
+++ b/.github/workflows/deploy-pit-vercel.yml
@@ -72,7 +72,7 @@ jobs:
             echo "::error::apps/pit/package.json exists. PIT workflow is still in integrated-shell mode and must be migrated to standalone PIT app mode."
             exit 1
           fi
-          if grep -nE "^[[:space:]]+- 'api/\*\*'|^[[:space:]]+- 'packages/|^[[:space:]]+- 'apps/isms-portal/\*\*'" .github/workflows/deploy-pit-vercel.yml; then
+          if grep -nE "^[[:space:]]+- 'api/\*\*'$|^[[:space:]]+- 'packages/\*\*'$|^[[:space:]]+- 'apps/isms-portal/\*\*'$" .github/workflows/deploy-pit-vercel.yml; then
             echo "::error::PIT workflow must not trigger broad api/**, packages/**, or apps/isms-portal/** deployments without an explicit PIT-owned boundary."
             exit 1
           fi

--- a/.github/workflows/deploy-pit-vercel.yml
+++ b/.github/workflows/deploy-pit-vercel.yml
@@ -1,5 +1,24 @@
 name: Deploy PIT to Vercel
 
+# WORKFLOW OWNERSHIP BOUNDARY
+# This workflow owns the PIT deployment surface only.
+#
+# Current deployment mode: integrated shell.
+# PIT currently has no standalone apps/pit package. PIT routes are hosted by
+# the isms-portal package, so this workflow intentionally builds isms-portal
+# while triggering only on PIT-owned route/module/docs paths.
+#
+# When PIT becomes a standalone app, update this workflow to:
+#   app path: apps/pit/**
+#   build command: pnpm --filter <pit-package-name> build
+#   output directory: apps/pit/dist
+#
+# Out of scope:
+#   apps/mmm/**
+#   broad apps/isms-portal/** outside PIT route files
+#   broad api/** or packages/** changes unless a PIT-owned boundary is introduced
+#   ISMS or MMM smoke routes
+
 on:
   push:
     branches:
@@ -28,6 +47,9 @@ on:
 env:
   NODE_VERSION: '22'
   PNPM_VERSION: '9.12.0'
+  PIT_DEPLOYMENT_MODE: integrated-shell
+  PIT_HOST_PACKAGE_FILTER: isms-portal
+  PIT_HOST_OUTPUT_DIR: apps/isms-portal/dist
 
 jobs:
   boundary-guard:
@@ -38,14 +60,30 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-      - name: Verify PIT deployment inputs
+      - name: Verify PIT integrated-shell deployment inputs
         run: |
           set -euo pipefail
           test -f apps/isms-portal/package.json
           test -d apps/isms-portal/src/pages/pit
           test -f apps/isms-portal/src/pages/PITInfo.tsx
           test -f docs/governance/PIT_APP_DESCRIPTION.md
-          echo "PIT deployment inputs are present."
+          test -f MONOREPO_VERCEL_WORKFLOW_OWNERSHIP_SPLIT.md
+          if [ -f apps/pit/package.json ]; then
+            echo "::error::apps/pit/package.json exists. PIT workflow is still in integrated-shell mode and must be migrated to standalone PIT app mode."
+            exit 1
+          fi
+          if grep -nE "^[[:space:]]+- 'api/\*\*'|^[[:space:]]+- 'packages/|^[[:space:]]+- 'apps/isms-portal/\*\*'" .github/workflows/deploy-pit-vercel.yml; then
+            echo "::error::PIT workflow must not trigger broad api/**, packages/**, or apps/isms-portal/** deployments without an explicit PIT-owned boundary."
+            exit 1
+          fi
+          if grep -nE "VERCEL_PROJECT_ID|VERCEL_ORG_ID|VERCEL_TOKEN|VERCEL_AUTOMATION_BYPASS_SECRET" .github/workflows/deploy-pit-vercel.yml | grep -v "PIT_VERCEL_"; then
+            echo "::error::PIT workflow must use the PIT_VERCEL_* secret namespace, not generic Vercel deployment secrets."
+            exit 1
+          fi
+          echo "PIT deployment mode: ${PIT_DEPLOYMENT_MODE}"
+          echo "PIT host package filter: ${PIT_HOST_PACKAGE_FILTER}"
+          echo "PIT host output directory: ${PIT_HOST_OUTPUT_DIR}"
+          echo "PIT integrated-shell deployment inputs are present."
 
   build:
     name: Build PIT Integrated Shell
@@ -69,14 +107,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
       - name: Verify route registry
-        run: pnpm --filter isms-portal verify:routes
+        run: pnpm --filter ${{ env.PIT_HOST_PACKAGE_FILTER }} verify:routes
       - name: Build PIT integrated shell
-        run: pnpm --filter isms-portal build
+        run: pnpm --filter ${{ env.PIT_HOST_PACKAGE_FILTER }} build
       - name: Upload PIT build artifact
         uses: actions/upload-artifact@v5
         with:
           name: pit-integrated-shell-dist
-          path: apps/isms-portal/dist/
+          path: ${{ env.PIT_HOST_OUTPUT_DIR }}/
           retention-days: 7
 
   deploy-preview:

--- a/apps/mmm/vercel.json
+++ b/apps/mmm/vercel.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
-  "installCommand": "corepack enable && pnpm install --no-frozen-lockfile",
-  "buildCommand": "pnpm --filter @maturion/mmm build",
-  "outputDirectory": "apps/mmm/dist",
   "rewrites": [
     {
       "source": "/((?!assets/|manifest\\.json$|sw\\.js$).*)",

--- a/apps/mmm/vercel.json
+++ b/apps/mmm/vercel.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
-  "installCommand": "npm install",
-  "buildCommand": "npm run build",
-  "outputDirectory": "dist",
+  "installCommand": "corepack enable && pnpm install --no-frozen-lockfile",
+  "buildCommand": "pnpm --filter @maturion/mmm build",
+  "outputDirectory": "apps/mmm/dist",
   "rewrites": [
     {
       "source": "/((?!assets/|manifest\\.json$|sw\\.js$).*)",

--- a/modules/pit/12-deployment/pit-vercel-workflow-ownership-20260617.md
+++ b/modules/pit/12-deployment/pit-vercel-workflow-ownership-20260617.md
@@ -6,7 +6,7 @@
 | Artifact type | Deployment workflow ownership evidence |
 | Workflow | `.github/workflows/deploy-pit-vercel.yml` |
 | Module | PIT |
-| Status | IMPLEMENTED_FOR_REVIEW |
+| Status | IMPLEMENTED_FOR_REVIEW — INTEGRATED_SHELL_MODE_EXPLICIT |
 
 ## 1. Purpose
 
@@ -34,12 +34,15 @@ docs/governance/PIT_APP_DESCRIPTION.md
 
 The workflow builds the `isms-portal` package because that is the current deployable host for PIT routes. It does not take ownership of the ISMS Portal workflow.
 
+The workflow now declares this explicitly as `PIT_DEPLOYMENT_MODE=integrated-shell` and includes a boundary guard that fails if `apps/pit/package.json` appears before the workflow is migrated to standalone PIT app mode.
+
 ## 3. Vercel project target
 
 | Item | Value |
 |---|---|
 | Vercel production target | `https://maturion-pit.vercel.app` |
 | Workflow environment | `pit-preview`, `pit-production` |
+| Deployment mode | `integrated-shell` |
 | Build package | `isms-portal` |
 | Build command | `pnpm --filter isms-portal build` |
 | Route verification | `pnpm --filter isms-portal verify:routes` |
@@ -55,9 +58,13 @@ PIT_VERCEL_ORG_ID
 PIT_VERCEL_TOKEN
 ```
 
-No generic ambiguous Vercel project secrets are used.
+Optional preview-protection bypass:
 
-Optional preview-protection bypass is not required by the initial workflow. The route smoke test treats non-404/non-5xx responses as evidence that the PIT route reached the deployed app or expected auth/protection posture.
+```text
+PIT_VERCEL_AUTOMATION_BYPASS_SECRET
+```
+
+No generic ambiguous Vercel project secrets are used.
 
 ## 5. Trigger paths
 
@@ -72,6 +79,8 @@ modules/pit/12-deployment/**
 .github/workflows/deploy-pit-vercel.yml
 MONOREPO_VERCEL_WORKFLOW_OWNERSHIP_SPLIT.md
 ```
+
+The boundary guard rejects broad `apps/isms-portal/**`, `api/**`, and `packages/**` workflow triggers unless a future PR explicitly introduces and documents a PIT-owned boundary.
 
 ## 6. Smoke routes
 
@@ -110,6 +119,7 @@ packages/** unless a later PR explicitly introduces a PIT-owned package boundary
 | Cannot block ISMS-only or MMM-only PRs | Path filters exclude `apps/mmm/**` and broad `apps/isms-portal/**`. |
 | Shared API/packages not auto-deployed | `api/**` and `packages/**` are not workflow triggers. |
 | ISMS/MMM workflows untouched | This issue changes only the PIT workflow and PIT evidence record. |
+| Integrated-shell posture explicit | Workflow comments, env vars, and boundary guard identify integrated-shell mode. |
 
 ## 9. Residual note
 


### PR DESCRIPTION
## Summary

Fixes the two residual Vercel deployment risks identified in the MMM/PIT workflow ownership review.

## Changes

- Aligns `apps/mmm/vercel.json` with the pnpm monorepo deployment model:
  - `corepack enable && pnpm install --no-frozen-lockfile`
  - `pnpm --filter @maturion/mmm build`
  - `apps/mmm/dist`
- Makes PIT integrated-shell deployment mode explicit in `.github/workflows/deploy-pit-vercel.yml`:
  - declares `PIT_DEPLOYMENT_MODE=integrated-shell`;
  - centralizes host package/output variables;
  - adds a guard that fails if `apps/pit/package.json` appears before workflow migration;
  - adds guards against broad `apps/isms-portal/**`, `api/**`, `packages/**`, and generic Vercel secrets.
- Updates PIT deployment evidence to record the explicit integrated-shell posture.

## Scope control

Deployment configuration/workflow ownership cleanup only. No ISMS, MMM, or PIT runtime feature behavior is changed. No handover, completion, or release posture is asserted.