### PR TITLE
MMM published maturity model view QA-to-red

### DIFF
--- a/.agent-admin/assurance/iaa-wave-record-wave-mmm-published-model-qa-red-2026-06-23.md
+++ b/.agent-admin/assurance/iaa-wave-record-wave-mmm-published-model-qa-red-2026-06-23.md
@@ -1,0 +1,61 @@
+# IAA Wave Record - MMM Published Model QA-to-Red
+
+Wave: `wave-mmm-published-model-qa-red-2026-06-23`
+Date: 2026-06-23
+Repository: `APGI-cmy/maturion-isms`
+Branch: `foreman/mmm-published-model-qa-red`
+Scope record: `.agent-admin/scope-declarations/wave-mmm-published-model-qa-red-2026-06-23.md`
+
+## PRE-BRIEF
+
+EXPECTED_QA_SCOPE:
+- Verify QA-to-red covers published model visibility only after final approval/final lock.
+- Verify QA-to-red covers collapsible MPS-first view and drilldown layers.
+- Verify QA-to-red covers criterion cards, current/next maturity tabs, and descriptor modal expectations.
+- Verify QA-to-red covers evidence management and AI question placeholders without implementing runtime evidence/AI behavior.
+- Verify QA-to-red covers read-only behavior, traceability, authorization boundaries, and error states.
+
+EXPECTED_FAILURE_MODES:
+- Publishing a model before final approval/final lock.
+- Allowing published view to mutate final-approved content.
+- Losing traceability between domain, MPS, intent, criterion, and descriptor layers.
+- Implementing evidence modal or AI runtime behavior in this QA-to-red wave.
+- Omitting authorization boundaries for published model access.
+- Implementing runtime UI/API behavior in this QA-to-red wave.
+
+FOREMAN_INSTRUCTIONS:
+- Keep this wave to scope, IAA pre-brief, builder record, and QA-to-red artifacts.
+- Do not implement published model UI, API routes, database migrations, evidence modal, AI question runtime, or approval workflow runtime behavior in this wave.
+- QA-to-red must be specific enough for the next implementation wave to convert into executable tests before code.
+
+IAA_WILL_QA:
+- IAA will check that the QA-to-red artifact derives from merged approval workflow and published view contracts.
+- IAA will check that this wave stays pre-code.
+- IAA will check that builder record exists before implementation work begins.
+- IAA will check that Step 6 does not leak into evidence modal harvest/adaptation implementation.
+
+RESULT: PREFLIGHT_BRIEF_COMPLETE
+
+```yaml
+IAA_PREFLIGHT_BRIEF:
+  schema_version: "1.0.0"
+  wave: "wave-mmm-published-model-qa-red-2026-06-23"
+  pr: "pending"
+  branch: "foreman/mmm-published-model-qa-red"
+  qualifying_tasks:
+    - "Create QA-to-red for published model visibility and read-only behavior."
+    - "Create QA-to-red for collapsible MPS-first view and drilldown layers."
+    - "Create QA-to-red for criterion cards, maturity tabs, descriptor modal, evidence placeholder, and AI question placeholder."
+  required_build_gates:
+    - "No runtime code changes."
+    - "No database migrations."
+    - "No API implementation."
+    - "No evidence modal implementation."
+    - "No UI implementation."
+  expected_qa_scope:
+    - "Final-approved/final-locked published model access."
+    - "Collapsible published model navigation."
+    - "Criterion detail cards and maturity tabs."
+    - "Traceability, authorization, and read-only boundaries."
+  result: "PREFLIGHT_BRIEF_COMPLETE"
+```

--- a/.agent-admin/builder-appointments/wave-mmm-published-model-qa-red-2026-06-23.md
+++ b/.agent-admin/builder-appointments/wave-mmm-published-model-qa-red-2026-06-23.md
@@ -1,0 +1,50 @@
+# Builder Record - MMM Published Model QA-to-Red
+
+Wave: `wave-mmm-published-model-qa-red-2026-06-23`
+Date: 2026-06-23
+Repository: `APGI-cmy/maturion-isms`
+Branch: `foreman/mmm-published-model-qa-red`
+Builder role: `qa-to-red-builder`
+
+## Task
+
+Create QA-to-red coverage for Step 6: published maturity model view before implementation code is written.
+
+## Required coverage
+
+- Final-approved/final-locked model visibility.
+- Published model route or entry point.
+- Read-only behavior after final lock.
+- Collapsible MPS-first view.
+- MPS to intent to criteria to descriptors drilldown.
+- Criterion cards.
+- Current maturity level tab.
+- Next maturity level tab.
+- Maturity descriptor modal.
+- Evidence management entry point placeholder.
+- AI question interface placeholder.
+- Domain to MPS to criterion to descriptor traceability.
+- Authorization boundaries.
+- Empty/loading/error states.
+- No mutation from published view.
+
+## Boundaries
+
+This record allows QA-to-red artifacts only.
+
+Not in scope:
+
+- UI implementation.
+- Database migrations.
+- API routes or edge functions.
+- Evidence management modal.
+- MAT evidence harvest.
+- AI question runtime behavior.
+- Maturity scoring or evidence scoring.
+- Approval workflow runtime behavior.
+
+## Required output location
+
+```text
+modules/MMM/approval-workflow/
+```

--- a/.agent-admin/scope-declarations/wave-mmm-published-model-qa-red-2026-06-23.md
+++ b/.agent-admin/scope-declarations/wave-mmm-published-model-qa-red-2026-06-23.md
@@ -1,0 +1,82 @@
+# MMM Published Maturity Model View QA-to-Red Scope
+
+Wave: `wave-mmm-published-model-qa-red-2026-06-23`
+Date: 2026-06-23
+Repository: `APGI-cmy/maturion-isms`
+Branch: `foreman/mmm-published-model-qa-red`
+Module scope: MMM published maturity model view
+Lane: QA-to-red / pre-build preparation
+CS2 Authority: Johan Ras
+Foreman role: scope, assurance, delegation, and QA-to-red coordination
+
+## Objective
+
+Prepare Step 6 of the MMM approval workflow sequence by establishing scope, IAA pre-brief, builder record, and QA-to-red coverage before any implementation code.
+
+This wave covers Step 6 in the CS2-approved sequence:
+
+1. Gap analysis / pre-build alignment for the approval workflow. Completed by PR #1831.
+2. Database/API contract for approval rounds, approvers, proposed edits, comments, notifications, and locks. Completed by PR #1833.
+3. Level 2 invite modal and approval workspace QA-to-red. Completed by PR #1837.
+4. Change summary e-mail and accept/reject/apply flow QA-to-red. Completed by PR #1838.
+5. Level 3 approval expansion QA-to-red. Completed by PR #1840.
+6. Published maturity model view. This wave prepares QA-to-red before code.
+
+## Authority inputs
+
+- `modules/MMM/approval-workflow/approval-workflow-prebuild-contract.md`
+- `modules/MMM/approval-workflow/approval-workflow-db-api-contract.md`
+- `modules/MMM/approval-workflow/approval-workflow-notification-lock-contract.md`
+- `modules/MMM/approval-workflow/approval-workflow-qa-to-red.md`
+- `modules/MMM/approval-workflow/level2-invite-workspace-qa-to-red.md`
+- `modules/MMM/approval-workflow/change-summary-accept-reject-apply-qa-to-red.md`
+- `modules/MMM/approval-workflow/level3-approval-expansion-qa-to-red.md`
+- Uploaded `The Maturity Roadmap(5).docx`
+- CS2 instruction to proceed with Step 6 QA-to-red before implementation.
+
+## Bounded file scope for this QA-to-red wave
+
+QA-to-red artifacts may be added under:
+
+- `modules/MMM/approval-workflow/`
+
+Required governance / assurance / delegation records for this wave may be added under:
+
+- `.agent-admin/scope-declarations/`
+- `.agent-admin/assurance/`
+- `.agent-admin/builder-appointments/`
+
+## Required QA-to-red coverage
+
+This wave must define failing tests for:
+
+- final-approved / final-locked model visibility;
+- published model route or entry point;
+- read-only post-final-lock behavior;
+- collapsible MPS-first view;
+- drilldown from MPS to intent statement to criteria to descriptors;
+- criterion cards;
+- current maturity level tab;
+- next maturity level tab;
+- maturity descriptor modal;
+- evidence management entry point placeholder;
+- AI question interface placeholder;
+- domain to MPS to criterion to descriptor traceability;
+- authorization boundaries for published model access;
+- empty/loading/error states;
+- no mutation of final-approved model content from published view.
+
+## Out of scope
+
+- Implementing published model UI components.
+- Implementing database migrations.
+- Implementing API routes or edge functions.
+- Implementing evidence management modal.
+- Implementing MAT evidence harvest/adaptation.
+- Implementing AI question runtime behavior.
+- Implementing maturity scoring or evidence scoring.
+- Implementing approval workflow runtime behavior.
+
+## Lane note
+
+This wave is QA-to-red only. Implementation may start only after QA-to-red has been committed and delegated against this scope.

--- a/modules/MMM/approval-workflow/published-model-view-qa-to-red.md
+++ b/modules/MMM/approval-workflow/published-model-view-qa-to-red.md
@@ -1,0 +1,295 @@
+# MMM Published Maturity Model View QA-to-Red
+
+Status: QA-to-red artifact
+Date: 2026-06-23
+Wave: `wave-mmm-published-model-qa-red-2026-06-23`
+CS2 Authority: Johan Ras
+
+## 1. Purpose
+
+This artifact defines failing test expectations for Step 6 of the MMM approval workflow: published maturity model view.
+
+It is intentionally pre-code. It does not implement published model UI, database migrations, API routes, edge functions, evidence management modal, MAT evidence harvest, AI question runtime, maturity scoring, evidence scoring, or approval workflow runtime behavior.
+
+## 2. Authority inputs
+
+- `approval-workflow-prebuild-contract.md`
+- `approval-workflow-db-api-contract.md`
+- `approval-workflow-notification-lock-contract.md`
+- `approval-workflow-qa-to-red.md`
+- `level2-invite-workspace-qa-to-red.md`
+- `change-summary-accept-reject-apply-qa-to-red.md`
+- `level3-approval-expansion-qa-to-red.md`
+- CS2 instruction to proceed with Step 6 QA-to-red before implementation.
+
+## 3. Feature under test
+
+After final approval and final lock, the user must be able to view a published maturity model per domain/framework.
+
+The published view must provide a collapsible structure that starts with MPSs and progressively exposes:
+
+1. MPSs only.
+2. MPS plus intent statement.
+3. MPS plus intent plus criteria.
+4. Criterion detail with maturity descriptors.
+5. Criterion detail with evidence management entry point.
+
+The view must be read-only with respect to final-approved maturity model content. Evidence management and AI question interfaces may appear as entry points/placeholders in this step but must not be implemented in this QA-to-red wave.
+
+## 4. Red tests — Published visibility and entry point
+
+### T-MMM-PUBLISHED-001 — Published view hidden before final approval
+
+Given a roadmap/control standard has not reached final approval,
+when a user attempts to open the published model route,
+then access must be blocked or the route must show a not-published state.
+
+### T-MMM-PUBLISHED-002 — Published view visible after final lock
+
+Given a roadmap/control standard is final approved and final locked,
+when an authorized user opens the published model route,
+then the published maturity model view must be available.
+
+### T-MMM-PUBLISHED-003 — Published view displays framework/domain identity
+
+Given the published view loads,
+then it must show framework name, domain name where applicable, publication status, and final approval state.
+
+### T-MMM-PUBLISHED-004 — Published view is read-only
+
+Given the published model is final locked,
+then the published view must not expose direct editing controls for domain, MPS, intent, criterion, or descriptor content.
+
+### T-MMM-PUBLISHED-005 — Published view cannot mutate canonical content
+
+Given a user interacts with published view navigation, tabs, modals, or placeholders,
+then canonical maturity model content must remain unchanged.
+
+## 5. Red tests — Collapsible MPS-first navigation
+
+### T-MMM-PUBLISHED-NAV-001 — Initial view shows MPS list
+
+Given the published model loads,
+then the first visible layer must show the list of MPSs for the selected domain/framework scope.
+
+### T-MMM-PUBLISHED-NAV-002 — MPS expansion reveals intent statement
+
+Given an MPS is collapsed,
+when the user expands it,
+then the MPS intent statement must become visible.
+
+### T-MMM-PUBLISHED-NAV-003 — Criteria expansion reveals criteria under correct MPS
+
+Given an expanded MPS has criteria,
+when the user expands the criteria layer,
+then each criterion must render under the correct MPS with a stable reference/sequence.
+
+### T-MMM-PUBLISHED-NAV-004 — Descriptor expansion reveals maturity descriptors
+
+Given a criterion has maturity descriptors,
+when the user expands criterion detail,
+then maturity descriptors must be visible by maturity level.
+
+### T-MMM-PUBLISHED-NAV-005 — Collapse preserves navigation context
+
+Given the user drills down to a criterion descriptor and collapses back up,
+then the view must preserve enough context to return to the same MPS/criterion without losing state unexpectedly.
+
+## 6. Red tests — Traceability and display references
+
+### T-MMM-PUBLISHED-TRACE-001 — MPS reference is visible
+
+Given an MPS appears in the published view,
+then its stable MPS number/reference and name must be visible.
+
+### T-MMM-PUBLISHED-TRACE-002 — Criterion reference is visible
+
+Given a criterion appears in the published view,
+then its reference must include MPS context and criterion sequence.
+
+### T-MMM-PUBLISHED-TRACE-003 — Descriptor reference is visible
+
+Given a maturity descriptor appears,
+then its reference must include domain/MPS/criterion and maturity level context.
+
+### T-MMM-PUBLISHED-TRACE-004 — Deep link preserves traceability
+
+Given a user opens a deep link to a criterion or descriptor,
+then the page must show the correct domain, MPS, criterion, and descriptor context.
+
+### T-MMM-PUBLISHED-TRACE-005 — Search or filter does not break traceability
+
+Given future search/filter behavior is added,
+then filtered results must still show domain/MPS/criterion/descriptor context.
+
+## 7. Red tests — Criterion card behavior
+
+### T-MMM-PUBLISHED-CRITERION-001 — Criterion card shows statement and status
+
+Given a criterion card renders,
+then it must show criterion statement/reference and current maturity/status information if available.
+
+### T-MMM-PUBLISHED-CRITERION-002 — Criterion card shows current maturity level tab
+
+Given criterion detail opens,
+then a current maturity level tab must be present.
+
+### T-MMM-PUBLISHED-CRITERION-003 — Criterion card shows next maturity level tab
+
+Given criterion detail opens,
+then a next maturity level tab must be present.
+
+### T-MMM-PUBLISHED-CRITERION-004 — Current level tab explains current position
+
+Given the current maturity level tab is selected,
+then it must show what the current level is and why that level is represented.
+
+### T-MMM-PUBLISHED-CRITERION-005 — Next level tab explains next requirement
+
+Given the next maturity level tab is selected,
+then it must show what is required to progress to the next level.
+
+### T-MMM-PUBLISHED-CRITERION-006 — Criterion card links to descriptor modal
+
+Given criterion detail renders,
+then the user must be able to open a maturity descriptor modal for all descriptor levels.
+
+## 8. Red tests — Maturity descriptor modal
+
+### T-MMM-PUBLISHED-DESCRIPTOR-001 — Descriptor modal shows all maturity levels
+
+Given the descriptor modal opens,
+then it must show Basic, Reactive, Compliant, Proactive, and Resilient descriptors where available.
+
+### T-MMM-PUBLISHED-DESCRIPTOR-002 — Descriptor modal highlights current level
+
+Given current maturity level information exists,
+then the descriptor modal must indicate the current level.
+
+### T-MMM-PUBLISHED-DESCRIPTOR-003 — Descriptor modal shows next level target
+
+Given next maturity level information exists,
+then the descriptor modal must indicate the next target level.
+
+### T-MMM-PUBLISHED-DESCRIPTOR-004 — Descriptor modal remains read-only
+
+Given the model is final locked,
+then descriptor modal content must not be editable from the published view.
+
+## 9. Red tests — Evidence management entry point placeholder
+
+### T-MMM-PUBLISHED-EVIDENCE-001 — Evidence entry point visible on criterion card
+
+Given a criterion card is visible,
+then an evidence management entry point must be visible or reserved for the criterion.
+
+### T-MMM-PUBLISHED-EVIDENCE-002 — Evidence entry point preserves criterion context
+
+Given the user activates the evidence entry point,
+then the future evidence modal route/action expectation must include domain, MPS, criterion, and descriptor context where applicable.
+
+### T-MMM-PUBLISHED-EVIDENCE-003 — Evidence entry point does not implement evidence upload in this wave
+
+Given this is the published model QA-to-red wave,
+then tests must not require evidence upload runtime behavior.
+
+### T-MMM-PUBLISHED-EVIDENCE-004 — Evidence placeholder is disabled or marked future-ready when runtime missing
+
+Given evidence runtime is not implemented,
+then the UI expectation must either disable the entry point or mark it as future-ready without breaking published view navigation.
+
+## 10. Red tests — AI question interface placeholder
+
+### T-MMM-PUBLISHED-AI-001 — AI question entry point visible on criterion detail
+
+Given criterion detail renders,
+then an AI question interface entry point or placeholder must be visible.
+
+### T-MMM-PUBLISHED-AI-002 — AI question context includes selected criterion
+
+Given the AI question entry point is activated,
+then the future AI request expectation must include domain, MPS, criterion, current level, and next level context.
+
+### T-MMM-PUBLISHED-AI-003 — AI question runtime is not implemented in this wave
+
+Given this is the published model QA-to-red wave,
+then tests must not require live AI question execution.
+
+### T-MMM-PUBLISHED-AI-004 — AI placeholder does not mutate maturity score
+
+Given the AI placeholder is viewed or activated,
+then maturity score, descriptor content, and final-approved model content must remain unchanged.
+
+## 11. Red tests — Authorization and read-only boundaries
+
+### T-MMM-PUBLISHED-AUTH-001 — Unauthorized user cannot view unpublished/final-private model
+
+Given a user lacks access to the organisation/framework,
+when they attempt to open the published view,
+then access must be denied.
+
+### T-MMM-PUBLISHED-AUTH-002 — Authorized user can view final published model
+
+Given a user has authorized access,
+when they open the final published model,
+then view access must be allowed.
+
+### T-MMM-PUBLISHED-AUTH-003 — Viewer cannot perform approval actions from published view
+
+Given a user is in the published model view,
+then Level 2/Level 3 approval actions must not be available from that view.
+
+### T-MMM-PUBLISHED-AUTH-004 — Viewer cannot edit model structure from published view
+
+Given a user is in the published model view,
+then controls to edit domains, MPS, intent statements, criteria, or descriptors must not be available.
+
+## 12. Red tests — Loading, empty, and error states
+
+### T-MMM-PUBLISHED-STATE-001 — Loading state visible
+
+Given the published model data is loading,
+then a loading state must be visible.
+
+### T-MMM-PUBLISHED-STATE-002 — Empty model state visible
+
+Given a final-approved model has no available published content due to data inconsistency,
+then an empty/error state must be visible rather than a blank page.
+
+### T-MMM-PUBLISHED-STATE-003 — Fetch error state visible
+
+Given the published model data fails to load,
+then a visible error state and retry expectation must exist.
+
+### T-MMM-PUBLISHED-STATE-004 — Partial data state preserves available traceability
+
+Given some descriptors or criteria fail to load,
+then available domain/MPS/criterion context must remain visible and missing data must be clearly marked.
+
+## 13. Non-goals for this QA-to-red wave
+
+The future implementation wave must not use these tests to implement:
+
+- evidence upload runtime;
+- MAT evidence harvest/adaptation;
+- AI question runtime;
+- evidence scoring;
+- maturity scoring recalculation;
+- approval workflow runtime actions;
+- database migrations or API endpoints beyond test expectations.
+
+## 14. Acceptance criteria for this QA-to-red artifact
+
+This artifact is complete when a future builder can convert these expectations into executable failing tests before implementing:
+
+- published model visibility after final approval/final lock;
+- read-only published model access;
+- collapsible MPS-first navigation;
+- drilldown to intent, criteria, and descriptors;
+- criterion cards;
+- current and next maturity tabs;
+- maturity descriptor modal;
+- evidence management and AI question placeholders;
+- traceability and deep-link context;
+- authorization, loading, empty, and error states;
+- no mutation of final-approved model content from the published view.


### PR DESCRIPTION
QA-to-red preparation PR for Step 6 of the MMM approval workflow sequence.

Scope:

- scope record for published maturity model view QA-to-red;
- canonical IAA pre-brief;
- builder record for QA-to-red work;
- QA-to-red artifact for published maturity model view.

This PR intentionally does not implement published model UI components, database migrations, API routes, edge functions, evidence management modal, MAT evidence harvest, AI question runtime, maturity scoring, evidence scoring, or approval workflow runtime behavior.

This PR prepares Step 6 only:

6. Published maturity model view.

It covers QA-to-red before code. The next implementation PR should convert these expectations into executable failing tests before building runtime behavior.