### PR TITLE
PIT Project Implementation Tracker navigation and wording

### DIFF
--- a/.agent-admin/assurance/iaa-wave-record-pit-project-implementation-tracker-routing.md
+++ b/.agent-admin/assurance/iaa-wave-record-pit-project-implementation-tracker-routing.md
@@ -1,0 +1,53 @@
+# IAA Wave Record — PIT Project Implementation Tracker Routing
+
+| Field | Value |
+|---|---|
+| Wave ID | `pit-project-implementation-tracker-routing` |
+| Governing issue | `#1810` |
+| Scope | Product routing and wording fix for PIT module entry |
+| Posture | `IMPLEMENTATION_FOR_REVIEW` |
+
+## PRE-BRIEF
+
+```yaml
+IAA_PREFLIGHT_BRIEF:
+  schema_version: "1.0.0"
+  wave: "pit-project-implementation-tracker-routing"
+  pr: "#1835"
+  issue: "#1810"
+  branch: "pit-nav-copy-fix"
+  qualifying_tasks:
+    - task_id: "pit-module-navigation-wording"
+      summary: "Route entitled Project Implementation users to the PIT tracker and correct PIT wording."
+      assurance_category: "product-routing-copy-boundary"
+  required_build_gates:
+    - "Routing Governance Check"
+    - "Deploy ISMS Portal to Vercel"
+    - "POLC Boundary Validation"
+  expected_qa_scope:
+    - "Entitled Project Implementation dashboard tile opens /pit/tracker."
+    - "Non-entitled Project Implementation dashboard tile keeps subscription upgrade path."
+    - "PIT marketing copy says Project Implementation Tracker."
+    - "Public marketing and subscription routes remain public."
+  high_risk_failure_modes:
+    - "Dashboard Project Implementation tile loops back to marketing/subscription after entitlement."
+    - "PIT acronym is expanded incorrectly."
+    - "Subscription flow is bypassed for non-entitled users."
+  required_builder_evidence:
+    - "Dashboard project-implementation entitlement path routes to ROUTES.PIT_TRACKER."
+    - "PITInfo copy uses Project Implementation Tracker."
+    - "No Supabase, billing, or subscription fixture files are changed."
+  required_foreman_qp_checks:
+    - "Verify entitled dashboard Project Implementation tile routes to /pit/tracker."
+    - "Verify non-entitled dashboard path still routes to subscribe upgrade."
+    - "Verify PIT marketing CTA routes to tracker only for authenticated entitled users."
+  ecap_required: false
+  ecap_expected_artifacts: []
+  final_iaa_focus:
+    - "Confirm no W8.2 completion claim is made."
+  result: PREFLIGHT_BRIEF_COMPLETE
+```
+
+## FINAL ASSURANCE
+
+PENDING. No final assurance, completion, or merge-readiness claim is made by this artifact.

--- a/.agent-admin/builder-appointments/pit-project-implementation-tracker-routing-builder.md
+++ b/.agent-admin/builder-appointments/pit-project-implementation-tracker-routing-builder.md
@@ -1,0 +1,34 @@
+# Builder Appointment — PIT Project Implementation Tracker Routing
+
+| Field | Value |
+|---|---|
+| Wave ID | `pit-project-implementation-tracker-routing` |
+| Governing issue | `#1810` |
+| Appointed builder | `pit-specialist` |
+| Builder resource | `copilot-builder-resource` |
+| Appointment status | `APPOINTED` |
+| Posture | `IMPLEMENTATION_FOR_REVIEW` |
+
+## Preconditions
+
+IAA pre-brief is recorded in:
+
+```text
+.agent-admin/assurance/iaa-wave-record-pit-project-implementation-tracker-routing.md
+```
+
+## Builder task
+
+- Change PIT wording from Process Integrity Testing to Project Implementation Tracker.
+- Route entitled dashboard Project Implementation clicks to `/pit/tracker`.
+- Keep non-entitled Project Implementation users on subscription/upgrade path.
+- Update PIT marketing CTA so authenticated entitled users can open Project Implementation Tracker.
+- Preserve public marketing/subscription flow.
+
+## Boundaries
+
+- No Supabase changes.
+- No billing or subscription fixture changes.
+- No W8.2 completion claim.
+
+RESULT: BUILDER_APPOINTED

--- a/.agent-admin/control/delegation-order.json
+++ b/.agent-admin/control/delegation-order.json
@@ -1,6 +1,5 @@
 {
   "schema_version": "1.0.0",
-<<<<<<< pit-nav-copy-fix
   "wave_id": "pit-nav-copy",
   "pr_number": 1835,
   "prebrief_commit_sha": "21501dd7a1af3117bae46d2cc083db5e06778cdc",
@@ -10,16 +9,5 @@
   "builder_task_ref": "pit-nav-copy",
   "first_implementation_commit_sha": "17d6138a92f0157230091b55f1966ff0a750e411",
   "qp_review_timestamp": "2026-06-23T10:35:00Z",
-=======
-  "wave_id": "maturion-public-chat-gateway-v01",
-  "pr_number": 1836,
-  "prebrief_commit_sha": "935e8ba2c7e7a37846db90dbde9da8f4b4af71e1",
-  "builder_appointment_timestamp": "2026-06-23T10:20:00Z",
-  "builder_appointment_commit_sha": "9cecde7af6d02a949c19b12f7d91658d00412a4c",
-  "builder_agent": "api-builder",
-  "builder_task_ref": "public-chat-gateway-v01",
-  "first_implementation_commit_sha": "006289fb9629183ab31dd22112f22ef3346d21b0",
-  "qp_review_timestamp": "2026-06-23T10:30:00Z",
->>>>>>> main
   "result": "DELEGATION_ORDER_VERIFIED"
 }

--- a/.agent-admin/control/delegation-order.json
+++ b/.agent-admin/control/delegation-order.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.0.0",
-  "wave_id": "pit-w82-role-aware-route-authorization",
-  "pr_number": 1829,
-  "prebrief_commit_sha": "6ac2fb8b70f334005c45b6c619f1d74cc04ff78b",
-  "builder_appointment_timestamp": "2026-06-19T12:36:00Z",
-  "builder_appointment_commit_sha": "70c04a8a5777fb20435a59da1e3252e32c3cce33",
+  "wave_id": "pit-nav-copy",
+  "pr_number": 1835,
+  "prebrief_commit_sha": "21501dd7a1af3117bae46d2cc083db5e06778cdc",
+  "builder_appointment_timestamp": "2026-06-23T10:30:00Z",
+  "builder_appointment_commit_sha": "d019c168db115316b1a528f5f1998d6e40b60fc8",
   "builder_agent": "pit-specialist",
-  "builder_task_ref": "pit-w82-route-authorization",
-  "first_implementation_commit_sha": "2882f5cb8b4ff10e1792384fef7b2ccd8fafcc5d",
-  "qp_review_timestamp": "2026-06-22T07:40:00Z",
+  "builder_task_ref": "pit-nav-copy",
+  "first_implementation_commit_sha": "17d6138a92f0157230091b55f1966ff0a750e411",
+  "qp_review_timestamp": "2026-06-23T10:35:00Z",
   "result": "DELEGATION_ORDER_VERIFIED"
 }

--- a/.agent-workspace/foreman-v2/memory/session-pit-project-implementation-tracker-routing.md
+++ b/.agent-workspace/foreman-v2/memory/session-pit-project-implementation-tracker-routing.md
@@ -1,0 +1,38 @@
+# Foreman Session Memory — PIT Project Implementation Tracker Routing
+
+session_id: pit-project-implementation-tracker-routing
+wave_id: pit-project-implementation-tracker-routing
+governing_issue: #1810
+governed_role: FOREMAN
+execution_mode: implementation_wave_supervision
+
+agents_delegated_to:
+  - pit-specialist: implement dashboard navigation and PIT copy correction for Project Implementation Tracker routing
+  - copilot-builder-resource: execute bounded code patch under pit-specialist delegation if direct specialist execution is unavailable
+
+## Gate model
+
+Implementation-only work is not handover. Handover, completion, release, and merge-readiness language remain gated.
+
+## Delegation order
+
+1. IAA pre-brief recorded in `.agent-admin/assurance/iaa-wave-record-pit-project-implementation-tracker-routing.md`.
+2. Builder appointment recorded in `.agent-admin/builder-appointments/pit-project-implementation-tracker-routing-builder.md`.
+3. Builder implementation commits follow the pre-brief and appointment.
+4. Foreman/QP review follows implementation and checks.
+
+## Implementation scope
+
+- Change PIT wording from Process Integrity Testing to Project Implementation Tracker.
+- Route entitled dashboard Project Implementation clicks to `/pit/tracker`.
+- Keep non-entitled Project Implementation users on subscription/upgrade path.
+- Update PIT marketing CTA so authenticated entitled users can open Project Implementation Tracker.
+- Preserve public marketing/subscription flow.
+
+## Explicit exclusions
+
+- No Supabase changes.
+- No billing or subscription fixture changes.
+- No W8.2 completion claim.
+
+Current posture: IMPLEMENTATION_FOR_REVIEW; W8.2_NOT_READY.

--- a/apps/isms-portal/src/pages/Dashboard.tsx
+++ b/apps/isms-portal/src/pages/Dashboard.tsx
@@ -20,7 +20,7 @@ const moduleLabels: Record<IsmsModuleKey, { title: string; description: string; 
     marketingRoute: ROUTES.MARKETING_RISK_MANAGEMENT,
   },
   'project-implementation': {
-    title: 'Project Implementation',
+    title: 'Project Implementation Tracker',
     description: 'Track security improvement projects and implementation evidence.',
     marketingRoute: ROUTES.MARKETING_PROJECT_IMPLEMENTATION,
   },
@@ -60,6 +60,11 @@ const Dashboard = () => {
       const handoff = createMaturityRoadmapHandoff(entitlement);
       storeMaturityRoadmapHandoff(handoff);
       navigate(ROUTES.MATURITY_SETUP);
+      return;
+    }
+
+    if (moduleKey === 'project-implementation') {
+      navigate(ROUTES.PIT_TRACKER);
       return;
     }
 

--- a/apps/isms-portal/src/pages/PITInfo.tsx
+++ b/apps/isms-portal/src/pages/PITInfo.tsx
@@ -2,39 +2,46 @@ import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { useAuth } from '@/context/AuthContext';
+import { useIsms } from '@/context/IsmsContext';
+import { hasModuleEntitlement } from '@/lib/entitlements';
+import { ROUTES } from '@/lib/routes';
 import { Wrench, CheckCircle2, ArrowRight, Shield, Target, BarChart } from 'lucide-react';
 
 /**
- * Process Integrity Testing (PIT) - Marketing/Information Page
+ * Project Implementation Tracker (PIT) - Marketing/Information Page
  * Pre-subscription page explaining the PIT module
  */
 const PITInfo = () => {
   const navigate = useNavigate();
+  const { user } = useAuth();
+  const { entitlement } = useIsms();
+  const canOpenTracker = Boolean(user) && hasModuleEntitlement(entitlement, 'project-implementation');
 
   const features = [
-    "Automated process testing and validation",
+    "Project implementation tracking and validation",
     "Control effectiveness measurement",
-    "Continuous process monitoring",
+    "Continuous project evidence monitoring",
     "Integration with audit frameworks",
-    "Process deviation alerts",
+    "Implementation deviation alerts",
     "Compliance tracking and reporting"
   ];
 
   const benefits = [
     {
       icon: Shield,
-      title: "Process Assurance",
-      description: "Ensure your processes work as designed every time"
+      title: "Implementation Assurance",
+      description: "Ensure your security improvement projects work as designed"
     },
     {
       icon: Target,
       title: "Control Effectiveness",
-      description: "Measure and improve the effectiveness of your controls"
+      description: "Measure and improve the effectiveness of implementation controls"
     },
     {
       icon: BarChart,
       title: "Audit Readiness",
-      description: "Stay audit-ready with continuous process validation"
+      description: "Stay audit-ready with project evidence and implementation validation"
     }
   ];
 
@@ -48,9 +55,9 @@ const PITInfo = () => {
         <div className="inline-flex items-center justify-center w-20 h-20 bg-blue-100 dark:bg-blue-900/20 rounded-full mb-6">
           <Wrench className="h-10 w-10 text-blue-600 dark:text-blue-400" />
         </div>
-        <h1 className="text-4xl font-bold mb-4">Process Integrity Testing (PIT)</h1>
+        <h1 className="text-4xl font-bold mb-4">Project Implementation Tracker (PIT)</h1>
         <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-          Systematic workflows, quality controls, and operational consistency through continuous testing
+          Track security improvement projects, implementation evidence, and operational consistency
         </p>
       </div>
 
@@ -60,7 +67,7 @@ const PITInfo = () => {
           <CardHeader>
             <CardTitle>Key Features</CardTitle>
             <CardDescription>
-              Comprehensive process testing capabilities
+              Project implementation tracking capabilities
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -77,9 +84,9 @@ const PITInfo = () => {
 
         <Card>
           <CardHeader>
-            <CardTitle>Why Process Integrity Testing?</CardTitle>
+            <CardTitle>Why Project Implementation Tracker?</CardTitle>
             <CardDescription>
-              Ensure operational excellence through systematic testing
+              Ensure operational excellence through systematic implementation tracking
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -103,16 +110,16 @@ const PITInfo = () => {
         <CardHeader>
           <CardTitle>How It Works</CardTitle>
           <CardDescription>
-            A systematic approach to process integrity validation
+            A systematic approach to project implementation validation
           </CardDescription>
         </CardHeader>
         <CardContent>
           <div className="grid md:grid-cols-4 gap-6">
             {[
-              { step: 1, title: "Define", desc: "Map your critical processes and controls" },
-              { step: 2, title: "Test", desc: "Execute automated and manual tests" },
-              { step: 3, title: "Monitor", desc: "Track process performance continuously" },
-              { step: 4, title: "Improve", desc: "Optimize based on test results" }
+              { step: 1, title: "Define", desc: "Map your critical projects and implementation controls" },
+              { step: 2, title: "Track", desc: "Capture implementation activity and evidence" },
+              { step: 3, title: "Monitor", desc: "Track project performance continuously" },
+              { step: 4, title: "Improve", desc: "Optimize based on implementation results" }
             ].map((item) => (
               <div key={item.step} className="text-center">
                 <div className="w-12 h-12 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xl font-bold mx-auto mb-3">
@@ -131,17 +138,21 @@ const PITInfo = () => {
         <CardContent className="pt-6">
           <div className="flex flex-col md:flex-row items-center justify-between gap-4">
             <div>
-              <h3 className="text-xl font-bold mb-2">Ready to Get Started?</h3>
+              <h3 className="text-xl font-bold mb-2">
+                {canOpenTracker ? 'Open Project Implementation Tracker' : 'Ready to Get Started?'}
+              </h3>
               <p className="text-muted-foreground">
-                Subscribe to unlock Process Integrity Testing and ensure operational excellence
+                {canOpenTracker
+                  ? 'Open the protected Project Implementation Tracker workspace for your entitled module.'
+                  : 'Subscribe to unlock Project Implementation Tracker and manage implementation evidence'}
               </p>
             </div>
-            <Button 
-              size="lg" 
+            <Button
+              size="lg"
               className="flex-shrink-0"
-              onClick={() => navigate('/subscribe')}
+              onClick={() => navigate(canOpenTracker ? ROUTES.PIT_TRACKER : ROUTES.SUBSCRIBE)}
             >
-              Subscribe Now
+              {canOpenTracker ? 'Open Project Implementation Tracker' : 'Subscribe Now'}
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
           </div>


### PR DESCRIPTION
Small product-routing and wording fix for the PIT module journey.

Scope:
- change PIT wording from Process Integrity Testing to Project Implementation Tracker
- route entitled Project Implementation dashboard clicks to /pit/tracker
- keep non-entitled Project Implementation users on the subscription upgrade path
- update PIT marketing CTA so authenticated entitled users can open Project Implementation Tracker
- preserve public marketing and subscription routes
- no Supabase changes
- no billing or subscription fixture changes
- no W8.2 completion claim

Current posture: implementation for review; W8.2 remains NOT_READY until deployed route evidence is captured after merge.