### PR TITLE
MMM approval workflow DB/API contract

### DIFF
--- a/.agent-admin/assurance/iaa-wave-record-wave-mmm-approval-db-api-contract-2026-06-23.md
+++ b/.agent-admin/assurance/iaa-wave-record-wave-mmm-approval-db-api-contract-2026-06-23.md
@@ -1,0 +1,61 @@
+# IAA Wave Record - MMM Approval DB/API Contract
+
+Wave: `wave-mmm-approval-db-api-contract-2026-06-23`
+Date: 2026-06-23
+Repository: `APGI-cmy/maturion-isms`
+Branch: `foreman/mmm-approval-db-api-contract`
+Scope record: `.agent-admin/scope-declarations/wave-mmm-approval-db-api-contract-2026-06-23.md`
+
+## PRE-BRIEF
+
+EXPECTED_QA_SCOPE:
+- Verify the DB/API contract derives from the merged approval workflow pre-build contract.
+- Verify the contract covers approval rounds, approvers, invitations, proposed edits, comments, notifications, locks, and AI learning events.
+- Verify the contract includes API request/response shape and failure modes for later implementation.
+- Verify no runtime code, migrations, edge functions, or UI implementation are introduced in this wave.
+- Verify QA-to-red scenarios are defined for the next implementation wave.
+
+EXPECTED_FAILURE_MODES:
+- Contract omits multi-approver tracking.
+- Contract allows proposed edits to overwrite canonical model fields directly.
+- Contract lacks lock transition rules.
+- Contract omits notification outbox/event idempotency.
+- Contract does not support level 3 approver flow or level 2 copied correspondence.
+- Contract does not provide enough API shape for a builder to implement safely later.
+
+FOREMAN_INSTRUCTIONS:
+- Keep this wave contract-only.
+- Do not create migrations, functions, UI components, or e-mail delivery code.
+- Ensure future implementation waves can write QA-to-red tests from this contract.
+- Keep each contract file bounded and traceable to the merged approval workflow pre-build artifacts.
+
+IAA_WILL_QA:
+- IAA will check DB/API completeness and state transition consistency.
+- IAA will check lock and notification failure modes.
+- IAA will check proposed-change immutability and audit/AI learning capture.
+- IAA will check that this PR remains pre-build specification work only.
+
+RESULT: PREFLIGHT_BRIEF_COMPLETE
+
+```yaml
+IAA_PREFLIGHT_BRIEF:
+  schema_version: "1.0.0"
+  wave: "wave-mmm-approval-db-api-contract-2026-06-23"
+  pr: "pending"
+  branch: "foreman/mmm-approval-db-api-contract"
+  qualifying_tasks:
+    - "Create MMM approval workflow DB/API contract."
+    - "Create MMM approval workflow notification and lock contract."
+    - "Create MMM approval workflow QA-to-red contract."
+  required_build_gates:
+    - "No runtime code changes."
+    - "No database migrations."
+    - "No API implementation."
+    - "No e-mail delivery implementation."
+    - "No UI implementation."
+  expected_qa_scope:
+    - "Verify contract coverage for approval rounds, approvers, proposed edits, comments, notifications, locks, and AI learning events."
+    - "Verify API payloads and failure modes are specified."
+    - "Verify QA-to-red scenarios are ready for later build wave."
+  result: "PREFLIGHT_BRIEF_COMPLETE"
+```

--- a/.agent-admin/scope-declarations/wave-mmm-approval-db-api-contract-2026-06-23.md
+++ b/.agent-admin/scope-declarations/wave-mmm-approval-db-api-contract-2026-06-23.md
@@ -1,0 +1,70 @@
+# MMM Approval Workflow DB/API Contract Scope
+
+Wave: `wave-mmm-approval-db-api-contract-2026-06-23`
+Date: 2026-06-23
+Repository: `APGI-cmy/maturion-isms`
+Branch: `foreman/mmm-approval-db-api-contract`
+Module scope: MMM approval workflow database and API contract
+Lane: pre-build / contract specification
+CS2 Authority: Johan Ras
+Foreman role: scope, alignment, and traceability only
+
+## Objective
+
+Define the database and API contract for MMM approval workflow implementation after approval workflow gap alignment has been merged.
+
+This wave covers step 2 in the CS2-approved sequence:
+
+1. Gap analysis / pre-build alignment for the approval workflow. Completed by PR #1831.
+2. Database/API contract for approval rounds, approvers, proposed edits, comments, notifications, and locks. This wave.
+3. Level 2 invite modal and approval workspace.
+4. Change summary email and accept/reject/apply flow.
+5. Level 3 approval expansion.
+6. Published maturity model view.
+7. Evidence modal harvest/adaptation from MAT.
+
+## Authority inputs
+
+- `modules/MMM/approval-workflow/approval-workflow-gap-analysis.md`
+- `modules/MMM/approval-workflow/approval-workflow-prebuild-contract.md`
+- Uploaded `The Maturity Roadmap(5).docx`
+- CS2 approval sequence instruction from 2026-06-23
+
+## Bounded file scope
+
+Pre-build contract artifacts may be added under:
+
+- `modules/MMM/approval-workflow/`
+
+Required governance / assurance records for this wave may be added under:
+
+- `.agent-admin/scope-declarations/`
+- `.agent-admin/assurance/`
+
+## Required outputs
+
+This wave must define:
+
+- approval round record contract;
+- approver invitation/access record contract;
+- proposed edit object contract;
+- comment/thread contract;
+- notification event contract;
+- lock state and lock transition contract;
+- AI learning event contract;
+- API / edge-function names, request payloads, responses, and failure modes;
+- QA-to-red tests for the later build.
+
+## Out of scope
+
+- Creating database migrations.
+- Implementing API routes or edge functions.
+- Implementing e-mail delivery.
+- Implementing UI components.
+- Implementing approval workspace behavior.
+- Implementing published maturity model view.
+- Implementing MAT evidence harvest.
+
+## Lane note
+
+This is a pre-build contract wave. It creates implementation-ready contracts but does not build the capability.

--- a/modules/MMM/approval-workflow/approval-workflow-db-api-contract.md
+++ b/modules/MMM/approval-workflow/approval-workflow-db-api-contract.md
@@ -1,0 +1,671 @@
+# MMM Approval Workflow DB/API Contract
+
+Status: pre-build contract
+Date: 2026-06-23
+Wave: `wave-mmm-approval-db-api-contract-2026-06-23`
+CS2 Authority: Johan Ras
+
+## 1. Purpose
+
+This artifact defines the database and API contract for the MMM approval workflow.
+
+It is contract-only. It does not create database migrations, API routes, edge functions, e-mail delivery code, or UI components.
+
+The contract implements Step 2 after the merged approval workflow pre-build alignment.
+
+## 2. Contract principles
+
+### 2.1 Proposed edits must not overwrite canonical content
+
+Approvers must never directly overwrite domain, MPS, intent, criteria, or descriptor records.
+
+All approver edits are stored as proposed changes until the level 1 user accepts, rejects, edits, or applies them through the controlled loop.
+
+### 2.2 Approval state and lock state are separate
+
+Approval state describes where the item is in the workflow.
+
+Lock state controls whether level 1 can edit canonical content outside the controlled approval loop.
+
+### 2.3 Notifications must be event-backed
+
+Every e-mail or in-app notification must be backed by a notification event record so delivery can be retried, audited, and made idempotent.
+
+### 2.4 AI learning capture must be organisation-specific
+
+Every decision that accepts, rejects, edits, supersedes, or applies a proposed change must produce an AI learning event linked to the organisation and model context.
+
+## 3. Proposed database record contracts
+
+The following table contracts define required logical records. They may later be implemented as Supabase tables, views, or equivalent storage structures.
+
+## 4. `mmm_approval_rounds`
+
+Represents one approval round for a domain or full roadmap.
+
+### Required fields
+
+| Field | Type | Required | Notes |
+|---|---|---:|---|
+| `id` | uuid | yes | Primary key. |
+| `organisation_id` | uuid | yes | Organisation owning the model. |
+| `framework_id` | uuid | yes | Maturity framework / roadmap id. |
+| `domain_id` | uuid nullable | conditional | Required for level 2 domain approval. Null allowed for level 3 full-roadmap approval. |
+| `approval_level` | enum | yes | `level_2` or `level_3`. Level 1 is component acceptance, not an approval round. |
+| `round_number` | integer | yes | Incremented per resubmission loop. |
+| `status` | enum | yes | See status enum below. |
+| `submitted_by_user_id` | uuid | yes | Level 1 user who initiated round. |
+| `submitted_at` | timestamptz | yes | Round submission timestamp. |
+| `resubmitted_from_round_id` | uuid nullable | no | Prior round if this is a resubmission. |
+| `all_approvers_required` | boolean | yes | Default true. |
+| `created_at` | timestamptz | yes | Audit timestamp. |
+| `updated_at` | timestamptz | yes | Audit timestamp. |
+
+### Status enum
+
+`mmm_approval_round_status`:
+
+- `draft`
+- `invited`
+- `in_review`
+- `changes_requested`
+- `resubmitted`
+- `approved_by_some`
+- `approved_by_all`
+- `cancelled`
+- `superseded`
+
+### Required invariants
+
+- A level 2 round must have `domain_id`.
+- A level 3 round may cover the full framework and may leave `domain_id` null.
+- A round reaches `approved_by_all` only when every required approver has an approval decision on the current round.
+- If any required approver requests changes, the round status becomes `changes_requested`.
+- Superseded rounds remain immutable.
+
+## 5. `mmm_approval_approvers`
+
+Represents an invited approver in a round.
+
+### Required fields
+
+| Field | Type | Required | Notes |
+|---|---|---:|---|
+| `id` | uuid | yes | Primary key. |
+| `approval_round_id` | uuid | yes | Parent round. |
+| `organisation_id` | uuid | yes | Organisation context. |
+| `user_id` | uuid nullable | no | Set after invitee signs up or links account. |
+| `email` | text | yes | Invitation e-mail. |
+| `full_name` | text | yes | Invite modal value. |
+| `designation` | text nullable | no | Role/title/designation. |
+| `approval_level` | enum | yes | Mirrors parent round. |
+| `status` | enum | yes | See approver status enum. |
+| `invited_by_user_id` | uuid | yes | Level 1 user or authorized inviter. |
+| `invited_at` | timestamptz | yes | Invite timestamp. |
+| `accepted_invite_at` | timestamptz nullable | no | Signup/access acceptance. |
+| `decision` | enum nullable | no | Latest decision. |
+| `decision_at` | timestamptz nullable | no | Latest decision timestamp. |
+| `decision_comment` | text nullable | no | Approval/change summary comment. |
+| `created_at` | timestamptz | yes | Audit timestamp. |
+| `updated_at` | timestamptz | yes | Audit timestamp. |
+
+### Approver status enum
+
+`mmm_approval_approver_status`:
+
+- `invited`
+- `invite_accepted`
+- `in_review`
+- `changes_submitted`
+- `approved`
+- `declined`
+- `replaced`
+- `expired`
+
+### Decision enum
+
+`mmm_approval_decision`:
+
+- `approved`
+- `changes_requested`
+- `declined`
+
+### Required invariants
+
+- The same email cannot appear twice in the same round unless a prior approver record is `replaced` or `expired`.
+- Approver write access is scoped to the approval round and invited object scope.
+- A level 3 approver cannot be invited until the prerequisite level 2 approval condition is satisfied.
+
+## 6. `mmm_approval_invitations`
+
+Tracks invite token lifecycle separately from approver identity.
+
+### Required fields
+
+| Field | Type | Required | Notes |
+|---|---|---:|---|
+| `id` | uuid | yes | Primary key. |
+| `approval_round_id` | uuid | yes | Parent round. |
+| `approver_id` | uuid | yes | Invited approver. |
+| `email` | text | yes | Target e-mail. |
+| `token_hash` | text | yes | Store hash only. |
+| `status` | enum | yes | See invitation status enum. |
+| `expires_at` | timestamptz | yes | Expiration. |
+| `sent_at` | timestamptz nullable | no | First send timestamp. |
+| `accepted_at` | timestamptz nullable | no | Invite accepted timestamp. |
+| `revoked_at` | timestamptz nullable | no | Invite revoked timestamp. |
+| `created_at` | timestamptz | yes | Audit timestamp. |
+
+### Invitation status enum
+
+`mmm_approval_invitation_status`:
+
+- `pending_send`
+- `sent`
+- `accepted`
+- `expired`
+- `revoked`
+- `failed`
+
+### Required invariants
+
+- Token values must not be stored in plaintext.
+- Invitation acceptance must bind the approver record to a user account or scoped guest access record.
+- Revoked/expired invitations must not grant access.
+
+## 7. `mmm_approval_proposed_changes`
+
+Stores approver-suggested edits.
+
+### Required fields
+
+| Field | Type | Required | Notes |
+|---|---|---:|---|
+| `id` | uuid | yes | Primary key. |
+| `approval_round_id` | uuid | yes | Parent round. |
+| `approver_id` | uuid | yes | Proposing approver. |
+| `organisation_id` | uuid | yes | Organisation context. |
+| `framework_id` | uuid | yes | Framework context. |
+| `domain_id` | uuid nullable | no | Domain context if applicable. |
+| `mps_id` | uuid nullable | no | MPS context if applicable. |
+| `criterion_id` | uuid nullable | no | Criteria context if applicable. |
+| `descriptor_id` | uuid nullable | no | Maturity descriptor context if applicable. |
+| `object_type` | enum | yes | See object type enum. |
+| `object_id` | uuid | yes | Target object id. |
+| `field_name` | text | yes | Field proposed for change. |
+| `display_reference` | text | yes | Human reference for e-mail/UI. |
+| `original_value` | text | yes | Snapshot value at time proposed. |
+| `proposed_value` | text | yes | Approver proposed value. |
+| `comment` | text nullable | no | Approver reason/comment. |
+| `status` | enum | yes | See proposed change status enum. |
+| `level_1_response` | text nullable | no | Accept/reject/edit response. |
+| `final_value` | text nullable | no | Value applied if accepted or edited. |
+| `applied_by_user_id` | uuid nullable | no | Level 1 actor. |
+| `applied_at` | timestamptz nullable | no | Apply timestamp. |
+| `created_at` | timestamptz | yes | Audit timestamp. |
+| `updated_at` | timestamptz | yes | Audit timestamp. |
+
+### Object type enum
+
+`mmm_approval_object_type`:
+
+- `domain`
+- `mps`
+- `intent_statement`
+- `criterion`
+- `maturity_descriptor`
+
+### Proposed change status enum
+
+`mmm_approval_proposed_change_status`:
+
+- `proposed`
+- `accepted`
+- `edited_by_level_1`
+- `rejected`
+- `applied`
+- `superseded`
+
+### Required invariants
+
+- Proposed changes are immutable after submission except status/response/final application fields.
+- `original_value` must be captured at proposal time.
+- Applying a change must create audit and AI learning events.
+- A proposed change must not apply if its target object has changed since proposal unless conflict resolution is performed.
+
+## 8. `mmm_approval_comments`
+
+Stores threaded comments attached to rounds or proposed changes.
+
+### Required fields
+
+| Field | Type | Required | Notes |
+|---|---|---:|---|
+| `id` | uuid | yes | Primary key. |
+| `approval_round_id` | uuid | yes | Parent round. |
+| `proposed_change_id` | uuid nullable | no | Optional target proposed change. |
+| `parent_comment_id` | uuid nullable | no | Threading. |
+| `author_user_id` | uuid | yes | Comment author. |
+| `author_role` | enum | yes | `level_1`, `level_2`, `level_3`, `system`. |
+| `body` | text | yes | Comment body. |
+| `visibility` | enum | yes | See visibility enum. |
+| `created_at` | timestamptz | yes | Audit timestamp. |
+| `updated_at` | timestamptz | yes | Audit timestamp. |
+
+### Visibility enum
+
+`mmm_approval_comment_visibility`:
+
+- `round_participants`
+- `level_1_only`
+- `level_2_and_level_1`
+- `level_3_level_2_and_level_1`
+
+### Required invariants
+
+- Level 3 change-loop comments must be visible to level 1 and copied level 2 approvers.
+- Comments cannot be hard-deleted after submission; use redaction/soft delete if required later.
+
+## 9. `mmm_approval_locks`
+
+Tracks lock state at framework, domain, and object levels.
+
+### Required fields
+
+| Field | Type | Required | Notes |
+|---|---|---:|---|
+| `id` | uuid | yes | Primary key. |
+| `organisation_id` | uuid | yes | Organisation context. |
+| `framework_id` | uuid | yes | Framework context. |
+| `domain_id` | uuid nullable | no | Domain lock scope. |
+| `object_type` | enum nullable | no | Optional narrower lock object type. |
+| `object_id` | uuid nullable | no | Optional narrower lock object id. |
+| `lock_state` | enum | yes | See lock state enum. |
+| `locked_by_round_id` | uuid nullable | no | Round that established lock. |
+| `temporarily_unlocked_by_round_id` | uuid nullable | no | Round that reopened item. |
+| `reason` | text | yes | Lock/unlock reason. |
+| `created_at` | timestamptz | yes | Audit timestamp. |
+| `updated_at` | timestamptz | yes | Audit timestamp. |
+
+### Lock state enum
+
+`mmm_approval_lock_state`:
+
+- `unlocked`
+- `locked_by_level_2`
+- `temporarily_unlocked_for_change_request`
+- `locked_by_final_approval`
+
+### Required invariants
+
+- Level 1 approval does not create a lock.
+- Level 2 `approved_by_all` creates a domain-level lock.
+- Level 3 change request may create a temporary unlock for affected items only.
+- Final approval creates final framework/domain locks.
+
+## 10. `mmm_approval_notification_events`
+
+Event outbox for e-mail and in-app notifications.
+
+### Required fields
+
+| Field | Type | Required | Notes |
+|---|---|---:|---|
+| `id` | uuid | yes | Primary key. |
+| `organisation_id` | uuid | yes | Organisation context. |
+| `approval_round_id` | uuid | yes | Parent round. |
+| `recipient_user_id` | uuid nullable | no | Known recipient. |
+| `recipient_email` | text | yes | Target e-mail. |
+| `notification_type` | enum | yes | See notification type enum. |
+| `payload_json` | jsonb | yes | Structured payload for renderer. |
+| `idempotency_key` | text | yes | Prevent duplicate sends. |
+| `status` | enum | yes | See notification status enum. |
+| `queued_at` | timestamptz | yes | Queue timestamp. |
+| `sent_at` | timestamptz nullable | no | Sent timestamp. |
+| `failed_at` | timestamptz nullable | no | Failure timestamp. |
+| `failure_reason` | text nullable | no | Error summary. |
+
+### Notification type enum
+
+`mmm_approval_notification_type`:
+
+- `level_2_invitation`
+- `level_2_changes_submitted`
+- `level_1_response_submitted`
+- `level_2_all_approved`
+- `level_3_invitation`
+- `level_3_changes_submitted`
+- `final_approval_complete`
+
+### Notification status enum
+
+`mmm_approval_notification_status`:
+
+- `queued`
+- `sent`
+- `failed`
+- `cancelled`
+
+## 11. `mmm_ai_learning_events`
+
+Records organisation-specific learning events from approval-loop decisions.
+
+### Required fields
+
+| Field | Type | Required | Notes |
+|---|---|---:|---|
+| `id` | uuid | yes | Primary key. |
+| `organisation_id` | uuid | yes | Organisation context. |
+| `framework_id` | uuid | yes | Framework context. |
+| `approval_round_id` | uuid nullable | no | Related round. |
+| `proposed_change_id` | uuid nullable | no | Related proposed change. |
+| `approval_level` | enum nullable | no | `level_2` or `level_3`. |
+| `object_type` | enum | yes | Same as approval object type. |
+| `object_id` | uuid | yes | Target object id. |
+| `original_value` | text nullable | no | Prior value. |
+| `proposed_value` | text nullable | no | Proposed value. |
+| `final_value` | text nullable | no | Accepted/applied value. |
+| `decision` | enum | yes | See learning decision enum. |
+| `reason` | text nullable | no | Reason/comment. |
+| `actor_role` | enum | yes | `level_1`, `level_2`, `level_3`, `system`. |
+| `created_at` | timestamptz | yes | Audit timestamp. |
+
+### Learning decision enum
+
+`mmm_ai_learning_decision`:
+
+- `accepted`
+- `rejected`
+- `edited`
+- `superseded`
+- `final_signed_off`
+
+## 12. API / edge-function contract
+
+The final implementation may use Supabase edge functions or equivalent API endpoints. The function names below are canonical for future build waves unless CS2 approves a change.
+
+## 13. `mmm-approval-round-create`
+
+Creates a level 2 or level 3 approval round and approver invitations.
+
+### Request
+
+```json
+{
+  "organisation_id": "uuid",
+  "framework_id": "uuid",
+  "domain_id": "uuid-or-null",
+  "approval_level": "level_2",
+  "submitted_by_user_id": "uuid",
+  "approvers": [
+    {
+      "full_name": "Jane Approver",
+      "email": "jane@example.com",
+      "designation": "Operations Executive",
+      "message": "Please review this domain.",
+      "due_date": "2026-07-15"
+    }
+  ]
+}
+```
+
+### Response
+
+```json
+{
+  "approval_round_id": "uuid",
+  "status": "invited",
+  "approver_ids": ["uuid"],
+  "notification_event_ids": ["uuid"]
+}
+```
+
+### Failure modes
+
+- missing domain for level 2;
+- level 3 requested before level 2 prerequisites are complete;
+- duplicate approver e-mail in active round;
+- unauthorised submitter;
+- target domain already locked by final approval.
+
+## 14. `mmm-approval-invite-accept`
+
+Accepts an invitation and grants scoped access.
+
+### Request
+
+```json
+{
+  "token": "plaintext-token-from-link",
+  "user_id": "uuid-or-null",
+  "signup_profile": {
+    "full_name": "Jane Approver",
+    "email": "jane@example.com"
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "approval_round_id": "uuid",
+  "approver_id": "uuid",
+  "access_scope": {
+    "framework_id": "uuid",
+    "domain_id": "uuid-or-null",
+    "approval_level": "level_2"
+  }
+}
+```
+
+### Failure modes
+
+- token invalid;
+- token expired;
+- invite revoked;
+- e-mail mismatch;
+- round superseded.
+
+## 15. `mmm-approval-proposed-changes-submit`
+
+Submits approver proposed changes and comments.
+
+### Request
+
+```json
+{
+  "approval_round_id": "uuid",
+  "approver_id": "uuid",
+  "changes": [
+    {
+      "object_type": "criterion",
+      "object_id": "uuid",
+      "field_name": "statement",
+      "display_reference": "MPS 4 / Criteria 7 / statement",
+      "original_value": "Current criterion text",
+      "proposed_value": "Proposed criterion text",
+      "comment": "Please clarify ownership."
+    }
+  ],
+  "round_comment": "I have proposed three changes."
+}
+```
+
+### Response
+
+```json
+{
+  "approval_round_id": "uuid",
+  "status": "changes_requested",
+  "proposed_change_ids": ["uuid"],
+  "notification_event_ids": ["uuid"]
+}
+```
+
+### Failure modes
+
+- approver not part of round;
+- round not in review state;
+- proposed value empty;
+- original value does not match latest snapshot and conflict detection fails;
+- target object outside approver scope.
+
+## 16. `mmm-approval-decision-submit`
+
+Records an approver approval decision.
+
+### Request
+
+```json
+{
+  "approval_round_id": "uuid",
+  "approver_id": "uuid",
+  "decision": "approved",
+  "decision_comment": "Approved with no further changes."
+}
+```
+
+### Response
+
+```json
+{
+  "approval_round_id": "uuid",
+  "round_status": "approved_by_all",
+  "lock_state_changes": [
+    {
+      "object_type": "domain",
+      "object_id": "uuid",
+      "lock_state": "locked_by_level_2"
+    }
+  ],
+  "notification_event_ids": ["uuid"]
+}
+```
+
+### Failure modes
+
+- pending proposed changes by same approver;
+- approver not in round;
+- round superseded;
+- decision conflicts with existing changes requested state.
+
+## 17. `mmm-approval-level1-response-submit`
+
+Allows level 1 to accept, reject, edit, or apply proposed changes.
+
+### Request
+
+```json
+{
+  "approval_round_id": "uuid",
+  "level_1_user_id": "uuid",
+  "responses": [
+    {
+      "proposed_change_id": "uuid",
+      "action": "edited_by_level_1",
+      "final_value": "Accepted wording with level 1 edits.",
+      "response_comment": "Accepted but tightened language."
+    }
+  ],
+  "resubmit": true
+}
+```
+
+### Response
+
+```json
+{
+  "approval_round_id": "uuid",
+  "new_round_id": "uuid-or-null",
+  "applied_change_ids": ["uuid"],
+  "ai_learning_event_ids": ["uuid"],
+  "notification_event_ids": ["uuid"]
+}
+```
+
+### Failure modes
+
+- level 1 user not authorised;
+- proposed change already applied/rejected/superseded;
+- target object is final locked;
+- final value empty for accept/edit action;
+- attempted apply without audit/AI learning event.
+
+## 18. `mmm-approval-lock-transition`
+
+Internal API used by approval functions to transition lock state.
+
+### Request
+
+```json
+{
+  "approval_round_id": "uuid",
+  "lock_scope": {
+    "framework_id": "uuid",
+    "domain_id": "uuid-or-null",
+    "object_type": "domain",
+    "object_id": "uuid"
+  },
+  "target_lock_state": "locked_by_level_2",
+  "reason": "All level 2 approvers approved."
+}
+```
+
+### Response
+
+```json
+{
+  "lock_id": "uuid",
+  "lock_state": "locked_by_level_2"
+}
+```
+
+### Failure modes
+
+- illegal transition;
+- final lock already present;
+- missing reason;
+- round state does not permit transition.
+
+## 19. Required authorization rules
+
+- Level 1 can create approval rounds for owned or administrable domains/frameworks.
+- Level 2 approvers can read the invited domain and propose changes/comments only within the round scope.
+- Level 3 approvers can read the invited full roadmap/control standard and propose changes/comments only within the final approval round.
+- Level 2 approvers copied into level 3 correspondence can comment on affected domain changes but cannot directly approve level 3 unless separately invited as final approvers.
+- No approver can directly update canonical domain/MPS/criteria/descriptor tables through the approval workspace.
+
+## 20. Required audit events
+
+Every state transition must produce an audit event in the later implementation.
+
+Required event categories:
+
+- approval round created;
+- approver invited;
+- invite accepted;
+- proposed changes submitted;
+- approver approved;
+- level 1 accepted change;
+- level 1 rejected change;
+- level 1 edited/applied change;
+- round resubmitted;
+- lock applied;
+- temporary unlock applied;
+- final approval completed.
+
+## 21. Acceptance criteria for this contract
+
+This DB/API contract is complete when future builders can implement:
+
+- the approval round storage model;
+- approver invite and scoped access;
+- proposed change storage and review;
+- comment threading;
+- notification event queue;
+- lock state transitions;
+- AI learning event capture;
+- API payload validation;
+- authorization boundaries;
+- QA-to-red tests without inventing additional domain rules.

--- a/modules/MMM/approval-workflow/approval-workflow-notification-lock-contract.md
+++ b/modules/MMM/approval-workflow/approval-workflow-notification-lock-contract.md
@@ -1,0 +1,303 @@
+# MMM Approval Workflow Notification and Lock Contract
+
+Status: pre-build contract
+Date: 2026-06-23
+Wave: `wave-mmm-approval-db-api-contract-2026-06-23`
+CS2 Authority: Johan Ras
+
+## 1. Purpose
+
+This artifact expands the notification and lock behavior required by the MMM approval workflow database/API contract.
+
+It is contract-only and does not implement e-mail sending, database migrations, API routes, or UI behavior.
+
+## 2. Notification principles
+
+### 2.1 Notifications are generated from approval events
+
+The system must not send approval e-mails directly from UI click handlers without recording a notification event.
+
+Every notification must be traceable to:
+
+- organisation;
+- framework;
+- approval round;
+- recipient;
+- notification type;
+- payload;
+- idempotency key;
+- status.
+
+### 2.2 E-mail and in-app notifications share payload contract
+
+The same structured payload must support:
+
+- e-mail rendering;
+- in-app notification rendering;
+- audit review;
+- retry after failure.
+
+### 2.3 Notification delivery is idempotent
+
+Each logical notification must have an idempotency key so retries do not spam approvers or users.
+
+Recommended idempotency key format:
+
+```text
+mmm-approval:{notification_type}:{approval_round_id}:{recipient_email}:{version_or_event_id}
+```
+
+## 3. Notification types
+
+### 3.1 `level_2_invitation`
+
+Sent when level 1 submits a domain for level 2 approval.
+
+Required recipients:
+
+- each invited level 2 approver.
+
+Required payload fields:
+
+- `organisation_name`;
+- `framework_name`;
+- `domain_name`;
+- `inviter_name`;
+- `approval_level`;
+- `invitation_link`;
+- `due_date` nullable;
+- `message` nullable;
+- `mps_count`;
+- `criteria_count`;
+- `descriptor_count`.
+
+### 3.2 `level_2_changes_submitted`
+
+Sent when one or more level 2 approvers submit proposed changes.
+
+Required recipients:
+
+- level 1 user / compiler.
+
+Required payload fields:
+
+- `domain_name`;
+- `approval_round_id`;
+- `approver_names`;
+- `change_count`;
+- `comment_count`;
+- `change_summary_items`;
+- `review_workspace_link`.
+
+### 3.3 `level_1_response_submitted`
+
+Sent when level 1 accepts, rejects, edits, or applies proposed changes and resubmits.
+
+Required recipients:
+
+- all active level 2 approvers in the round.
+
+Required payload fields:
+
+- `domain_name`;
+- `round_number`;
+- `accepted_count`;
+- `rejected_count`;
+- `edited_count`;
+- `resubmission_link`;
+- `response_summary_items`.
+
+### 3.4 `level_2_all_approved`
+
+Sent when all required level 2 approvers sign off.
+
+Required recipients:
+
+- level 1 user;
+- all level 2 approvers.
+
+Required payload fields:
+
+- `domain_name`;
+- `approved_by`;
+- `approved_at`;
+- `lock_state`;
+- `next_action`.
+
+### 3.5 `level_3_invitation`
+
+Sent when level 1 invites final approvers after level 2 prerequisite approvals are met.
+
+Required recipients:
+
+- each invited level 3 approver.
+
+Required payload fields:
+
+- `organisation_name`;
+- `framework_name`;
+- `inviter_name`;
+- `approval_level`;
+- `invitation_link`;
+- `domain_count`;
+- `mps_count`;
+- `criteria_count`;
+- `due_date` nullable;
+- `message` nullable.
+
+### 3.6 `level_3_changes_submitted`
+
+Sent when a final approver proposes changes.
+
+Required recipients:
+
+- level 1 user;
+- level 2 approvers for affected domains as copied recipients.
+
+Required payload fields:
+
+- `framework_name`;
+- `approval_round_id`;
+- `final_approver_names`;
+- `change_count`;
+- `affected_domain_names`;
+- `copied_level_2_approvers`;
+- `change_summary_items`;
+- `review_workspace_link`.
+
+### 3.7 `final_approval_complete`
+
+Sent when all required final approvers sign off.
+
+Required recipients:
+
+- level 1 user;
+- level 2 approvers;
+- level 3 approvers;
+- optional organisation administrators later.
+
+Required payload fields:
+
+- `framework_name`;
+- `approved_by`;
+- `approved_at`;
+- `final_lock_state`;
+- `published_model_link` nullable until publication implementation exists.
+
+## 4. Change summary item contract
+
+All change-summary notification payloads must use the same item structure.
+
+```json
+{
+  "display_reference": "MPS 4 / Criteria 7 / Descriptor: Compliant",
+  "object_type": "maturity_descriptor",
+  "field_name": "descriptor_text",
+  "original_value_excerpt": "There is a policy in place and it is current.",
+  "proposed_value_excerpt": "There is an approved policy in place...",
+  "comment_excerpt": "Please make ownership explicit.",
+  "proposed_change_id": "uuid",
+  "status": "proposed"
+}
+```
+
+Rules:
+
+- Excerpts must be short enough for e-mail but link to full workspace detail.
+- Each item must retain precise reference to domain/MPS/criterion/descriptor.
+- Level 3 change summaries must include affected domain and copied level 2 approvers.
+
+## 5. Lock principles
+
+### 5.1 Level 1 approval does not lock
+
+Level 1 acceptance confirms user satisfaction with AI-generated content but leaves content editable with audit trail.
+
+### 5.2 Level 2 approval locks a domain
+
+A domain becomes locked only after every required level 2 approver in the active round approves.
+
+Lock scope:
+
+- domain;
+- MPS records under domain;
+- intent statements under domain/MPS;
+- criteria under domain/MPS;
+- maturity descriptors under criteria.
+
+### 5.3 Change requests create controlled temporary unlocks
+
+When level 2 or level 3 requests changes, only affected objects become temporarily editable by level 1.
+
+Temporary unlocks must record:
+
+- approval round;
+- requested change;
+- object scope;
+- reason;
+- actor;
+- timestamp.
+
+### 5.4 Final approval creates final lock
+
+Final approval locks the maturity roadmap/control standard.
+
+Post-final change requires a future change-management workflow and is outside this contract.
+
+## 6. Lock transition matrix
+
+| From | To | Allowed when | Actor/API |
+|---|---|---|---|
+| `unlocked` | `locked_by_level_2` | all level 2 approvers approved | `mmm-approval-decision-submit` |
+| `locked_by_level_2` | `temporarily_unlocked_for_change_request` | level 3 requests changes affecting object | `mmm-approval-proposed-changes-submit` |
+| `temporarily_unlocked_for_change_request` | `locked_by_level_2` | level 1 applies/rejects and level 2 confirms or no level 2 reconfirm required | `mmm-approval-level1-response-submit` |
+| `locked_by_level_2` | `locked_by_final_approval` | all level 3 approvers approved | `mmm-approval-decision-submit` |
+| `temporarily_unlocked_for_change_request` | `locked_by_final_approval` | final approval completed after change loop resolution | `mmm-approval-decision-submit` |
+
+Forbidden transitions:
+
+- `unlocked` directly to `locked_by_final_approval`.
+- `locked_by_final_approval` to any editable state in this workflow.
+- Any transition without reason and approval round reference.
+
+## 7. Lock conflict rules
+
+If a proposed change targets an object that has changed since proposal:
+
+1. The proposed change must be flagged as conflicted in the later implementation.
+2. The system must not auto-apply the change.
+3. Level 1 must compare original, proposed, and current values.
+4. A new edited value may be applied only with a new audit and AI learning event.
+
+## 8. Copied correspondence rules for level 3
+
+When level 3 proposes changes:
+
+- level 1 receives the actionable notification;
+- level 2 approvers for affected domains are copied;
+- copied level 2 approvers may comment;
+- copied level 2 approvers do not become final approvers unless invited as final approvers;
+- comments from copied level 2 approvers are included in the round audit trail.
+
+## 9. Notification failure handling
+
+Required failure behavior for later implementation:
+
+- Failed notification events remain stored with `failed` status.
+- Retry creates no duplicate logical notification because idempotency key is reused.
+- UI must eventually be able to show notification delivery status.
+- Approval state must not become final merely because e-mail delivery succeeded; approval decisions drive state, notification delivery supports communication.
+
+## 10. Acceptance criteria
+
+This notification/lock contract is complete when future builders can implement:
+
+- idempotent notification event creation;
+- invitation e-mails;
+- change-summary e-mails;
+- level 3 copied correspondence;
+- lock state transitions;
+- temporary unlock behavior;
+- conflict handling;
+- final lock behavior;
+- notification retry logic.

--- a/modules/MMM/approval-workflow/approval-workflow-qa-to-red.md
+++ b/modules/MMM/approval-workflow/approval-workflow-qa-to-red.md
@@ -1,0 +1,172 @@
+# MMM Approval Workflow DB/API QA-to-Red Contract
+
+Status: QA-to-red pre-build contract
+Date: 2026-06-23
+Wave: `wave-mmm-approval-db-api-contract-2026-06-23`
+CS2 Authority: Johan Ras
+
+## 1. Purpose
+
+This artifact defines failing test expectations for the future implementation of the MMM approval workflow database/API layer.
+
+It is not executable test code yet. It is the QA-to-red contract the next implementation wave must convert into tests before building.
+
+## 2. Test scope
+
+Future QA-to-red tests must cover:
+
+- approval round creation;
+- multi-approver invitation;
+- invite acceptance and scoped access;
+- proposed-change submission;
+- comments;
+- level 1 accept/reject/edit/apply;
+- notification event creation;
+- lock transitions;
+- level 3 approval prerequisites;
+- AI learning event capture;
+- authorization failures.
+
+## 3. Required red tests
+
+### T-MMM-APPROVAL-DB-001 — Level 2 round requires domain scope
+
+Given a user attempts to create a level 2 approval round without a `domain_id`,
+when `mmm-approval-round-create` is called,
+then the API must reject the request and no approval round, approver, invitation, or notification event may be created.
+
+### T-MMM-APPROVAL-DB-002 — Level 3 round blocked before level 2 approval
+
+Given not all domains have required level 2 approval,
+when the user attempts to create a level 3 approval round,
+then the API must reject the request with a prerequisite failure.
+
+### T-MMM-APPROVAL-DB-003 — Duplicate approver e-mail rejected in same round
+
+Given a user submits two approver entries with the same e-mail for one approval round,
+when `mmm-approval-round-create` is called,
+then the API must reject the duplicate or return per-approver validation failure before sending invitations.
+
+### T-MMM-APPROVAL-DB-004 — Invitation token stored hashed, not plaintext
+
+Given an invitation is created,
+when the invitation record is stored,
+then the database contract must store `token_hash` and must not expose a plaintext token field.
+
+### T-MMM-APPROVAL-DB-005 — Expired or revoked invite cannot grant access
+
+Given an invitation is expired or revoked,
+when `mmm-approval-invite-accept` is called,
+then access must be denied and no approver account binding may occur.
+
+### T-MMM-APPROVAL-DB-006 — Approver cannot edit outside invited scope
+
+Given a level 2 approver is invited to Domain A,
+when the approver submits a proposed change for Domain B,
+then `mmm-approval-proposed-changes-submit` must reject the change.
+
+### T-MMM-APPROVAL-DB-007 — Proposed edits do not overwrite canonical model content
+
+Given an approver submits a proposed criterion statement change,
+when the proposed change is saved,
+then the canonical criterion record must remain unchanged until level 1 applies the change.
+
+### T-MMM-APPROVAL-DB-008 — Proposed change captures original snapshot
+
+Given an approver proposes a change,
+when it is saved,
+then `original_value`, `proposed_value`, `display_reference`, object identifiers, approver id, and round id must be stored.
+
+### T-MMM-APPROVAL-DB-009 — Level 1 accept creates audit and AI learning events
+
+Given level 1 accepts a proposed change,
+when `mmm-approval-level1-response-submit` is called,
+then the canonical field is updated, audit event is recorded, and an AI learning event is created.
+
+### T-MMM-APPROVAL-DB-010 — Level 1 reject preserves canonical value
+
+Given level 1 rejects a proposed change,
+when the response is submitted,
+then the canonical field must remain unchanged and rejection reason must be recorded.
+
+### T-MMM-APPROVAL-DB-011 — Level 1 edited apply records final value
+
+Given level 1 edits an approver proposed value before applying,
+when the response is submitted,
+then the final applied value must differ from the proposed value and both proposed and final values must be retained.
+
+### T-MMM-APPROVAL-DB-012 — Any changes-requested decision blocks all-approved state
+
+Given one approver approves and another submits changes requested,
+when the round status is recalculated,
+then the round must be `changes_requested`, not `approved_by_all`.
+
+### T-MMM-APPROVAL-DB-013 — All level 2 approvers required for domain lock
+
+Given a level 2 round has multiple required approvers,
+when only some approvers approve,
+then the domain must not enter `locked_by_level_2`.
+
+### T-MMM-APPROVAL-DB-014 — All level 2 approvers approved creates domain lock
+
+Given all required level 2 approvers approve,
+when the last approval is submitted,
+then the round becomes `approved_by_all` and a domain lock is created.
+
+### T-MMM-APPROVAL-DB-015 — Level 3 invite creates `level_3_pending`
+
+Given all prerequisite domains have level 2 approval,
+when a level 3 approval round is created,
+then affected domains/framework state must be representable as `level_3_pending` before final approval.
+
+### T-MMM-APPROVAL-DB-016 — Level 3 proposed changes copy level 2 approvers
+
+Given a level 3 approver proposes changes affecting a domain,
+when notifications are generated,
+then level 1 receives the actionable notification and the level 2 approvers for the affected domain are copied.
+
+### T-MMM-APPROVAL-DB-017 — Level 3 change creates temporary unlock only for affected items
+
+Given a domain is locked after level 2 approval,
+when level 3 requests a change to one criterion,
+then only that affected criterion path may enter temporary unlock state.
+
+### T-MMM-APPROVAL-DB-018 — Final approval creates final lock
+
+Given all required level 3 approvers approve,
+when the last approval is submitted,
+then the framework/control standard enters final lock state and later edits are blocked by this workflow.
+
+### T-MMM-APPROVAL-DB-019 — Notification events are idempotent
+
+Given a notification delivery retry occurs,
+when a notification event with the same idempotency key already exists,
+then no duplicate logical notification should be queued.
+
+### T-MMM-APPROVAL-DB-020 — Failed notification does not imply approval failure
+
+Given an e-mail send fails,
+when approval state is recalculated,
+then approval decisions and locks remain based on decisions, while notification delivery status remains failed/retryable.
+
+### T-MMM-APPROVAL-DB-021 — Comments are threaded and visible by allowed scope
+
+Given an approver comments on a proposed change,
+when round participants view comments,
+then visibility rules must allow only authorized round participants to read the comment.
+
+### T-MMM-APPROVAL-DB-022 — Final-locked object cannot be changed through approval response
+
+Given an object is `locked_by_final_approval`,
+when level 1 attempts to apply a proposed change through the approval response API,
+then the API must reject the attempt.
+
+## 4. Required non-goals for red tests
+
+The next implementation wave must not write UI tests for invite modals or approval workspaces until the DB/API layer exists.
+
+The next implementation wave must not implement evidence modal harvest, published model UI, or level 3 workspace UI.
+
+## 5. Acceptance criteria
+
+This QA-to-red contract is complete when future builders can convert each test expectation into executable tests against the database/API implementation without inventing missing workflow rules.


### PR DESCRIPTION
Pre-build contract PR for Step 2 of the MMM approval workflow sequence.

Scope:

- database/API contract for approval rounds, approvers, invitations, proposed edits, comments, notifications, locks, and AI learning events;
- notification and lock transition contract;
- QA-to-red contract for the later implementation wave;
- governance scope and IAA pre-brief records.

This PR does not create database migrations, API routes, edge functions, e-mail delivery code, UI components, or runtime app behavior.

This PR covers Step 2 only:

2. Database/API contract for approval rounds, approvers, proposed edits, comments, notifications, and locks.

The next implementation sequence remains:

3. Level 2 invite modal and approval workspace.
4. Change summary email and accept/reject/apply flow.
5. Level 3 approval expansion.
6. Published maturity model view.
7. Evidence modal harvest/adaptation from MAT.