### PR TITLE
ISMS prebuild boundary alignment

### DIFF
--- a/modules/isms/BUILD_PROGRESS_TRACKER.md
+++ b/modules/isms/BUILD_PROGRESS_TRACKER.md
@@ -2,12 +2,71 @@
 
 **Module**: ISMS Navigator  
 **Module Slug**: isms  
-**Last Updated**: 2026-06-23  
-**Updated By**: foreman-v2-agent (slice: `isms-post-p1-3-tracker-reconciliation`)
+**Last Updated**: 2026-06-26  
+**Updated By**: foreman-v2-agent (slice: `isms-prebuild-boundary-alignment-clean`)
 
-> **Classification**: W1-W8 COMPLETE — P1.3 REAL PREVIEW DEPLOY EVIDENCE RECORDED; MMM/PIT WORKFLOW SPLITS RECONCILED  
+> **Classification**: W1-W8 COMPLETE — P1.3 REAL PREVIEW DEPLOY EVIDENCE RECORDED; ISMS PRE-BUILD BOUNDARY ALIGNMENT ACTIVE  
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0  
 > **Current Governance Model**: `AGENT_GATE_SYSTEM_TRANSITION_NOTICE.md` / PR #1800 gate model
+
+---
+
+## Current Stage Summary
+
+**Current Stage**: ISMS pre-build boundary alignment to PR #1850 shared platform/module boundary authority.  
+**Implementation Transfer**: Owner final decision remains recorded with conditions.  
+**Next Required Action**: Merge ISMS pre-build boundary alignment before any P2 runtime persistence, PIT linkup, MMM linkup, Risk Management linkup, RADAM / Systems Integration linkup, or future module linkup implementation is appointed.
+
+---
+
+## Boundary Authority and Active Gate
+
+PR #1850 is the controlling shared pre-build authority for ISMS/module linkup strategy.
+
+Authority artifact:
+
+- `modules/isms/prebuild-harvest-package/platform-module-boundary-linkup-strategy.md`
+
+ISMS-side alignment record:
+
+- `modules/isms/prebuild-harvest-package/isms-prebuild-boundary-alignment-20260626.md`
+
+Tracker addendum:
+
+- `modules/isms/BUILD_PROGRESS_TRACKER_BOUNDARY_ALIGNMENT_20260626.md`
+
+Related module-side alignments:
+
+- PIT PR #1853 — PIT-side pre-build alignment to PR #1850.
+- MMM PR #1854 — MMM-side pre-build alignment to PR #1850.
+
+Operating principle:
+
+- ISMS owns public landing, `/modules`, public free-assessment entry, marketing routes, subscription, checkout, authentication, onboarding, dashboard, entitlement summary, entitlement/journey-state handoff, shared platform shell, and cross-module governance framing.
+- PIT owns `/pit/tracker` runtime after entitled ISMS handoff.
+- MMM owns Maturity Roadmap runtime after approved ISMS handoff.
+- Risk Management, RADAM / Systems Integration, and future modules own their runtime surfaces only after governed ISMS handoff.
+- The canonical evidence host is `https://maturion-isms-portal.vercel.app` unless CS2 approves another host model.
+- `maturion-pit.vercel.app` must not act as a duplicate public acquisition journey unless explicitly governed.
+
+---
+
+## Immediate Defect Being Governed
+
+The immediate defect is the canonical ISMS to PIT entitlement loop:
+
+```text
+ISMS landing/card
+  -> PIT marketing
+  -> subscription/checkout
+  -> auth/onboarding
+  -> dashboard still shows no PIT entitlement
+  -> clicking PIT returns to subscription
+```
+
+Boundary RED tests must prove the canonical ISMS journey reaches `/pit/tracker` without looping after entitlement is established.
+
+This tracker records pre-build alignment only. It does not implement the correction.
 
 ---
 
@@ -25,102 +84,17 @@
 | Stage 8 | Implementation Plan | COMPLETE — Planning artifact only | `modules/isms/07-implementation-plan/implementation-plan.md` |
 | Stage 9 | Builder Checklist | RECONCILED WITH CONDITIONS | `modules/isms/08-builder-checklist/stage9-final-reconciliation-w8.md` |
 | Stage 10 | IAA Pre-Brief + Acknowledgements | CLOSED WITH CONDITIONS | `modules/isms/09-iaa-pre-brief/iaa-pre-brief-acknowledgements.md` |
-| Stage 11 | Builder Appointment | COMPLETE FOR W1-W8 ONLY | `.agent-admin/builder-appointments/isms-stage11-w1-route-public-shell-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w2-free-assessment-flow-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w3-subscribe-auth-onboarding-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w4-context-entitlement-handoff-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w5-ask-maturion-adapter-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w6-backend-persistence-audit-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w7-deployment-runtime-hardening-builder-appointment.md`; `.agent-admin/builder-appointments/isms-stage11-w8-cumulative-regression-pbfag-builder-appointment.md` |
-| Stage 12 | W1 Build Execution & Evidence | MERGED — ACCEPTED FOR W1 SCOPE | `modules/isms/11-build/w1-route-public-shell-evidence.md` |
-| Stage 12 | W2 Build Execution & Evidence | MERGED — ACCEPTED FOR W2 SCOPE | `modules/isms/11-build/w2-free-assessment-flow-evidence.md` |
-| Stage 12 | W3 Build Execution & Evidence | MERGED — ACCEPTED FOR W3 SCOPE | `modules/isms/11-build/w3-subscribe-auth-onboarding-evidence.md` |
-| Stage 12 | W4 Build Execution & Evidence | MERGED — ACCEPTED FOR W4 SCOPE | `modules/isms/11-build/w4-context-entitlement-handoff-evidence.md` |
-| Stage 12 | W5 Build Execution & Evidence | MERGED — ACCEPTED FOR W5 SCOPE | `modules/isms/11-build/w5-ask-maturion-adapter-evidence.md` |
-| Stage 12 | W6 Build Execution & Evidence | MERGED — ACCEPTED FOR W6 SCOPE | `modules/isms/11-build/w6-backend-persistence-audit-evidence.md` |
-| Stage 12 | W7 Build Execution & Evidence | MERGED — ACCEPTED FOR W7 SCOPE | `modules/isms/11-build/w7-deployment-runtime-hardening-evidence.md` |
-| Stage 12 | W8 Build Execution & Evidence | MERGED — ACCEPTED FOR W8 SCOPE | `modules/isms/11-build/w8-cumulative-regression-pbfag-evidence.md` |
+| Stage 11 | Builder Appointment | COMPLETE FOR W1-W8 ONLY | W1-W8 builder appointments |
+| Stage 12 | W1-W8 Build Execution & Evidence | MERGED — ACCEPTED FOR W1-W8 SCOPE | `modules/isms/11-build/` |
 | Post-W8 | P1 External Deployment Proof | VERIFIED WITH FOLLOW-UP FINDINGS | `modules/isms/12-deployment/p1-external-deployment-proof-20260615.md` |
 | Post-W8 | P1.1 Deployment Hygiene Cleanup | MERGED — ACCEPTED FOR P1.1 SCOPE | `modules/isms/12-deployment/p1-1-deployment-hygiene-cleanup-20260615.md` |
 | Post-W8 | P1.2 Vercel Workflow Split | MERGED — ACCEPTED FOR P1.2 SCOPE | `modules/isms/12-deployment/p1-2-vercel-workflow-split-20260616.md` |
 | Post-W8 | P1.3 Real Preview Deploy Verification | MERGED — EVIDENCE RECORDED FOR P1.3 SCOPE | `modules/isms/12-deployment/p1-3-real-preview-deploy-verification-20260616.md` |
-| Post-W8 | MMM/PIT Workflow Split Reconciliation | MERGED — NON-ISMS DEPLOYMENT COORDINATION RECORDED | `MONOREPO_VERCEL_WORKFLOW_OWNERSHIP_SPLIT.md`; `modules/MMM/12-deployment/mmm-vercel-workflow-ownership-20260619.md`; `modules/pit/12-deployment/pit-vercel-workflow-ownership-20260617.md`; PR #1830 |
-
----
-
-## Post-W8: P1 External Deployment Proof
-
-**Status**: VERIFIED WITH FOLLOW-UP FINDINGS  
-**Evidence**: `modules/isms/12-deployment/p1-external-deployment-proof-20260615.md`
-
-**Verified**:
-- production deployment `dpl_wwAYwu19XLPP1Kzm8cmvF2q1SqNC` is `READY`;
-- production domain `https://maturion-isms-portal.vercel.app` returns HTTP 200;
-- representative SPA deep links return HTTP 200;
-- runtime log query found no logs in the checked one-hour window.
-
----
-
-## Post-W8: P1.1 Deployment Hygiene Cleanup
-
-**Status**: MERGED — ACCEPTED FOR P1.1 SCOPE  
-**Merged PR**: #1809 (`07535ab07f14ce3bb5b8238eecf6e5d9e04233b9`)  
-**Evidence**: `modules/isms/12-deployment/p1-1-deployment-hygiene-cleanup-20260615.md`
-
-**Scope delivered**:
-- confirms stale PR #1795 is closed and unmerged;
-- bounds root Node engine to `>=20 <23`;
-- keeps pnpm package manager unchanged because lockfile is `lockfileVersion: '9.0'`;
-- patches API bearer validation TypeScript surface in `api/ai/feedback/pending.ts` and `api/ai/feedback/approve.ts`.
-
----
-
-## Post-W8: P1.2 Vercel Workflow Split
-
-**Status**: MERGED — ACCEPTED FOR P1.2 SCOPE  
-**Merged PR**: #1812 (`50785d5b6084fd7a2100cad8e946b596ac8b89a6`)  
-**Evidence**: `modules/isms/12-deployment/p1-2-vercel-workflow-split-20260616.md`
-
-**Scope delivered**:
-- adds `MONOREPO_VERCEL_WORKFLOW_OWNERSHIP_SPLIT.md` coordination artifact;
-- adds `.github/workflows/deploy-isms-portal-vercel.yml`;
-- scopes ISMS deploy workflow to `apps/isms-portal/**` and ISMS workflow/docs paths;
-- avoids broad `api/**` ownership in the ISMS workflow.
-
-**Post-merge verification**:
-- PR #1812 was merged on 2026-06-16;
-- PR-scoped CI passed, including `Deploy ISMS Preview`;
-- actual Vercel deploy/smoke steps remained conditional on repository secrets: `ISMS_VERCEL_ORG_ID`, `ISMS_VERCEL_PROJECT_ID`, `ISMS_VERCEL_TOKEN`, and optional `ISMS_VERCEL_AUTOMATION_BYPASS_SECRET`.
-
----
-
-## Post-W8: P1.3 Real Preview Deploy Verification
-
-**Status**: MERGED — EVIDENCE RECORDED FOR P1.3 SCOPE  
-**Merged PR**: #1819 (`52606466798c5bf39509ae6c0fad136dff1d21f6`)  
-**Evidence**: `modules/isms/12-deployment/p1-3-real-preview-deploy-verification-20260616.md`
-
-**Scope recorded**:
-- ISMS app-specific Vercel secrets were configured by the owner before verification;
-- PR #1819 triggered the ISMS-only Vercel workflow on an ISMS app path;
-- `Deploy ISMS Portal to Vercel` passed on the latest PR head before merge;
-- `Deploy ISMS Preview` performed a real Vercel preview deploy rather than the previous missing-secret skip path;
-- Vercel reported the ISMS project preview as `Ready`;
-- the workflow smoke step passed after treating Vercel preview `401/403` as protected-preview posture rather than SPA route failure.
-
-**Preview URL recorded**:
-- `https://maturion-isms-portal-git-foreman-ism-d5f042-rassie-ras-projects.vercel.app`
-
----
-
-## Post-W8: MMM/PIT Workflow Split Reconciliation
-
-**Status**: MERGED — NON-ISMS DEPLOYMENT COORDINATION RECORDED  
-**Merged PR**: #1830 (`6a7654309be18a1deca8ad48cfc300f646c4390e`)  
-**Evidence**:
-- `MONOREPO_VERCEL_WORKFLOW_OWNERSHIP_SPLIT.md`
-- `modules/MMM/12-deployment/mmm-vercel-workflow-ownership-20260619.md`
-- `modules/pit/12-deployment/pit-vercel-workflow-ownership-20260617.md`
-
-**Scope recorded**:
-- MMM workflow ownership split issue #1815 was implemented and residual Vercel config risk was remediated;
-- PIT workflow ownership split issue #1816 was implemented and integrated-shell posture was made explicit;
-- app-specific Vercel secret namespaces are used by ISMS, MMM, and PIT workflows;
-- broad `api/**` and broad `packages/**` changes no longer automatically trigger unrelated app preview deployments.
+| Post-W8 | MMM/PIT Workflow Split Reconciliation | MERGED — NON-ISMS DEPLOYMENT COORDINATION RECORDED | PR #1830 |
+| Boundary | PR #1850 Shared Boundary Authority | MERGED — CONTROLLING PRE-BUILD AUTHORITY | `modules/isms/prebuild-harvest-package/platform-module-boundary-linkup-strategy.md` |
+| Boundary | PIT Pre-Build Boundary Alignment | MERGED — PIT-SIDE ALIGNMENT RECORDED | PR #1853 |
+| Boundary | MMM Pre-Build Boundary Alignment | MERGED — MMM-SIDE ALIGNMENT RECORDED | PR #1854 |
+| Boundary | ISMS Pre-Build Boundary Alignment | ACTIVE — DOCS-ONLY ALIGNMENT BEFORE P2/LINKUP BUILD | PR #1857 |
 
 ---
 
@@ -130,19 +104,12 @@
 **Decision Record**: `.agent-admin/owner-decisions/isms-w8-owner-final-decision-20260615.md`
 
 Accepted conditions:
+
 - W1-W8 are complete for appointed scope only;
 - production auth/payment hardening remains future-gated;
 - live AI provider integration remains future-gated;
 - runtime persistence hooks remain future-gated;
 - audit writer invocation remains future-gated.
-
----
-
-## Current Stage Summary
-
-**Current Stage**: Post-W8 P1.3 real preview deploy evidence and MMM/PIT workflow split reconciliation have been recorded.  
-**Implementation Transfer**: Owner final decision remains recorded with conditions.  
-**Next Required Action**: Start P2 runtime Supabase persistence hooks as the next separately authorized ISMS productionization lane.
 
 ---
 
@@ -153,25 +120,18 @@ Accepted conditions:
 - [x] Stage 3 FRS approved with conditions
 - [x] Stage 4 TRS approved with conditions
 - [x] Stage 5 Architecture reconciled to TRS and approved with conditions
-- [x] Architecture completeness gap analysis filed
-- [x] Architecture remediation pack created
 - [x] Stage 6 QA-to-Red catalog created
 - [x] Stage 7 PBFAG completed and W8 amendment filed
 - [x] Stage 8 Implementation Plan complete
-- [x] Wave evidence plan complete
 - [x] Stage 9 Builder Checklist complete and W8 final reconciliation filed
 - [x] Stage 10 IAA Pre-Brief filed
-- [x] Stage 10 acknowledgements recorded or explicitly waived with binding Stage 11 condition
 - [x] Stage 11 W1-W8 Builder Appointments complete
 - [x] Stage 12 W1-W8 merged
-- [x] W8 owner final decision recorded
-- [x] P1 external deployment proof recorded
-- [x] P1.1 deployment hygiene merged
-- [x] P1.2 workflow split PR opened
-- [x] P1.2 workflow split CI passed
-- [x] P1.2 workflow split review conversations resolved
 - [x] P1.3 real preview deploy evidence recorded
-- [x] MMM/PIT workflow split reconciliation recorded after PR #1830
+- [x] PR #1850 shared ISMS/module boundary authority merged
+- [x] PIT-side boundary alignment merged in PR #1853
+- [x] MMM-side boundary alignment merged in PR #1854
+- [ ] ISMS-side pre-build boundary alignment merged
 
 ---
 
@@ -184,8 +144,23 @@ The following remain outside W1-W8 appointed scope and require separate future a
 - runtime persistence hooks;
 - audit writer invocation;
 - bundle-size review;
-- canonical App Description path mismatch cleanup.
+- canonical App Description path mismatch cleanup;
+- PIT linkup implementation;
+- MMM linkup implementation;
+- Risk Management linkup implementation;
+- RADAM / Systems Integration linkup implementation;
+- future module linkup implementation;
+- Supabase runtime persistence hooks;
+- workflow/deployment changes that alter app or module ownership.
 
 ---
 
-**Last Tracker Reconciliation**: 2026-06-23
+## Claim Restriction
+
+No completion, release, production-readiness, or fully functional claim may be made from PR #1850, PIT PR #1853, MMM PR #1854, or the ISMS boundary alignment record alone.
+
+Future implementation requires a separately scoped QA-to-red/build wave, builder appointment, build-to-green work, and canonical-host evidence.
+
+---
+
+**Last Tracker Reconciliation**: 2026-06-26

--- a/modules/isms/BUILD_PROGRESS_TRACKER_BOUNDARY_ALIGNMENT_20260626.md
+++ b/modules/isms/BUILD_PROGRESS_TRACKER_BOUNDARY_ALIGNMENT_20260626.md
@@ -1,0 +1,87 @@
+# ISMS Build Progress Tracker Addendum - Boundary Alignment
+
+| Field | Value |
+|---|---|
+| Module | ISMS Navigator |
+| Module slug | `isms` |
+| Date | 2026-06-26 |
+| Status | Active tracker addendum |
+| Authority | PR #1850 shared platform/module boundary authority |
+| Primary tracker | `modules/isms/BUILD_PROGRESS_TRACKER.md` |
+| Alignment record | `modules/isms/prebuild-harvest-package/isms-prebuild-boundary-alignment-20260626.md` |
+
+---
+
+## Current active lane
+
+The current ISMS active lane is pre-build boundary alignment to PR #1850.
+
+The prior tracker statement that the next required action is P2 runtime Supabase persistence is superseded for this boundary-governance moment. P2 runtime persistence remains future-gated until ISMS pre-build boundary alignment is merged and a later implementation slice is separately scoped and appointed.
+
+---
+
+## Boundary authority now governing ISMS
+
+PR #1850 and this authority artifact govern ISMS/module linkup work:
+
+```text
+modules/isms/prebuild-harvest-package/platform-module-boundary-linkup-strategy.md
+```
+
+ISMS-side alignment is recorded in:
+
+```text
+modules/isms/prebuild-harvest-package/isms-prebuild-boundary-alignment-20260626.md
+```
+
+Related module-side alignments:
+
+- PIT PR #1853 - PIT-side pre-build alignment to PR #1850.
+- MMM PR #1854 - MMM-side pre-build alignment to PR #1850.
+
+---
+
+## Operating principle
+
+- ISMS owns public landing, modules overview, public free-assessment entry, marketing routes, subscription, authentication, onboarding, dashboard, entitlement summary, entitlement/journey-state handoff, shared platform shell, and cross-module governance framing.
+- PIT owns Project Implementation Tracker runtime after entitled ISMS handoff.
+- MMM owns Maturity Roadmap runtime after approved ISMS handoff.
+- Risk Management, RADAM / Systems Integration, and future modules own their own runtime surfaces only after governed ISMS handoff.
+- ISMS may consume module descriptors and render public/dashboard entry points, but must not build module runtime unless a governed cross-module wave explicitly appoints that work.
+
+---
+
+## Implementation block
+
+The following remain blocked until this ISMS pre-build boundary alignment is merged and a later slice is separately appointed:
+
+- P2 runtime persistence;
+- Supabase runtime persistence hooks;
+- PIT linkup implementation;
+- MMM linkup implementation;
+- Risk Management linkup implementation;
+- RADAM / Systems Integration linkup implementation;
+- future module linkup implementation;
+- workflow/deployment changes that alter app or module ownership;
+- `.agent-admin/control/delegation-order.json` changes unless a gate explicitly requires them.
+
+---
+
+## Required next sequence
+
+```text
+Merge ISMS pre-build boundary alignment
+  -> classify the next linkup or productionization slice
+  -> create or update boundary-specific QA-to-red
+  -> appoint the correct builder only after QA-to-red exists
+  -> build to green inside the authorized ISMS/module lane
+  -> capture canonical-host browser/runtime evidence
+```
+
+---
+
+## Claim restriction
+
+No completion, release, production-readiness, or fully functional claim may be made from PR #1850, PIT PR #1853, MMM PR #1854, or the ISMS boundary alignment record alone.
+
+This addendum is documentation/pre-build governance only. It does not implement runtime behavior.

--- a/modules/isms/prebuild-harvest-package/isms-prebuild-boundary-alignment-20260626.md
+++ b/modules/isms/prebuild-harvest-package/isms-prebuild-boundary-alignment-20260626.md
@@ -1,0 +1,193 @@
+# ISMS Pre-Build Boundary Alignment Record
+
+| Field | Value |
+|---|---|
+| Artifact type | ISMS pre-build boundary alignment record |
+| Owning module | ISMS platform shell |
+| Date | 2026-06-26 |
+| Status | Pre-build governance alignment |
+| Authority | PR #1850 shared platform/module boundary authority |
+| Primary authority artifact | `modules/isms/prebuild-harvest-package/platform-module-boundary-linkup-strategy.md` |
+| Related module-side alignments | PIT PR #1853; MMM PR #1854 |
+
+---
+
+## 1. Purpose
+
+This record aligns the ISMS pre-build stack to the platform/module boundary strategy introduced by PR #1850.
+
+It confirms that ISMS remains the canonical public platform front door and shared journey owner while PIT, MMM, Risk Management, RADAM / Systems Integration, Incident & Intelligence, Data Analytics & Assurance, Skills Development, and future modules remain owners of their governed runtime surfaces after an approved ISMS handoff.
+
+This is a documentation and pre-build governance alignment only.
+
+It does not implement runtime behavior.
+
+---
+
+## 2. Authority adopted
+
+This ISMS alignment adopts the boundary strategy in:
+
+```text
+modules/isms/prebuild-harvest-package/platform-module-boundary-linkup-strategy.md
+```
+
+The authority rule is:
+
+```text
+ISMS owns the shared platform journey.
+Modules own their governed module runtime surfaces.
+Agents must not build across that boundary unless specifically appointed for a cross-module wave.
+```
+
+For ISMS, this means ISMS pre-build artifacts must preserve ISMS ownership of the public platform shell and handoff contract without drifting into PIT, MMM, Risk Management, RADAM / Systems Integration, or other module runtime implementation.
+
+---
+
+## 3. ISMS-owned surfaces
+
+ISMS owns:
+
+- public landing / front door;
+- modules overview;
+- module marketing and explanation routes;
+- public free-assessment entry and other public trust/acquisition surfaces;
+- subscription and checkout orchestration;
+- authentication entry and shell;
+- onboarding and organisation baseline journey;
+- dashboard and entitlement summary;
+- entitlement and journey-state handoff;
+- shared platform shell and navigation framing;
+- cross-module governance framing and descriptor consumption.
+
+ISMS may render module cards, module descriptions, public calls-to-action, subscription states, dashboard states, and runtime entry links from approved module descriptors.
+
+ISMS must not build the module runtime behind those entry links unless a governed cross-module wave explicitly appoints that work.
+
+---
+
+## 4. Module-owned runtime surfaces
+
+Modules own their runtime surfaces after the approved ISMS handoff.
+
+Current module boundaries include:
+
+- PIT owns Project Implementation Tracker runtime, including project implementation execution surfaces, projects, milestones, deliverables, tasks, PIT evidence/progress behavior, and PIT runtime after entitled handoff.
+- MMM owns Maturity Roadmap runtime, including Domain -> MPS -> Criteria structures, maturity scoring, maturity evidence, assessment/roadmap logic, and MMM runtime after approved ISMS handoff.
+- Risk Management owns its module-specific risk runtime once appointed and handed off.
+- RADAM / Systems Integration owns its runtime integration, data extraction, and assurance/data-source behavior once appointed and handed off.
+- Future modules own their own runtime surfaces only after descriptor registration and governed ISMS handoff.
+
+Modules may supply descriptor content, entitlement keys, pricing/package requirements, runtime entry routes, role requirements, and approved marketing copy. They must not duplicate ISMS public acquisition, subscription, authentication, onboarding, dashboard, or entitlement/journey-state behavior.
+
+---
+
+## 5. ISMS pre-build stack alignment
+
+This record aligns the following ISMS pre-build references to the boundary strategy:
+
+- App Description;
+- UX / Workflow / Wiring Spec;
+- Functional Requirements Specification;
+- Technical Requirements Specification;
+- Architecture;
+- QA-to-Red;
+- PBFAG;
+- Implementation Plan;
+- Builder Checklist;
+- IAA record / pre-brief references;
+- BUILD_PROGRESS_TRACKER.
+
+The aligned interpretation is:
+
+1. ISMS public and shared journey artifacts describe ISMS-owned public/platform behavior only.
+2. ISMS artifacts may define descriptor contracts and handoff obligations for modules.
+3. ISMS artifacts must not define PIT, MMM, Risk, RADAM, or other module runtime behavior as if it belongs to ISMS.
+4. Any cross-module linkup affecting public landing, modules overview, marketing, subscription, authentication, onboarding, dashboard, entitlement, runtime route protection, module host/domain behavior, cross-module route constants, or shared role/entitlement context is governed cross-module work before implementation.
+
+---
+
+## 6. Canonical host and origin rule
+
+The canonical public host for platform acquisition and discovery remains:
+
+```text
+https://maturion-isms-portal.vercel.app
+```
+
+ISMS must preserve the canonical journey:
+
+```text
+ISMS public landing
+  -> ISMS modules overview or module card
+  -> ISMS-owned marketing / free-assessment / subscription route as applicable
+  -> ISMS authentication where required
+  -> ISMS onboarding where required
+  -> ISMS dashboard or approved handoff surface with entitlement/journey state visible
+  -> module runtime entry route when eligible or entitled
+```
+
+ISMS must not use browser local storage on one origin as proof of entitlement, onboarding, journey-state, or dashboard continuity on another origin.
+
+Until a governed cross-origin state model exists, the acquisition, subscription, onboarding, dashboard, and first runtime handoff must remain on the canonical ISMS host or another CS2-approved host model.
+
+---
+
+## 7. ISMS QA-to-red alignment obligations
+
+Future ISMS/module linkup QA-to-red must verify:
+
+1. ISMS public landing and module cards route non-entitled users to ISMS-owned marketing, public assessment, subscription, authentication, onboarding, or dashboard surfaces as applicable.
+2. Public free assessment remains an ISMS-owned acquisition/trust surface unless CS2 explicitly delegates otherwise.
+3. Marketing routes route non-entitled users to ISMS-owned subscription or approved acquisition flows.
+4. Subscription, authentication, onboarding, and dashboard states preserve or establish expected entitlement and journey-state before module runtime handoff.
+5. Dashboard or approved handoff surface shows the expected module entitlement, journey state, or runtime entry affordance.
+6. Eligible or entitled users reach the owning module runtime without unintended loopback to subscription, authentication, onboarding, dashboard setup, public assessment, or marketing.
+7. Direct runtime entry routes deny or redirect non-entitled users predictably to ISMS-owned surfaces.
+8. Direct runtime entry routes render only the owning module runtime for eligible users; ISMS links and frames but does not build module runtime content.
+9. Module-specific hosts do not expose duplicate public acquisition, subscription, authentication, onboarding, dashboard, or free-assessment loops.
+10. Cross-origin local-storage assumptions are not used as proof of entitlement or journey continuity.
+11. Role-gated module routes still respect shared role context after entitlement handoff.
+12. ISMS changes do not alter PIT, MMM, Risk Management, RADAM / Systems Integration, or other module runtime behavior unless a governed cross-module appointment authorizes it.
+
+---
+
+## 8. Implementation block
+
+The following remain blocked until this ISMS pre-build alignment is merged and a later slice is separately appointed:
+
+- P2 runtime persistence;
+- Supabase runtime persistence hooks;
+- PIT linkup implementation;
+- MMM linkup implementation;
+- Risk Management linkup implementation;
+- RADAM / Systems Integration linkup implementation;
+- future module linkup implementation;
+- workflow/deployment changes that alter app or module ownership;
+- `.agent-admin/control/delegation-order.json` changes unless a gate explicitly requires them.
+
+---
+
+## 9. Claim restriction
+
+No completion, release, production-readiness, or fully functional claim may be made from PR #1850, PIT PR #1853, MMM PR #1854, or this ISMS alignment record alone.
+
+This record only establishes ISMS-side pre-build boundary alignment.
+
+Future implementation requires a separately scoped QA-to-red/build wave, builder appointment, build-to-green work, and canonical-host evidence.
+
+---
+
+## 10. Next governed sequence
+
+The correct sequence after this ISMS alignment is:
+
+```text
+Merge ISMS pre-build boundary alignment
+  -> classify the next linkup or productionization slice
+  -> create or update boundary-specific QA-to-red
+  -> appoint the correct builder only after QA-to-red exists
+  -> build to green inside the authorized ISMS/module lane
+  -> capture canonical-host browser/runtime evidence
+  -> run Foreman / ECAP / IAA gates before CS2 merge decision
+```


### PR DESCRIPTION
Docs-only ISMS prebuild boundary alignment to PR 1850. Adds one alignment record and one tracker addendum under modules/isms. No runtime changes.