### PR TITLE
Layer down Maturion Agent Network Organigram canon

### DIFF
--- a/.agent-admin/prehandover/PREHANDOVER_PROOF_LAYER_DOWN_91ACE344_ISSUE_1851.md
+++ b/.agent-admin/prehandover/PREHANDOVER_PROOF_LAYER_DOWN_91ACE344_ISSUE_1851.md
@@ -1,0 +1,51 @@
+# PREHANDOVER PROOF — Layer-Down 91ace344 / Issue #1851
+
+**Repository**: `APGI-cmy/maturion-isms`  
+**Issue**: #1851  
+**Source Repository**: `APGI-cmy/maturion-foreman-governance`  
+**Source Commit**: `91ace34412e34836e3db5aa4373ea45409fff7c1`  
+**Changed Artifact**: `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`  
+**Final State**: READY_FOR_REVIEW  
+**Agent Contract Files Changed**: No
+
+---
+
+## Scope
+
+Layer down the Maturion Agent Network Organigram canon into `maturion-isms` as a non-agent governance awareness update.
+
+Files added in this consumer wave:
+
+- `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`
+- `governance/alignment/layer-down-91ace344-maturion-agent-network-organigram.json`
+- `.agent-admin/prehandover/PREHANDOVER_PROOF_LAYER_DOWN_91ACE344_ISSUE_1851.md`
+
+---
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Source issue reviewed | PASS |
+| Changed artifact is non-agent governance canon | PASS |
+| `.github/agents/*.md` untouched | PASS |
+| Consumer canon awareness file added | PASS |
+| Alignment inventory addendum added | PASS |
+| No executable artifact changed | PASS |
+| No runtime specialist activated | PASS |
+| No Supabase or runtime code changed | PASS |
+| No Maturion-as-CS2 authority granted | PASS |
+
+---
+
+## Consumer Impact
+
+This layer-down affects future `maturion-isms` work involving Maturion runtime grounding, AIMC, MMM/Maturity Roadmap, MAT, PIT, specialist routing, runtime registries, tenant knowledge boundaries and memory rules.
+
+The wave intentionally does not implement routing, retrieval, registry, Supabase, tenant, memory, agent-contract or App Management Centre changes.
+
+---
+
+## Closure Note
+
+Issue #1851 may be closed after the ripple PR for this branch is merged to `main` and the governance-liaison/FM approval path is satisfied.

--- a/governance/alignment/layer-down-91ace344-maturion-agent-network-organigram.json
+++ b/governance/alignment/layer-down-91ace344-maturion-agent-network-organigram.json
@@ -1,0 +1,23 @@
+{
+  "record_type": "GOVERNANCE_ALIGNMENT_INVENTORY_ADDENDUM",
+  "repository": "APGI-cmy/maturion-isms",
+  "layer_down_issue": 1851,
+  "source_repository": "APGI-cmy/maturion-foreman-governance",
+  "source_commit": "91ace34412e34836e3db5aa4373ea45409fff7c1",
+  "source_path": "governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md",
+  "artifact": {
+    "filename": "MATURION_AGENT_NETWORK_ORGANIGRAM.md",
+    "path": "governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md",
+    "canonical_version": "1.0.0",
+    "local_version": "1.0.0+consumer-awareness",
+    "canonical_hash_sha256": "702a6dc272c02b6741ada74e28ccfa05924c78b19465b6ac3dc9e42b13a83b92",
+    "local_hash_sha256": null,
+    "alignment_status": "LAYERED_DOWN_CONSUMER_AWARENESS",
+    "layer_down_status": "PUBLIC_API",
+    "last_verified": "2026-06-24T14:00:00Z",
+    "change_note": "Layer-down of Maturion agent-network organigram canon from governance commit 91ace344. Consumer copy records operative obligations for Maturion, AIMC, MMM, MAT, PIT and runtime specialist architecture. Full canonical text remains authoritative in governance repo."
+  },
+  "non_agent_change": true,
+  "requires_cs2_agent_contract_escalation": false,
+  "pre_handover_proof": ".agent-admin/prehandover/PREHANDOVER_PROOF_LAYER_DOWN_91ACE344_ISSUE_1851.md"
+}

--- a/governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md
+++ b/governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md
@@ -1,0 +1,156 @@
+# MATURION_AGENT_NETWORK_ORGANIGRAM
+
+**Status**: LAYERED-DOWN CANON AWARENESS COPY  
+**Canonical Status**: CANONICAL | Version 1.0.0 | Authority: CS2  
+**Effective Date**: 2026-06-24  
+**Canonical Source**: `APGI-cmy/maturion-foreman-governance/governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`  
+**Canonical Commit**: `91ace34412e34836e3db5aa4373ea45409fff7c1`  
+**Canonical SHA256**: `702a6dc272c02b6741ada74e28ccfa05924c78b19465b6ac3dc9e42b13a83b92`  
+**Layer-Down Issue**: `APGI-cmy/maturion-isms#1851`  
+**Layer-Down Status**: PUBLIC_API consumer awareness
+
+---
+
+## 1. Consumer Layer-Down Purpose
+
+This document layers down the canonical Maturion Agent Network Organigram into `APGI-cmy/maturion-isms`.
+
+The canonical source remains the governance repository. This consumer copy records the operative rules that affect this repository's Maturion, AIMC, MMM, MAT, PIT, runtime-specialist and build-governance work.
+
+---
+
+## 2. Canonical Principle
+
+```text
+One Maturion interface. Many governed capabilities behind it.
+```
+
+Users must experience Maturion as one coherent AI interface. Specialist routing, app context, knowledge retrieval, memory selection and agent delegation must remain governed behind the scenes unless transparency is required for trust, limitation disclosure, audit, approval or safety.
+
+---
+
+## 3. Mandatory Separation
+
+`maturion-isms` must distinguish two networks.
+
+### 3.1 Builder / Governance Agent Network
+
+Builder/governance agents operate around repos, PRs, pre-build artifacts, canon, gates, QA, evidence, delivery governance and future build orchestration.
+
+They answer:
+
+```text
+How do we safely plan, build, review, govern and merge platform work?
+```
+
+Examples include Foreman, Builder agents, IAA, ECAP, QP, CodexAdvisor/agent-factory roles, governance liaison roles and future Maturion-as-CS2 build orchestration.
+
+### 3.2 Runtime / Onboard App Agent Network
+
+Runtime/onboard app agents operate inside APGI products and applications through Maturion/AIMC.
+
+They answer:
+
+```text
+How does Maturion assist a user inside an app using governed subject knowledge, app context, tenant context, memory and specialist capability?
+```
+
+Examples relevant to this repository include Runtime Maturion, ISMS specialist, MMM/Maturity Roadmap specialist, MAT specialist, PIT specialist, risk-platform specialist, document-parser specialist, criteria-generator specialist, maturity-scoring specialist and report-writer specialist.
+
+### 3.3 Boundary Rule
+
+```text
+Build agents govern and build the system.
+Runtime agents operate inside the system for users.
+```
+
+`.github/agents` contracts may inform runtime design, but must not be silently converted into production runtime specialists. Runtime specialists require strategy alignment, canon coverage, registry design, knowledge-plane rules, security/tenant review, evidence and CS2 approval.
+
+---
+
+## 4. Maturion Position in ISMS/AIMC
+
+Runtime Maturion is not a hollow router. In `maturion-isms`, Maturion owns:
+
+1. app, embodiment, user, organisation, tenant, page/workflow and permission context assembly;
+2. governed knowledge-plane selection;
+3. Subject Knowledge Domain retrieval;
+4. Framework / Context Domain retrieval only when authenticated, authorised and scoped;
+5. specialist routing where specialist expertise is required;
+6. validation of specialist output against guardrails, tenant isolation, memory rules and authority boundaries;
+7. final synthesis into one user-facing answer;
+8. escalation when knowledge, authority, safety, permissions or specialist availability are insufficient.
+
+Specialists own deep-domain or app-specific reasoning inside declared boundaries.
+
+---
+
+## 5. Maturion-as-CS2 Authority
+
+The governance canon defines staged maturity levels for future Maturion-as-CS2 authority:
+
+1. Level 0 — Advisor.
+2. Level 1 — CS2 Proxy Evaluator.
+3. Level 2 — Delegated CS2 for low-risk governed actions.
+4. Level 3 — Operational CS2 Orchestrator.
+5. Level 4 — Autonomous CS2 with human override.
+
+This layer-down does not grant any CS2 authority to Maturion in `maturion-isms`. Any authority change requires separate canon, evidence, implementation and CS2 approval.
+
+---
+
+## 6. Runtime Specialist Lifecycle
+
+Runtime specialists must progress through explicit lifecycle states:
+
+```text
+PROPOSED
+  -> STRATEGY_DEFINED
+    -> STUB_CONTRACTED
+      -> KNOWLEDGE_BASED
+        -> RUNTIME_REGISTERED
+          -> ACTIVE
+            -> DEGRADED / DEPRECATED / RETIRED
+```
+
+No specialist in this repository may be treated as production-active merely because it is named in strategy, `.github/agents`, a registry stub, or a document.
+
+---
+
+## 7. ISMS/MMM/AIMC Ripple Duties
+
+This repository must account for the canon in future work touching:
+
+- Maturion runtime grounding;
+- AIMC gateway/runtime orchestration;
+- MMM knowledge retrieval and maturity-roadmap workflows;
+- MAT/PIT specialist routing;
+- runtime specialist registries;
+- Supabase/AIMC knowledge planes;
+- tenant isolation and memory boundaries;
+- App Management Centre / Maturion-as-CS2 integration points.
+
+Public or unauthenticated modes must not retrieve tenant/customer context. Tenant-scoped knowledge may only be used when authenticated, authorised and scoped.
+
+---
+
+## 8. Activation Prohibitions
+
+This layer-down does not:
+
+- activate any runtime specialist;
+- modify `.github/agents`;
+- create a runtime specialist registry;
+- implement retrieval or routing code;
+- mutate Supabase;
+- grant Maturion CS2 authority;
+- change tenant isolation or memory rules;
+- change PR gates.
+
+Those actions require separate governed waves.
+
+---
+
+## 9. Alignment Record
+
+This consumer copy is intentionally concise and records operative obligations. The full canonical text remains authoritative in `APGI-cmy/maturion-foreman-governance` at commit `91ace34412e34836e3db5aa4373ea45409fff7c1`.


### PR DESCRIPTION
## Summary

Closes #1851.

Layers down the governance artifact from `APGI-cmy/maturion-foreman-governance` commit `91ace34412e34836e3db5aa4373ea45409fff7c1`.

## Files added

- `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`
- `governance/alignment/layer-down-91ace344-maturion-agent-network-organigram.json`
- `.agent-admin/prehandover/PREHANDOVER_PROOF_LAYER_DOWN_91ACE344_ISSUE_1851.md`

## Boundary

Non-agent governance layer-down only. No `.github/agents/*.md` files, runtime code, database files, or executable artifacts are changed.