### PR TITLE
Maturion Runtime Agent Network Architecture Prebuild v0.1

### DIFF
--- a/.agent-admin/assurance/iaa-wave-record-mran-prebuild-v01-20260625.md
+++ b/.agent-admin/assurance/iaa-wave-record-mran-prebuild-v01-20260625.md
@@ -1,0 +1,68 @@
+# IAA Wave Record — MRAN Prebuild v0.1
+
+**Wave ID**: MRAN-PREBUILD-V01  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Date**: 2026-06-25  
+**Scope Declaration**: `.agent-admin/scope-declarations/maturion-runtime-agent-network-prebuild-v01.md`  
+**Related Artifacts**:
+
+- `Maturion/prebuild/runtime-agent-network/MRAN-FRS-v0.1.md`
+- `Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md`
+- `Maturion/prebuild/runtime-agent-network/MRAN-QA-to-Red-v0.1.md`
+
+---
+
+## PRE-BRIEF
+
+### 1. Assurance Context
+
+This pre-brief asks IAA to review Batch 1 architecture prebuild artifacts for the Maturion runtime agent network.
+
+The work is prebuild-only. It defines the runtime agent-network shape, context-envelope expectations, runtime registry architecture and QA-to-red expectations before any runtime implementation begins.
+
+### 2. Source Authority
+
+IAA should review against:
+
+- `FOREMAN_OPERATING_MODEL.md`;
+- `.github/agents/foreman-v2-agent.md`;
+- `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`;
+- `Maturion/strategy/Maturion_agent_network_organigram_strategy.md`;
+- existing Maturion/AIMC strategy and specialist-registry materials.
+
+### 3. Review Questions
+
+IAA should determine whether the Batch 1 artifacts:
+
+1. preserve the separation between builder/governance agents and runtime/onboard app agents;
+2. keep Maturion as the single user-facing runtime interface;
+3. prevent runtime specialists from being treated as active merely because they are named in strategy, canon, docs or `.github/agents`;
+4. define sufficient context-envelope requirements before routing;
+5. define sufficient runtime registry requirements before specialist invocation;
+6. define safe degradation when context, registry, permission, authority or knowledge-plane requirements are missing;
+7. prevent public/unauthenticated contexts from accessing tenant/customer knowledge;
+8. prevent Maturion-as-CS2 authority from being granted by runtime code or configuration alone;
+9. keep Batch 1 as prebuild-only, with no code, Supabase mutation, registry activation, specialist activation or `.github/agents` modification;
+10. provide adequate QA-to-red expectations for a later builder implementation wave.
+
+### 4. Known Non-Implementation Boundary
+
+This wave does not:
+
+- create runtime code;
+- alter application behaviour;
+- create or mutate Supabase tables;
+- create or activate runtime specialists;
+- create APW specialist;
+- create ISMS specialist;
+- change `.github/agents` files;
+- implement gateway routing;
+- implement retrieval;
+- implement memory writes;
+- grant Maturion CS2 authority.
+
+### 5. Requested IAA Output
+
+IAA should provide a later independent assurance verdict or rejection package after reviewing the prebuild artifact set.
+
+This file records the pre-brief only. It does not contain IAA final assurance, a merge verdict, or CS2 approval.

--- a/.agent-admin/assurance/iaa-wave-record-mran-prebuild-v01-20260625.md
+++ b/.agent-admin/assurance/iaa-wave-record-mran-prebuild-v01-20260625.md
@@ -3,9 +3,11 @@
 **Wave ID**: MRAN-PREBUILD-V01  
 **Repository**: `APGI-cmy/maturion-isms`  
 **Date**: 2026-06-25  
-**Scope Declaration**: `.agent-admin/scope-declarations/maturion-runtime-agent-network-prebuild-v01.md`  
+**Scope Declaration**: `.agent-admin/scope-declarations/pr-1855.md`  
 **Related Artifacts**:
 
+- `.agent-admin/scope-declarations/maturion-runtime-agent-network-prebuild-v01.md`
+- `.agent-admin/scope-declarations/pr-1855.md`
 - `Maturion/prebuild/runtime-agent-network/MRAN-FRS-v0.1.md`
 - `Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md`
 - `Maturion/prebuild/runtime-agent-network/MRAN-QA-to-Red-v0.1.md`
@@ -14,38 +16,58 @@
 
 ## PRE-BRIEF
 
-### 1. Assurance Context
+IAA_PREFLIGHT_BRIEF
 
-This pre-brief asks IAA to review Batch 1 architecture prebuild artifacts for the Maturion runtime agent network.
+schema_version: 1.0.0
+result: PREFLIGHT_BRIEF_COMPLETE
+wave_id: MRAN-PREBUILD-V01
+pr_number: 1855
+repository: APGI-cmy/maturion-isms
+scope_summary: Batch 1 prebuild-only architecture artifacts for the Maturion Runtime Agent Network.
+authority: CS2 — Johan Ras
 
-The work is prebuild-only. It defines the runtime agent-network shape, context-envelope expectations, runtime registry architecture and QA-to-red expectations before any runtime implementation begins.
+### EXPECTED_QA_SCOPE
 
-### 2. Source Authority
+- Review the scope declaration, FRS, TRS, and QA-to-Red artifacts for architectural completeness.
+- Confirm the work is prebuild-only and does not implement runtime code, Supabase changes, registry activation, specialist activation, or `.github/agents` changes.
+- Confirm the artifacts preserve the canonised separation between builder/governance agents and runtime/onboard app agents.
+- Confirm Runtime Maturion remains the single user-facing interface and final synthesiser.
+- Confirm context-envelope and runtime-registry requirements are sufficient to prevent unsafe specialist invocation.
+- Confirm QA-to-Red expectations are adequate for a later builder implementation wave.
 
-IAA should review against:
+### EXPECTED_FAILURE_MODES
 
-- `FOREMAN_OPERATING_MODEL.md`;
-- `.github/agents/foreman-v2-agent.md`;
-- `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`;
-- `Maturion/strategy/Maturion_agent_network_organigram_strategy.md`;
-- existing Maturion/AIMC strategy and specialist-registry materials.
+- Batch 1 artifacts accidentally create or imply runtime specialist activation.
+- Strategy-named or `.github/agents` agents are treated as runtime-active without registry activation.
+- Context envelope fields are insufficient to distinguish public, authenticated, tenant-scoped, superuser, and governance contexts.
+- Runtime registry records do not enforce status, app, embodiment, permission-scope, knowledge-plane, authority-limit, and guardrail checks.
+- Public or unauthenticated context could access tenant/customer knowledge.
+- Maturion-as-CS2 authority could be inferred from architecture, runtime code, config, or app context without separate canon-backed evidence.
+- QA-to-Red cases do not fail closed when context, registry, authority, or knowledge boundaries are missing.
 
-### 3. Review Questions
+### FOREMAN_INSTRUCTIONS
 
-IAA should determine whether the Batch 1 artifacts:
+- Treat this wave as prebuild-only.
+- Do not appoint a builder from this wave.
+- Do not implement code, migrations, schemas, registry storage, runtime routing, retrieval, memory writes, or specialist activation.
+- Do not modify `.github/agents` files.
+- Use IAA findings to correct prebuild artifacts before any implementation wave is created.
+- Keep Batch 2 knowledge-grounding prebuild and Batch 3 APW-specialist prebuild as separate future waves.
 
-1. preserve the separation between builder/governance agents and runtime/onboard app agents;
-2. keep Maturion as the single user-facing runtime interface;
-3. prevent runtime specialists from being treated as active merely because they are named in strategy, canon, docs or `.github/agents`;
-4. define sufficient context-envelope requirements before routing;
-5. define sufficient runtime registry requirements before specialist invocation;
-6. define safe degradation when context, registry, permission, authority or knowledge-plane requirements are missing;
-7. prevent public/unauthenticated contexts from accessing tenant/customer knowledge;
-8. prevent Maturion-as-CS2 authority from being granted by runtime code or configuration alone;
-9. keep Batch 1 as prebuild-only, with no code, Supabase mutation, registry activation, specialist activation or `.github/agents` modification;
-10. provide adequate QA-to-red expectations for a later builder implementation wave.
+### IAA_WILL_QA
 
-### 4. Known Non-Implementation Boundary
+- IAA will compare the artifacts against `FOREMAN_OPERATING_MODEL.md`, `.github/agents/foreman-v2-agent.md`, `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`, and the Maturion Agent Network Organigram strategy.
+- IAA will check whether the active PR scope declaration matches the changed-file set.
+- IAA will check that the FRS contains explicit runtime behaviour, non-scope, lifecycle, and prohibited-behaviour requirements.
+- IAA will check that the TRS defines a sufficient context envelope and runtime registry model.
+- IAA will check that QA-to-Red includes failure cases for missing context, missing registry activation, public/tenant boundary violation, knowledge-plane leakage, build/runtime confusion, and improper Maturion-as-CS2 authority.
+- IAA will not issue final assurance inside this pre-brief block.
+
+RESULT: PREFLIGHT_BRIEF_COMPLETE
+
+---
+
+## NON-IMPLEMENTATION BOUNDARY
 
 This wave does not:
 
@@ -61,7 +83,9 @@ This wave does not:
 - implement memory writes;
 - grant Maturion CS2 authority.
 
-### 5. Requested IAA Output
+---
+
+## REQUESTED IAA OUTPUT
 
 IAA should provide a later independent assurance verdict or rejection package after reviewing the prebuild artifact set.
 

--- a/.agent-admin/scope-declarations/maturion-runtime-agent-network-prebuild-v01.md
+++ b/.agent-admin/scope-declarations/maturion-runtime-agent-network-prebuild-v01.md
@@ -1,0 +1,114 @@
+# Scope Declaration — Maturion Runtime Agent Network Prebuild v0.1
+
+**Scope ID**: MRAN-PREBUILD-V01  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Maturion Runtime Agent Network Architecture Prebuild v0.1  
+**Date**: 2026-06-25  
+**Authority**: CS2 — Johan Ras  
+**Operating Role**: Foreman-led governed delivery  
+**Task Type**: Prebuild architecture artifacts only  
+**Affected Scope**: Cross-module Maturion / AIMC runtime architecture  
+**Implementation Status**: No implementation in this wave
+
+---
+
+## 1. Purpose
+
+This wave creates the first architecture prebuild artifact set for the runtime Maturion agent network.
+
+The purpose is to define the system shape before any builder writes runtime code, modifies Supabase, creates runtime registries, activates specialists, changes `.github/agents`, or grants Maturion additional authority.
+
+This batch answers:
+
+```text
+What exactly is the system we are about to build, and what must never happen?
+```
+
+---
+
+## 2. Source Authority
+
+This scope is governed by:
+
+- `FOREMAN_OPERATING_MODEL.md`;
+- `.github/agents/foreman-v2-agent.md`;
+- `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`;
+- `Maturion/strategy/Maturion_agent_network_organigram_strategy.md`;
+- existing Maturion/AIMC strategy and specialist-registry materials.
+
+---
+
+## 3. In Scope
+
+This wave creates the following prebuild artifacts:
+
+1. `Maturion/prebuild/runtime-agent-network/MRAN-FRS-v0.1.md`
+2. `Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md`
+3. `Maturion/prebuild/runtime-agent-network/MRAN-QA-to-Red-v0.1.md`
+4. `.agent-admin/assurance/iaa-wave-record-mran-prebuild-v01-20260625.md`
+5. this scope declaration.
+
+The artifacts define:
+
+- runtime agent-network purpose and boundaries;
+- Maturion's runtime orchestration responsibilities;
+- context-envelope requirements;
+- runtime registry architecture requirements;
+- specialist lifecycle states;
+- activation prohibitions;
+- QA-to-red validation expectations;
+- IAA pre-brief questions for independent assurance.
+
+---
+
+## 4. Out of Scope
+
+This wave does not:
+
+- create runtime code;
+- alter application behaviour;
+- create or mutate Supabase tables;
+- create or activate runtime specialists;
+- create APW specialist;
+- create ISMS specialist;
+- change `.github/agents` files;
+- modify build/governance agent contracts;
+- implement gateway routing;
+- implement retrieval;
+- implement memory writes;
+- alter tenant isolation;
+- grant Maturion CS2 authority;
+- update App Management Centre implementation.
+
+---
+
+## 5. Foreman Boundary
+
+Foreman may create and organise these prebuild artifacts. Foreman may not implement product/runtime artifacts.
+
+Builder appointment is not part of this wave. If Batch 1 is accepted, the next governed wave may create Batch 2 knowledge-grounding prebuild artifacts. Builder implementation remains blocked until the relevant prebuild range and QA-to-red are accepted.
+
+---
+
+## 6. Success Criteria
+
+This wave succeeds when:
+
+1. the scope declaration exists;
+2. FRS defines the runtime agent-network behaviour and prohibitions;
+3. TRS defines context-envelope and runtime-registry architecture;
+4. QA-to-red defines failure-first expectations for registry/context-envelope behaviour;
+5. IAA pre-brief is recorded for independent review;
+6. no implementation files are changed;
+7. no runtime specialist is activated;
+8. no Maturion-as-CS2 authority is granted.
+
+---
+
+## 7. Known Follow-On Waves
+
+This wave intentionally leaves the following to later batches:
+
+1. Batch 2 — Knowledge Grounding Prebuild: Supabase/AIMC metadata, source hierarchy, public/private/tenant filters.
+2. Batch 3 — APW Specialist Prebuild: public APW specialist scope, public-safe Maturion behaviour, APW routing and fallback rules.
+3. Later implementation waves — only after prebuild artifacts, QA-to-red, IAA pre-brief, builder appointment, QP, ECAP, IAA final, and CS2 review are satisfied.

--- a/.agent-admin/scope-declarations/pr-1855.md
+++ b/.agent-admin/scope-declarations/pr-1855.md
@@ -1,0 +1,84 @@
+# Scope Declaration — PR #1855
+
+**Scope ID**: PR-1855-MRAN-PREBUILD-V01  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Pull Request**: #1855  
+**Wave**: Maturion Runtime Agent Network Architecture Prebuild v0.1  
+**Date**: 2026-06-26  
+**Authority**: CS2 — Johan Ras  
+**Operating Role**: Foreman-led governed delivery  
+**Task Type**: Prebuild architecture artifacts only  
+**Affected Scope**: Cross-module Maturion / AIMC runtime architecture  
+**Implementation Status**: No implementation in this PR
+
+---
+
+## 1. Active PR Scope
+
+This is the active per-PR scope declaration for PR #1855.
+
+It mirrors the wave scope declaration and exists so PR-level scope/diff parity gates can discover the active changed-file set.
+
+---
+
+## 2. Changed Files in Scope
+
+This PR is limited to these files:
+
+1. `.agent-admin/scope-declarations/maturion-runtime-agent-network-prebuild-v01.md`
+2. `.agent-admin/scope-declarations/pr-1855.md`
+3. `Maturion/prebuild/runtime-agent-network/MRAN-FRS-v0.1.md`
+4. `Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md`
+5. `Maturion/prebuild/runtime-agent-network/MRAN-QA-to-Red-v0.1.md`
+6. `.agent-admin/assurance/iaa-wave-record-mran-prebuild-v01-20260625.md`
+
+---
+
+## 3. Source Authority
+
+This scope is governed by:
+
+- `FOREMAN_OPERATING_MODEL.md`;
+- `.github/agents/foreman-v2-agent.md`;
+- `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`;
+- `Maturion/strategy/Maturion_agent_network_organigram_strategy.md`;
+- existing Maturion/AIMC strategy and specialist-registry materials.
+
+---
+
+## 4. In Scope
+
+This PR creates Batch 1 architecture prebuild artifacts for the runtime Maturion agent network:
+
+- functional requirements;
+- technical requirements for context envelope and runtime registry architecture;
+- QA-to-Red expectations;
+- IAA pre-brief;
+- scope declarations.
+
+---
+
+## 5. Out of Scope
+
+This PR does not:
+
+- create runtime code;
+- alter application behaviour;
+- create or mutate Supabase tables;
+- create or activate runtime specialists;
+- create APW specialist;
+- create ISMS specialist;
+- change `.github/agents` files;
+- modify build/governance agent contracts;
+- implement gateway routing;
+- implement retrieval;
+- implement memory writes;
+- alter tenant isolation;
+- grant Maturion CS2 authority;
+- update App Management Centre implementation.
+
+---
+
+## 6. Gate Note
+
+This file is the active PR-level scope declaration. The wave-named scope declaration remains the durable wave artifact, while this file supports PR-level scope/diff validation.

--- a/Maturion/prebuild/runtime-agent-network/MRAN-FRS-v0.1.md
+++ b/Maturion/prebuild/runtime-agent-network/MRAN-FRS-v0.1.md
@@ -1,0 +1,252 @@
+# FRS — Maturion Runtime Agent Network v0.1
+
+**Artifact ID**: MRAN-FRS-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — Functional Requirements  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Maturion Runtime Agent Network Architecture Prebuild v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-25  
+**Scope Declaration**: `.agent-admin/scope-declarations/maturion-runtime-agent-network-prebuild-v01.md`
+
+---
+
+## 1. Purpose
+
+This Functional Requirements Specification defines what the Maturion runtime agent network must do before any runtime implementation begins.
+
+The runtime agent network is not a visible swarm of bots. It is the governed capability layer behind Maturion, allowing Maturion to consult app specialists, domain specialists, knowledge/data specialists, output specialists and oversight services while preserving one coherent user-facing interface.
+
+Canonical principle:
+
+```text
+One Maturion interface. Many governed capabilities behind it.
+```
+
+---
+
+## 2. Product Intent
+
+Maturion must become the unified runtime AI interface across APGI applications.
+
+A user should experience one coherent security professional who understands:
+
+- which app or embodiment he is operating in;
+- whether the user is public, authenticated, organisation-scoped, tenant-scoped or privileged;
+- what knowledge planes may be used;
+- which specialist capabilities are available;
+- when specialist routing is appropriate;
+- what must be refused, degraded, or escalated.
+
+---
+
+## 3. Functional Boundary
+
+### 3.1 In Scope
+
+The runtime agent network must support:
+
+1. app/embodiment context detection;
+2. context envelope intake and validation;
+3. runtime specialist discovery through a governed registry;
+4. specialist lifecycle enforcement;
+5. allowed knowledge-plane selection;
+6. safe delegation to specialists;
+7. specialist output validation;
+8. one final Maturion response synthesis;
+9. limitation disclosure and graceful degradation;
+10. audit trace sufficient for governance review.
+
+### 3.2 Out of Scope for Batch 1
+
+Batch 1 does not implement:
+
+- runtime code;
+- Supabase retrieval;
+- embeddings or vector search;
+- public APW retrieval;
+- APW specialist activation;
+- ISMS specialist activation;
+- runtime registry storage;
+- memory writes;
+- tenant-context queries;
+- Maturion-as-CS2 authority.
+
+---
+
+## 4. Runtime Maturion Functional Requirements
+
+### FRS-MRAN-001 — Single Interface
+
+Maturion must remain the single user-facing AI interface unless a later product design explicitly approves an exception.
+
+Specialists must not become unmanaged user-facing personas.
+
+### FRS-MRAN-002 — Context Awareness
+
+Maturion must operate from a context envelope that identifies, at minimum:
+
+- app;
+- embodiment;
+- environment;
+- authentication state;
+- user role where available;
+- organisation/tenant scope where available;
+- page or workflow;
+- permission scope;
+- session id or trace id where available.
+
+### FRS-MRAN-003 — Permission-Aware Knowledge Use
+
+Maturion must select knowledge based on permission scope. Public or unauthenticated contexts must not use tenant/customer knowledge. Tenant-scoped contexts must not bleed into other tenants or global memory.
+
+### FRS-MRAN-004 — Runtime Registry Lookup
+
+Maturion must consult a governed runtime registry before treating any specialist as available or active.
+
+Named specialists in strategy, canon, `.github/agents`, or documentation are not sufficient for runtime activation.
+
+### FRS-MRAN-005 — Specialist Lifecycle Enforcement
+
+Maturion must respect specialist lifecycle states:
+
+```text
+PROPOSED
+  -> STRATEGY_DEFINED
+    -> STUB_CONTRACTED
+      -> KNOWLEDGE_BASED
+        -> RUNTIME_REGISTERED
+          -> ACTIVE
+            -> DEGRADED / DEPRECATED / RETIRED
+```
+
+Only `ACTIVE` specialists may be used for production runtime answers. `DEGRADED` specialists may be used only with disclosed limitations. `PROPOSED`, `STRATEGY_DEFINED`, `STUB_CONTRACTED`, and `KNOWLEDGE_BASED` specialists must not be treated as production-ready.
+
+### FRS-MRAN-006 — Delegation Boundary
+
+Maturion may delegate specialist reasoning internally, but must retain responsibility for:
+
+- context assembly;
+- authority checking;
+- final answer synthesis;
+- limitation disclosure;
+- escalation decisions.
+
+### FRS-MRAN-007 — Specialist Non-Autonomy
+
+Specialists must not independently expand authority, change tenant scope, write memory, approve actions, or issue user-facing final answers unless explicitly authorised by runtime architecture and governance.
+
+### FRS-MRAN-008 — Build-Agent Separation
+
+Build/governance agents and runtime/onboard app agents must remain distinct.
+
+`.github/agents` contracts may inform runtime design, but may not be used as runtime agent activation records.
+
+### FRS-MRAN-009 — Degraded Mode
+
+If a required specialist, registry entry, context envelope field, or knowledge plane is missing, Maturion must degrade safely.
+
+Safe degradation includes:
+
+- answering only from allowed public/general knowledge;
+- disclosing that governed knowledge is not available;
+- refusing tenant/private questions in public mode;
+- escalating rather than guessing.
+
+### FRS-MRAN-010 — Audit Trace
+
+Runtime orchestration must eventually produce an audit trace showing:
+
+- context envelope summary;
+- registry decision;
+- specialist invoked or not invoked;
+- knowledge-plane class used;
+- degradation or escalation outcome;
+- final response class.
+
+The audit trace must avoid storing secrets or unnecessary tenant data.
+
+---
+
+## 5. Specialist Functional Categories
+
+The runtime registry must support at least these specialist categories:
+
+| Category | Purpose |
+|---|---|
+| App specialist | Knows app routes, workflows, public/private boundaries and handoff behaviour. |
+| Domain specialist | Knows a professional domain such as risk, controls, threat intelligence, or training. |
+| Knowledge/data specialist | Supports parsing, ranking, retrieval, metadata and knowledge hygiene. |
+| Output specialist | Produces governed reports, summaries, scores, evidence packs, or executive outputs. |
+| Oversight service | Applies safety, memory, tenant, policy, or anomaly guardrails. |
+
+---
+
+## 6. First Known Runtime Specialist Candidates
+
+The following are candidates only unless a future governed wave registers and activates them:
+
+- APW specialist;
+- ISMS specialist;
+- MMM / Maturity Roadmap specialist;
+- MAT specialist;
+- PIT specialist;
+- XDETECT specialist;
+- risk-platform specialist;
+- document-parser specialist;
+- criteria-generator specialist;
+- maturity-scoring specialist;
+- report-writer specialist;
+- memory / Arbiter-facing service.
+
+This FRS does not activate any of them.
+
+---
+
+## 7. Prohibited Runtime Behaviour
+
+The runtime agent network must never:
+
+1. treat a strategy-named specialist as active without registry activation;
+2. use `.github/agents` as production runtime activation records;
+3. expose tenant context in public APW mode;
+4. retrieve customer documents without authenticated scoped authority;
+5. write private organisational data into global shared memory;
+6. allow specialists to bypass Maturion final synthesis;
+7. allow specialists to issue CS2 or governance authority;
+8. grant Maturion CS2 authority from runtime code alone;
+9. call private tools/secrets from public browser code;
+10. invent governed APGI facts when approved knowledge is missing.
+
+---
+
+## 8. Acceptance Conditions for FRS v0.1
+
+This FRS is acceptable for Batch 1 only if it preserves:
+
+- one Maturion interface;
+- build/runtime agent separation;
+- registry-before-activation;
+- context-envelope-before-routing;
+- permission-aware knowledge selection;
+- safe degradation;
+- no implementation in Batch 1.
+
+---
+
+## 9. Deferred to Batch 2
+
+Batch 2 must define knowledge grounding in detail, including:
+
+- Supabase/AIMC metadata requirements;
+- source hierarchy;
+- public-safe filtering;
+- tenant/private filters;
+- missing metadata behaviour;
+- retrieval audit evidence.
+
+---
+
+## 10. Deferred to Batch 3
+
+Batch 3 must define the first specialist prebuild, likely APW specialist, including mandate, non-scope, public-mode behaviour, public-safe knowledge rules and routing conditions.

--- a/Maturion/prebuild/runtime-agent-network/MRAN-QA-to-Red-v0.1.md
+++ b/Maturion/prebuild/runtime-agent-network/MRAN-QA-to-Red-v0.1.md
@@ -1,0 +1,201 @@
+# QA-to-Red — Maturion Runtime Agent Network v0.1
+
+**Artifact ID**: MRAN-QA-RED-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — QA-to-Red  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Maturion Runtime Agent Network Architecture Prebuild v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-25  
+**Related FRS**: `Maturion/prebuild/runtime-agent-network/MRAN-FRS-v0.1.md`  
+**Related TRS**: `Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md`
+
+---
+
+## 1. Purpose
+
+This QA-to-Red artifact defines failure-first validation expectations for the Maturion runtime agent network before implementation exists.
+
+The goal is to make the future implementation prove that it blocks unsafe behaviour, not merely that it returns an answer.
+
+---
+
+## 2. QA-to-Red Principle
+
+```text
+The system must fail closed when context, registry, authority, or knowledge boundaries are missing.
+```
+
+A future implementation must demonstrate red tests for the cases below before a builder attempts to make them green.
+
+---
+
+## 3. Test Categories
+
+### QA-MRAN-CAT-001 — Context Envelope Validation
+
+The system must reject or degrade when required context fields are missing.
+
+Red cases:
+
+1. request has no `app`;
+2. request has no `embodiment`;
+3. request has no `permission_scope`;
+4. request claims `tenant_scoped` without `tenant_id`;
+5. request claims `public` while supplying tenant identifiers;
+6. request asks for memory access while `memory_allowed = false`.
+
+Expected red result:
+
+- no specialist invocation;
+- no tenant/private retrieval;
+- safe refusal, limitation disclosure or escalation.
+
+### QA-MRAN-CAT-002 — Registry Before Specialist Invocation
+
+The system must not invoke a specialist unless the runtime registry permits it.
+
+Red cases:
+
+1. APW specialist is named in strategy/canon but absent from runtime registry;
+2. PIT specialist exists in `.github/agents` or docs but not runtime registry;
+3. specialist exists with status `PROPOSED`;
+4. specialist exists with status `STRATEGY_DEFINED`;
+5. specialist exists with status `STUB_CONTRACTED`;
+6. specialist exists with status `RUNTIME_REGISTERED` but not `ACTIVE`;
+7. specialist exists with `ACTIVE` status but current app is not allowed.
+
+Expected red result:
+
+- specialist not invoked;
+- audit trace records blocked or degraded decision;
+- Maturion responds safely without pretending the specialist was used.
+
+### QA-MRAN-CAT-003 — Public Mode Isolation
+
+Public/unauthenticated contexts must not access tenant or customer knowledge.
+
+Red cases:
+
+1. public APW request attempts tenant retrieval;
+2. public APW request contains `tenant_context_allowed = true`;
+3. public APW request includes `organisation_id` or `tenant_id` without authentication;
+4. public APW request asks for customer-specific document analysis;
+5. public APW request asks for internal governance or private strategy not marked public-safe.
+
+Expected red result:
+
+- tenant/private retrieval blocked;
+- no customer data exposed;
+- Maturion explains limitation or offers public-safe handoff.
+
+### QA-MRAN-CAT-004 — Knowledge Plane Boundaries
+
+Specialists must receive only knowledge planes allowed by the context envelope.
+
+Red cases:
+
+1. app specialist requests Framework / Context Domain when envelope disallows it;
+2. output specialist receives tenant data in public mode;
+3. domain specialist receives memory data without memory permission;
+4. missing knowledge metadata causes unrestricted retrieval;
+5. stale/unknown metadata is treated as public-safe.
+
+Expected red result:
+
+- retrieval blocked or degraded;
+- unknown metadata is not treated as safe;
+- audit trace records missing metadata or blocked knowledge plane.
+
+### QA-MRAN-CAT-005 — Maturion Final Synthesis
+
+Specialists must not bypass Maturion final synthesis.
+
+Red cases:
+
+1. specialist returns a final user-facing answer directly;
+2. specialist attempts to escalate authority beyond its mandate;
+3. specialist attempts to write memory directly;
+4. specialist output conflicts with canon;
+5. specialist output contains private information outside permission scope.
+
+Expected red result:
+
+- output rejected or revised through Maturion validation;
+- audit trace records validation failure;
+- user receives safe Maturion-synthesised response or escalation.
+
+### QA-MRAN-CAT-006 — Build/Runtime Agent Separation
+
+Runtime must not treat build/governance agent files as runtime activation records.
+
+Red cases:
+
+1. `.github/agents/maturion-agent.md` treated as runtime activation;
+2. Foreman or builder agent used as runtime specialist;
+3. CodexAdvisor contract used to decide runtime specialist status;
+4. IAA/ECAP role used as runtime app specialist;
+5. runtime registry auto-populates from `.github/agents` without review.
+
+Expected red result:
+
+- runtime activation blocked;
+- build/governance agent file class ignored for runtime availability;
+- system requires runtime registry record.
+
+### QA-MRAN-CAT-007 — Maturion-as-CS2 Authority
+
+Runtime code must not grant Maturion CS2 authority.
+
+Red cases:
+
+1. runtime request asks Maturion to approve a PR;
+2. runtime specialist attempts to waive a gate;
+3. App Management Centre context claims Level 3 or Level 4 authority without canon-backed evidence;
+4. user asks public APW Maturion to approve governance progression;
+5. local code config claims `maturion_is_cs2 = true` without authority record.
+
+Expected red result:
+
+- authority denied or escalated;
+- no approval or waiver issued;
+- Maturion explains authority limitation.
+
+---
+
+## 4. Minimum Future Test Fixtures
+
+Future implementation should include fixtures for:
+
+- public APW request;
+- authenticated ISMS request;
+- tenant-scoped MMM request;
+- governance/App Management Centre request;
+- missing context envelope;
+- unknown specialist;
+- non-active specialist;
+- active specialist with wrong app;
+- missing metadata knowledge document;
+- tenant data attempted in public mode.
+
+---
+
+## 5. Red Evidence Required Before Build-to-Green
+
+Before implementation builders are appointed, the future implementation wave must define tests or validation scripts that initially fail for the red cases above.
+
+Evidence must show:
+
+1. the failure condition;
+2. the expected safe outcome;
+3. the guardrail being tested;
+4. the intended green behaviour;
+5. the artifact requirement traced back to FRS/TRS.
+
+---
+
+## 6. Batch 1 QA Disposition
+
+This QA-to-Red artifact is prebuild-only. It does not create tests, code, migrations, registry entries, or runtime functionality.
+
+It creates the test expectation that future implementation must satisfy.

--- a/Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md
+++ b/Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md
@@ -56,7 +56,7 @@ Batch 1 defines this flow only. It does not implement it.
 
 ### 4.1 Required Envelope Fields
 
-Every runtime Maturion request must eventually carry a context envelope with these fields:
+Every runtime Maturion request must eventually carry a context envelope with these fields. Literal strings such as `string|null` and `boolean` indicate field type expectations, not fixed runtime values.
 
 ```json
 {
@@ -67,7 +67,7 @@ Every runtime Maturion request must eventually carry a context envelope with the
   "page_or_workflow": "string|null",
   "module": "string|null",
   "user": {
-    "authenticated": true,
+    "authenticated": "boolean",
     "id": "string|null",
     "role": "string|null",
     "organisation_id": "string|null",
@@ -76,11 +76,11 @@ Every runtime Maturion request must eventually carry a context envelope with the
   },
   "permission_scope": "public|authenticated|tenant_scoped|superuser|governance",
   "knowledge_scope": {
-    "subject_allowed": true,
-    "app_context_allowed": true,
-    "framework_context_allowed": false,
-    "tenant_context_allowed": false,
-    "memory_allowed": false
+    "subject_allowed": "boolean",
+    "app_context_allowed": "boolean",
+    "framework_context_allowed": "boolean",
+    "tenant_context_allowed": "boolean",
+    "memory_allowed": "boolean"
   },
   "trace": {
     "session_id": "string|null",

--- a/Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md
+++ b/Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md
@@ -1,0 +1,291 @@
+# TRS — Context Envelope + Runtime Registry Architecture v0.1
+
+**Artifact ID**: MRAN-TRS-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — Technical Requirements  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Maturion Runtime Agent Network Architecture Prebuild v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-25  
+**Related FRS**: `Maturion/prebuild/runtime-agent-network/MRAN-FRS-v0.1.md`
+
+---
+
+## 1. Purpose
+
+This Technical Requirements Specification defines the initial architecture for two foundational runtime components:
+
+1. the Maturion runtime context envelope;
+2. the runtime specialist registry.
+
+These are preconditions for safe runtime specialist routing and knowledge-grounded Maturion behaviour.
+
+---
+
+## 2. Architectural Principle
+
+```text
+No context envelope, no safe routing.
+No runtime registry, no active specialist.
+```
+
+A runtime request must be interpreted through context and registry before Maturion may invoke specialist capability.
+
+---
+
+## 3. High-Level Runtime Flow
+
+```text
+User request
+  -> App supplies context envelope
+    -> Maturion validates context
+      -> Maturion determines permission scope
+        -> Maturion checks runtime registry
+          -> Maturion selects allowed knowledge planes
+            -> Maturion invokes specialist only if ACTIVE and permitted
+              -> Maturion validates specialist output
+                -> Maturion synthesises final answer
+                  -> Audit trace recorded
+```
+
+Batch 1 defines this flow only. It does not implement it.
+
+---
+
+## 4. Context Envelope Architecture
+
+### 4.1 Required Envelope Fields
+
+Every runtime Maturion request must eventually carry a context envelope with these fields:
+
+```json
+{
+  "request_id": "string",
+  "app": "APW|ISMS|MMM|MAT|PIT|XDETECT|AMC|OTHER",
+  "embodiment": "public-web|authenticated-app|admin-console|builder-console|service",
+  "environment": "local|preview|staging|production",
+  "page_or_workflow": "string|null",
+  "module": "string|null",
+  "user": {
+    "authenticated": true,
+    "id": "string|null",
+    "role": "string|null",
+    "organisation_id": "string|null",
+    "tenant_id": "string|null",
+    "timezone": "string|null"
+  },
+  "permission_scope": "public|authenticated|tenant_scoped|superuser|governance",
+  "knowledge_scope": {
+    "subject_allowed": true,
+    "app_context_allowed": true,
+    "framework_context_allowed": false,
+    "tenant_context_allowed": false,
+    "memory_allowed": false
+  },
+  "trace": {
+    "session_id": "string|null",
+    "source": "browser|server|worker|admin|test",
+    "correlation_id": "string|null"
+  }
+}
+```
+
+### 4.2 Public APW Context Envelope
+
+A public APW request must have:
+
+```json
+{
+  "app": "APW",
+  "embodiment": "public-web",
+  "permission_scope": "public",
+  "user": {
+    "authenticated": false,
+    "id": null,
+    "organisation_id": null,
+    "tenant_id": null
+  },
+  "knowledge_scope": {
+    "subject_allowed": true,
+    "app_context_allowed": true,
+    "framework_context_allowed": false,
+    "tenant_context_allowed": false,
+    "memory_allowed": false
+  }
+}
+```
+
+Public APW mode must not send tenant identifiers or privileged memory access.
+
+### 4.3 Authenticated Tenant Context Envelope
+
+An authenticated app request may include tenant and organisation context only where the user/session is authorised.
+
+The system must reject or degrade if:
+
+- `permission_scope = tenant_scoped` but `tenant_id` is absent;
+- `tenant_context_allowed = true` but authentication is false;
+- framework context is requested without an organisation or framework boundary;
+- public app context includes tenant-private fields.
+
+### 4.4 Governance / Build Context Envelope
+
+Build/governance orchestration must use a separate `permission_scope = governance` or equivalent. It must not be confused with runtime end-user permissions.
+
+This is important for future App Management Centre work where Maturion may assist with build orchestration under staged authority.
+
+---
+
+## 5. Runtime Registry Architecture
+
+### 5.1 Registry Purpose
+
+The runtime registry is the authoritative runtime source for whether a specialist exists, what class it belongs to, where it may be used, and whether Maturion may invoke it.
+
+Strategy documents, canon, `.github/agents`, and markdown contracts do not by themselves activate runtime specialists.
+
+### 5.2 Minimum Registry Record
+
+A runtime specialist registry record must contain:
+
+```json
+{
+  "runtime_agent_id": "string",
+  "display_name": "string",
+  "agent_class": "app_specialist|domain_specialist|knowledge_data_specialist|output_specialist|oversight_service",
+  "status": "PROPOSED|STRATEGY_DEFINED|STUB_CONTRACTED|KNOWLEDGE_BASED|RUNTIME_REGISTERED|ACTIVE|DEGRADED|DEPRECATED|RETIRED",
+  "orchestrator": "maturion",
+  "allowed_apps": ["APW", "ISMS"],
+  "allowed_embodiments": ["public-web", "authenticated-app"],
+  "allowed_permission_scopes": ["public"],
+  "allowed_knowledge_planes": ["subject", "app_context"],
+  "input_contract_ref": "string|null",
+  "output_contract_ref": "string|null",
+  "guardrail_refs": ["string"],
+  "authority_limits": ["string"],
+  "audit_required": true,
+  "owner": "string",
+  "last_reviewed": "date|null"
+}
+```
+
+### 5.3 Registry Storage
+
+Batch 1 does not choose final storage. Future implementation may use:
+
+- Supabase table;
+- versioned JSON registry;
+- hybrid canon + database model;
+- service-backed registry.
+
+The chosen storage must support auditability, versioning, lifecycle state and environment separation.
+
+### 5.4 Registry Resolution Rules
+
+Maturion must apply these checks before specialist invocation:
+
+1. specialist exists in runtime registry;
+2. status permits invocation;
+3. current app is allowed;
+4. current embodiment is allowed;
+5. permission scope is allowed;
+6. knowledge planes required by the specialist are allowed by the context envelope;
+7. authority limits do not prohibit the requested task;
+8. no guardrail blocks invocation.
+
+### 5.5 Status Behaviour
+
+| Status | Runtime Behaviour |
+|---|---|
+| PROPOSED | Do not invoke. Mention only as roadmap/design if appropriate. |
+| STRATEGY_DEFINED | Do not invoke. May inform planning. |
+| STUB_CONTRACTED | Do not use for production answers. |
+| KNOWLEDGE_BASED | Do not invoke unless separately runtime-registered. |
+| RUNTIME_REGISTERED | Registered but not production-active. Use only in test/sandbox if authorised. |
+| ACTIVE | May invoke within allowed scope. |
+| DEGRADED | May invoke only with limitation disclosure and safe fallback. |
+| DEPRECATED | Do not invoke for new flows. |
+| RETIRED | Do not invoke. |
+
+---
+
+## 6. Knowledge Plane Interface
+
+Batch 1 only defines the interface need. Batch 2 must define metadata and retrieval details.
+
+The runtime architecture must distinguish:
+
+- constitutional/canon rules;
+- Subject Knowledge Domain;
+- App Context Domain;
+- Framework / Context Domain;
+- tenant/org/user context;
+- memory;
+- current session input.
+
+No specialist may receive a knowledge plane that is disallowed by the context envelope.
+
+---
+
+## 7. Audit Trace Architecture
+
+Every runtime orchestration should eventually produce a minimal audit trace:
+
+```json
+{
+  "request_id": "string",
+  "app": "string",
+  "permission_scope": "string",
+  "registry_decision": "no_specialist|specialist_invoked|blocked|degraded",
+  "specialist_id": "string|null",
+  "knowledge_planes_used": ["subject", "app_context"],
+  "degradation_reason": "string|null",
+  "escalation_required": false,
+  "response_class": "informational|advisory|refusal|handoff|escalation"
+}
+```
+
+The audit trace must not store secrets, raw confidential documents, or unnecessary tenant data.
+
+---
+
+## 8. Failure Behaviour
+
+Maturion must block, degrade, or escalate when:
+
+- required context envelope fields are missing;
+- public mode attempts tenant/private retrieval;
+- registry entry is missing;
+- specialist status is not invokable;
+- authority limits are exceeded;
+- knowledge-plane metadata is insufficient;
+- output validation fails.
+
+---
+
+## 9. Implementation Preconditions
+
+Before implementation begins, later prebuild artifacts must answer:
+
+1. where the runtime registry lives;
+2. how registry records are versioned;
+3. how registry updates are approved;
+4. how Supabase/AIMC knowledge metadata maps to knowledge planes;
+5. how public/private/tenant filters are enforced;
+6. how audit traces are stored and protected;
+7. how specialist invocation is tested;
+8. how degraded mode is exposed to users.
+
+---
+
+## 10. Batch 1 Technical Acceptance
+
+Batch 1 is technically acceptable if it defines:
+
+- context-envelope minimum fields;
+- public APW envelope baseline;
+- authenticated tenant envelope baseline;
+- runtime registry minimum record;
+- registry resolution rules;
+- lifecycle state behaviour;
+- no implementation before Batch 2 and Batch 3 prebuild dependencies are satisfied.


### PR DESCRIPTION
## Summary

Creates Batch 1 prebuild artifacts for the Maturion Runtime Agent Network.

Artifacts added:

- `.agent-admin/scope-declarations/maturion-runtime-agent-network-prebuild-v01.md`
- `Maturion/prebuild/runtime-agent-network/MRAN-FRS-v0.1.md`
- `Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md`
- `Maturion/prebuild/runtime-agent-network/MRAN-QA-to-Red-v0.1.md`
- `.agent-admin/assurance/iaa-wave-record-mran-prebuild-v01-20260625.md`

## Purpose

Defines the runtime agent-network shape before implementation: Maturion as the single interface, context-envelope requirements, runtime registry architecture, specialist lifecycle enforcement, failure-first QA expectations, and IAA pre-brief.

## Boundary

Prebuild only. No runtime code, database changes, Supabase mutation, specialist activation, runtime registry creation, `.github/agents` changes, or Maturion CS2 authority changes.