### PR TITLE
Maturion Runtime Knowledge Grounding Prebuild v0.1

### DIFF
--- a/.agent-admin/assurance/iaa-wave-record-mrkg-prebuild-v01-20260626.md
+++ b/.agent-admin/assurance/iaa-wave-record-mrkg-prebuild-v01-20260626.md
@@ -3,10 +3,11 @@
 **Wave ID**: MRKG-PREBUILD-V01  
 **Repository**: `APGI-cmy/maturion-isms`  
 **Date**: 2026-06-26  
-**Scope Declaration**: `.agent-admin/scope-declarations/maturion-runtime-knowledge-grounding-prebuild-v01.md`  
+**Scope Declaration**: `.agent-admin/scope-declarations/pr-1858.md`  
 **Related Artifacts**:
 
 - `.agent-admin/scope-declarations/maturion-runtime-knowledge-grounding-prebuild-v01.md`
+- `.agent-admin/scope-declarations/pr-1858.md`
 - `Maturion/prebuild/runtime-knowledge-grounding/MRKG-FRS-addendum-v0.1.md`
 - `Maturion/prebuild/runtime-knowledge-grounding/MRKG-TRS-supabase-aimc-metadata-v0.1.md`
 - `Maturion/prebuild/runtime-knowledge-grounding/MRKG-QA-to-Red-v0.1.md`
@@ -15,16 +16,18 @@
 
 ## PRE-BRIEF
 
-IAA_PREFLIGHT_BRIEF
+IAA_PREFLIGHT_BRIEF:
 
 schema_version: 1.0.0
 result: PREFLIGHT_BRIEF_COMPLETE
 wave_id: MRKG-PREBUILD-V01
 repository: APGI-cmy/maturion-isms
+PR: 1858
+CURRENT_HEAD_SHA: bad7e7ba35a44ca7a9c3d7db14afbafa070c6629
 scope_summary: Batch 2 prebuild-only knowledge-grounding artifacts for Runtime Maturion and governed specialists.
 authority: CS2 — Johan Ras
 
-### EXPECTED_QA_SCOPE
+EXPECTED_QA_SCOPE:
 
 - Review the FRS addendum, TRS addendum and QA-to-Red artifacts for Runtime Maturion knowledge grounding.
 - Confirm the work is prebuild-only and does not implement runtime code, Supabase changes, embeddings, retrieval services, metadata records, specialist activation or `.github/agents` changes.
@@ -35,7 +38,7 @@ authority: CS2 — Johan Ras
 - Confirm fallback behaviour avoids invented APGI facts and cross-tenant leakage.
 - Confirm QA-to-Red expectations are adequate for a later builder implementation wave.
 
-### EXPECTED_FAILURE_MODES
+EXPECTED_FAILURE_MODES:
 
 - Public Maturion can retrieve internal, restricted or tenant knowledge.
 - Tenant-scoped retrieval can cross tenant or organisation boundaries.
@@ -45,7 +48,7 @@ authority: CS2 — Johan Ras
 - Fallback behaviour silently uses another tenant, private memory, unrestricted vector search or general model knowledge as approved APGI fact.
 - Secret or restricted sources enter prompt context or audit traces without approved secret-handling architecture.
 
-### FOREMAN_INSTRUCTIONS
+FOREMAN_INSTRUCTIONS:
 
 - Treat this wave as prebuild-only.
 - Do not appoint a builder from this wave.
@@ -54,7 +57,7 @@ authority: CS2 — Johan Ras
 - Use IAA findings to correct prebuild artifacts before any implementation wave is created.
 - Keep Batch 3 APW Specialist Prebuild as a separate future wave.
 
-### IAA_WILL_QA
+IAA_WILL_QA:
 
 - IAA will compare the artifacts against Batch 1 runtime-agent-network prebuild artifacts and the layered-down Maturion Agent Network Organigram canon.
 - IAA will check that knowledge-plane separation aligns with context-envelope and runtime-registry requirements.

--- a/.agent-admin/assurance/iaa-wave-record-mrkg-prebuild-v01-20260626.md
+++ b/.agent-admin/assurance/iaa-wave-record-mrkg-prebuild-v01-20260626.md
@@ -1,0 +1,94 @@
+# IAA Wave Record — MRKG Prebuild v0.1
+
+**Wave ID**: MRKG-PREBUILD-V01  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Date**: 2026-06-26  
+**Scope Declaration**: `.agent-admin/scope-declarations/maturion-runtime-knowledge-grounding-prebuild-v01.md`  
+**Related Artifacts**:
+
+- `.agent-admin/scope-declarations/maturion-runtime-knowledge-grounding-prebuild-v01.md`
+- `Maturion/prebuild/runtime-knowledge-grounding/MRKG-FRS-addendum-v0.1.md`
+- `Maturion/prebuild/runtime-knowledge-grounding/MRKG-TRS-supabase-aimc-metadata-v0.1.md`
+- `Maturion/prebuild/runtime-knowledge-grounding/MRKG-QA-to-Red-v0.1.md`
+
+---
+
+## PRE-BRIEF
+
+IAA_PREFLIGHT_BRIEF
+
+schema_version: 1.0.0
+result: PREFLIGHT_BRIEF_COMPLETE
+wave_id: MRKG-PREBUILD-V01
+repository: APGI-cmy/maturion-isms
+scope_summary: Batch 2 prebuild-only knowledge-grounding artifacts for Runtime Maturion and governed specialists.
+authority: CS2 — Johan Ras
+
+### EXPECTED_QA_SCOPE
+
+- Review the FRS addendum, TRS addendum and QA-to-Red artifacts for Runtime Maturion knowledge grounding.
+- Confirm the work is prebuild-only and does not implement runtime code, Supabase changes, embeddings, retrieval services, metadata records, specialist activation or `.github/agents` changes.
+- Confirm knowledge planes are sufficiently separated.
+- Confirm public/private/tenant filters are explicit enough to prevent unsafe retrieval.
+- Confirm source hierarchy and conflict behaviour are defined.
+- Confirm missing metadata fails closed and does not default to public-safe.
+- Confirm fallback behaviour avoids invented APGI facts and cross-tenant leakage.
+- Confirm QA-to-Red expectations are adequate for a later builder implementation wave.
+
+### EXPECTED_FAILURE_MODES
+
+- Public Maturion can retrieve internal, restricted or tenant knowledge.
+- Tenant-scoped retrieval can cross tenant or organisation boundaries.
+- Missing metadata defaults to public, tenant-safe or retrieval-allowed.
+- Lower-authority or stale sources override canon or newer approved artifacts.
+- Specialists receive knowledge planes beyond the context envelope or registry limits.
+- Fallback behaviour silently uses another tenant, private memory, unrestricted vector search or general model knowledge as approved APGI fact.
+- Secret or restricted sources enter prompt context or audit traces without approved secret-handling architecture.
+
+### FOREMAN_INSTRUCTIONS
+
+- Treat this wave as prebuild-only.
+- Do not appoint a builder from this wave.
+- Do not implement code, migrations, schemas, retrieval services, embeddings, metadata storage, Supabase policies, runtime routing, memory writes or specialist activation.
+- Do not modify `.github/agents` files.
+- Use IAA findings to correct prebuild artifacts before any implementation wave is created.
+- Keep Batch 3 APW Specialist Prebuild as a separate future wave.
+
+### IAA_WILL_QA
+
+- IAA will compare the artifacts against Batch 1 runtime-agent-network prebuild artifacts and the layered-down Maturion Agent Network Organigram canon.
+- IAA will check that knowledge-plane separation aligns with context-envelope and runtime-registry requirements.
+- IAA will check whether public, authenticated, tenant, governance and secret filters are clear and fail closed.
+- IAA will check that source hierarchy and conflict handling preserve authority order.
+- IAA will check that QA-to-Red covers public-safe retrieval, tenant isolation, missing metadata, source conflict, staleness, specialist limits, fallback behaviour and secret/restricted knowledge.
+- IAA will not issue final assurance inside this pre-brief block.
+
+RESULT: PREFLIGHT_BRIEF_COMPLETE
+
+---
+
+## NON-IMPLEMENTATION BOUNDARY
+
+This wave does not:
+
+- create runtime code;
+- alter application behaviour;
+- create or mutate Supabase tables;
+- run migrations;
+- create embeddings;
+- upload or reclassify knowledge documents;
+- create or activate runtime specialists;
+- create APW specialist;
+- create retrieval services;
+- alter tenant isolation;
+- write or read production tenant data;
+- change `.github/agents` files;
+- grant Maturion CS2 authority.
+
+---
+
+## REQUESTED IAA OUTPUT
+
+IAA should provide a later independent assurance verdict or rejection package after reviewing the prebuild artifact set.
+
+This file records the pre-brief only. It does not contain IAA final assurance, a merge verdict, or CS2 approval.

--- a/.agent-admin/scope-declarations/maturion-runtime-knowledge-grounding-prebuild-v01.md
+++ b/.agent-admin/scope-declarations/maturion-runtime-knowledge-grounding-prebuild-v01.md
@@ -1,0 +1,116 @@
+# Scope Declaration — Maturion Runtime Knowledge Grounding Prebuild v0.1
+
+**Scope ID**: MRKG-PREBUILD-V01  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Maturion Runtime Knowledge Grounding Prebuild v0.1  
+**Date**: 2026-06-26  
+**Authority**: CS2 — Johan Ras  
+**Operating Role**: Foreman-led governed delivery  
+**Task Type**: Prebuild architecture artifacts only  
+**Affected Scope**: Cross-module Maturion / AIMC knowledge grounding  
+**Implementation Status**: No implementation in this wave
+
+---
+
+## 1. Purpose
+
+This wave creates Batch 2 prebuild artifacts for Maturion runtime knowledge grounding.
+
+It defines how Maturion and runtime specialists may use Supabase/AIMC knowledge safely, including public/private/tenant filters, source hierarchy, metadata expectations, safe fallback behaviour, and failure-first QA expectations.
+
+This batch answers:
+
+```text
+What knowledge can Maturion use, from where, under what authority, and with what safety filters?
+```
+
+---
+
+## 2. Source Authority
+
+This scope is governed by:
+
+- `FOREMAN_OPERATING_MODEL.md`;
+- `.github/agents/foreman-v2-agent.md`;
+- `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`;
+- `Maturion/prebuild/runtime-agent-network/MRAN-FRS-v0.1.md`;
+- `Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md`;
+- `Maturion/prebuild/runtime-agent-network/MRAN-QA-to-Red-v0.1.md`;
+- `Maturion/strategy/Maturion_agent_network_organigram_strategy.md`.
+
+---
+
+## 3. In Scope
+
+This wave creates:
+
+1. `Maturion/prebuild/runtime-knowledge-grounding/MRKG-FRS-addendum-v0.1.md`
+2. `Maturion/prebuild/runtime-knowledge-grounding/MRKG-TRS-supabase-aimc-metadata-v0.1.md`
+3. `Maturion/prebuild/runtime-knowledge-grounding/MRKG-QA-to-Red-v0.1.md`
+4. `.agent-admin/assurance/iaa-wave-record-mrkg-prebuild-v01-20260626.md`
+5. this wave scope declaration.
+
+The artifacts define:
+
+- knowledge-plane behaviour;
+- Supabase/AIMC metadata requirements;
+- public/private/tenant filtering;
+- source hierarchy and trust order;
+- missing metadata behaviour;
+- fallback/degraded modes;
+- QA-to-Red tests for public-safe retrieval, tenant isolation, missing metadata and fallback behaviour;
+- IAA pre-brief for independent review.
+
+---
+
+## 4. Out of Scope
+
+This wave does not:
+
+- create runtime code;
+- alter application behaviour;
+- create or mutate Supabase tables;
+- run migrations;
+- create embeddings;
+- upload or reclassify knowledge documents;
+- create or activate runtime specialists;
+- create APW specialist;
+- create retrieval services;
+- alter tenant isolation;
+- write or read production tenant data;
+- change `.github/agents` files;
+- grant Maturion CS2 authority.
+
+---
+
+## 5. Foreman Boundary
+
+Foreman may create and organise these prebuild artifacts. Foreman may not implement runtime, Supabase, retrieval, migration, registry, or product behaviour.
+
+Builder appointment is not part of this wave.
+
+---
+
+## 6. Success Criteria
+
+This wave succeeds when:
+
+1. the scope declaration exists;
+2. FRS addendum defines knowledge-plane and retrieval behaviour;
+3. TRS addendum defines Supabase/AIMC metadata, filters and source hierarchy;
+4. QA-to-Red defines failure-first expectations for public-safe retrieval, tenant isolation, missing metadata and fallback behaviour;
+5. IAA pre-brief is recorded in canonical form;
+6. no implementation files are changed;
+7. no Supabase mutation occurs;
+8. no runtime specialist is activated;
+9. no Maturion-as-CS2 authority is granted.
+
+---
+
+## 7. Known Follow-On Waves
+
+This wave intentionally leaves the following to later batches:
+
+1. Batch 3 — APW Specialist Prebuild.
+2. Implementation waves for metadata enforcement, retrieval services, registry integration, audit trace storage, and public Maturion behaviour.
+3. Supabase schema or migration work only after the relevant prebuild artifacts, QA-to-red, IAA pre-brief, builder appointment, QP, ECAP, IAA final, and CS2 review are satisfied.

--- a/.agent-admin/scope-declarations/pr-1858.md
+++ b/.agent-admin/scope-declarations/pr-1858.md
@@ -1,0 +1,83 @@
+# Scope Declaration — PR #1858
+
+**Scope ID**: PR-1858-MRKG-PREBUILD-V01  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Pull Request**: #1858  
+**Wave**: Maturion Runtime Knowledge Grounding Prebuild v0.1  
+**Date**: 2026-06-26  
+**Authority**: CS2 — Johan Ras  
+**Operating Role**: Foreman-led governed delivery  
+**Task Type**: Prebuild architecture artifacts only  
+**Affected Scope**: Cross-module Maturion / AIMC knowledge grounding  
+**Implementation Status**: No implementation in this PR
+
+---
+
+## 1. Active PR Scope
+
+This is the active per-PR scope declaration for PR #1858.
+
+It mirrors the wave scope declaration and exists so PR-level scope/diff parity gates can discover the active changed-file set.
+
+---
+
+## 2. Changed Files in Scope
+
+This PR is limited to these files:
+
+1. `.agent-admin/scope-declarations/maturion-runtime-knowledge-grounding-prebuild-v01.md`
+2. `.agent-admin/scope-declarations/pr-1858.md`
+3. `Maturion/prebuild/runtime-knowledge-grounding/MRKG-FRS-addendum-v0.1.md`
+4. `Maturion/prebuild/runtime-knowledge-grounding/MRKG-TRS-supabase-aimc-metadata-v0.1.md`
+5. `Maturion/prebuild/runtime-knowledge-grounding/MRKG-QA-to-Red-v0.1.md`
+6. `.agent-admin/assurance/iaa-wave-record-mrkg-prebuild-v01-20260626.md`
+
+---
+
+## 3. Source Authority
+
+This scope is governed by:
+
+- `FOREMAN_OPERATING_MODEL.md`;
+- `.github/agents/foreman-v2-agent.md`;
+- `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`;
+- Batch 1 runtime-agent-network prebuild artifacts;
+- `Maturion/strategy/Maturion_agent_network_organigram_strategy.md`.
+
+---
+
+## 4. In Scope
+
+This PR creates Batch 2 prebuild artifacts for Runtime Maturion knowledge grounding:
+
+- FRS addendum for knowledge planes and retrieval behaviour;
+- TRS addendum for Supabase/AIMC metadata, source hierarchy and filters;
+- QA-to-Red expectations for public-safe retrieval, tenant isolation, missing metadata and fallback behaviour;
+- IAA pre-brief;
+- scope declarations.
+
+---
+
+## 5. Out of Scope
+
+This PR does not:
+
+- create runtime code;
+- alter application behaviour;
+- create or mutate Supabase tables;
+- run migrations;
+- create embeddings;
+- upload or reclassify knowledge documents;
+- create or activate runtime specialists;
+- create APW specialist;
+- create retrieval services;
+- alter tenant isolation;
+- write or read production tenant data;
+- change `.github/agents` files;
+- grant Maturion CS2 authority.
+
+---
+
+## 6. Gate Note
+
+This file is the active PR-level scope declaration. The wave-named scope declaration remains the durable wave artifact, while this file supports PR-level scope/diff validation.

--- a/Maturion/prebuild/runtime-knowledge-grounding/MRKG-FRS-addendum-v0.1.md
+++ b/Maturion/prebuild/runtime-knowledge-grounding/MRKG-FRS-addendum-v0.1.md
@@ -1,0 +1,222 @@
+# FRS Addendum — Maturion Runtime Knowledge Grounding v0.1
+
+**Artifact ID**: MRKG-FRS-ADD-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — Functional Requirements Addendum  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Maturion Runtime Knowledge Grounding Prebuild v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-26  
+**Parent FRS**: `Maturion/prebuild/runtime-agent-network/MRAN-FRS-v0.1.md`  
+**Scope Declaration**: `.agent-admin/scope-declarations/maturion-runtime-knowledge-grounding-prebuild-v01.md`
+
+---
+
+## 1. Purpose
+
+This addendum defines how Runtime Maturion and governed runtime specialists may use knowledge safely.
+
+It extends the Batch 1 runtime agent-network prebuild by defining knowledge-plane behaviour, retrieval authority, source hierarchy, safety filters and fallback rules.
+
+Core question:
+
+```text
+What knowledge can Maturion use, from where, under what authority, and with what safety filters?
+```
+
+---
+
+## 2. Functional Principle
+
+```text
+No metadata, no unrestricted retrieval.
+No authority, no private knowledge.
+No tenant scope, no tenant context.
+No verified source class, no confident governed answer.
+```
+
+Maturion must prefer a safe limitation over an unsafe answer.
+
+---
+
+## 3. Knowledge Plane Definitions
+
+Runtime Maturion must distinguish at least these knowledge planes:
+
+| Plane | Description | Example Use |
+|---|---|---|
+| Canon / Constitution | Governance canon, non-negotiable rules, authority boundaries. | Agent separation, CS2 authority limits, activation prohibitions. |
+| Subject Knowledge Domain | General APGI-approved subject matter. | Risk, security, assurance, maturity model concepts. |
+| App Context Domain | Public or app-specific product knowledge. | APW public pages, ISMS module descriptions, onboarding explanations. |
+| Framework / Context Domain | Client framework mappings or contextual implementation guidance. | ISO/NIST/COSO mappings, maturity framework variants. |
+| Tenant / Organisation Context | Customer-specific data, settings, documents, findings or evidence. | Tenant audit findings, evidence, policies, account state. |
+| User / Session Context | Current authenticated user role, session, page/workflow and explicit request. | Current page help, form guidance, workflow step support. |
+| Memory | Approved retained context from prior interactions. | Remembered preferences or project state, where allowed. |
+
+---
+
+## 4. Retrieval Authority Requirements
+
+### FRS-MRKG-001 — Permission-Scope Driven Retrieval
+
+Maturion must select retrieval scope from the validated context envelope.
+
+Public requests may use only public-safe knowledge planes. Authenticated requests may use authenticated app context. Tenant-scoped requests may use tenant knowledge only when tenant identity, user identity and permission are validated.
+
+### FRS-MRKG-002 — Metadata-First Retrieval
+
+Every retrievable knowledge object must carry metadata sufficient to decide whether Maturion may use it.
+
+If metadata is missing, ambiguous, stale or contradictory, the object must not be treated as public-safe, tenant-safe or authority-safe.
+
+### FRS-MRKG-003 — Source Hierarchy
+
+Maturion must apply a source hierarchy before answering governed questions.
+
+Default hierarchy:
+
+1. Canon / constitutional authority;
+2. CS2-approved strategy or prebuild artifacts;
+3. module authority documents;
+4. approved knowledge-base records;
+5. public website / public app content;
+6. user-provided current-session content;
+7. general model knowledge as fallback only, with limitation disclosure where appropriate.
+
+### FRS-MRKG-004 — Public-Safe Retrieval
+
+Public or unauthenticated Maturion may retrieve only knowledge marked public-safe or otherwise approved for public use.
+
+Public mode must not expose:
+
+- tenant records;
+- customer names or account data;
+- private strategy not marked public;
+- internal governance details that are not public-facing;
+- evidence, incidents, audit findings or operational data;
+- private memory.
+
+### FRS-MRKG-005 — Tenant Isolation
+
+Tenant-scoped retrieval must be restricted to the active tenant/organisation scope.
+
+Maturion must not blend tenant knowledge, compare tenants, leak cross-tenant context, or answer from one tenant's data for another tenant.
+
+### FRS-MRKG-006 — Specialist Knowledge Limits
+
+Specialists may receive only the knowledge planes allowed by:
+
+- the context envelope;
+- the runtime registry record;
+- the specialist contract or prebuild scope;
+- the current task purpose;
+- relevant guardrails.
+
+Specialists must not self-expand retrieval scope.
+
+### FRS-MRKG-007 — Missing Knowledge Behaviour
+
+When required knowledge is missing, Maturion must:
+
+- say that the governed source is unavailable;
+- avoid inventing APGI facts;
+- answer from public/general knowledge only if safe;
+- request source material or escalate where necessary;
+- preserve user trust by clearly marking limitations.
+
+### FRS-MRKG-008 — Conflict Resolution
+
+If sources conflict, Maturion must prefer the highest-authority applicable source. If conflict remains unresolved, Maturion must disclose uncertainty and escalate rather than silently choosing a lower-authority source.
+
+### FRS-MRKG-009 — Retrieval Auditability
+
+Future implementation must record enough retrieval evidence to explain why a source was used or blocked, without storing secrets or unnecessary private data in the trace.
+
+### FRS-MRKG-010 — No Authority by Retrieval
+
+Retrieving a canon, policy, strategy or customer document must not grant Maturion authority to approve, waive, sign off or act as CS2. Authority remains separately governed.
+
+---
+
+## 5. Public Mode Behaviour
+
+In public APW/public-web mode, Maturion may:
+
+- explain APGI/Maturion concepts using approved public-safe material;
+- answer generic subject questions from public-safe knowledge;
+- guide a user toward contact/onboarding paths;
+- explain limitations where private knowledge would be required.
+
+In public APW/public-web mode, Maturion must not:
+
+- retrieve tenant records;
+- identify customer-specific implementations;
+- expose internal project/gate/PR details unless deliberately public-safe;
+- use private memory;
+- provide private operational advice based on non-public sources.
+
+---
+
+## 6. Authenticated App Behaviour
+
+In authenticated app mode, Maturion may use app context and authenticated user/session context.
+
+Tenant or organisation knowledge may be used only when:
+
+1. the user is authenticated;
+2. tenant/organisation scope is present;
+3. permission allows access;
+4. source metadata matches the tenant/organisation scope;
+5. audit trace can record the retrieval decision.
+
+---
+
+## 7. Fallback Behaviour
+
+Fallback must be conservative.
+
+Allowed fallback examples:
+
+- answer from public knowledge when public/private classification is clear;
+- answer from current user-provided content when the user explicitly supplied the content in the current session;
+- ask the user to upload or identify the relevant document;
+- route to human review or CS2 when authority is unclear;
+- provide general explanation with clear limitation statement.
+
+Disallowed fallback examples:
+
+- treating missing metadata as public;
+- assuming tenant access because a user is logged in;
+- using old strategy as current canon without checking authority;
+- inferring customer facts from similar tenants;
+- using global memory for tenant-specific answers.
+
+---
+
+## 8. Acceptance Conditions
+
+This addendum is acceptable for Batch 2 if it defines:
+
+- knowledge planes;
+- retrieval authority requirements;
+- public-safe behaviour;
+- tenant isolation behaviour;
+- source hierarchy;
+- missing knowledge fallback;
+- conflict handling;
+- retrieval auditability;
+- no implementation in Batch 2.
+
+---
+
+## 9. Deferred Implementation
+
+Implementation remains blocked until later waves define and approve:
+
+- metadata storage model;
+- retrieval enforcement service;
+- registry integration;
+- source ingestion process;
+- audit trace storage;
+- public/private/tenant test fixtures;
+- builder appointment and build-to-green package.

--- a/Maturion/prebuild/runtime-knowledge-grounding/MRKG-QA-to-Red-v0.1.md
+++ b/Maturion/prebuild/runtime-knowledge-grounding/MRKG-QA-to-Red-v0.1.md
@@ -1,0 +1,221 @@
+# QA-to-Red — Maturion Runtime Knowledge Grounding v0.1
+
+**Artifact ID**: MRKG-QA-RED-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — QA-to-Red  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Maturion Runtime Knowledge Grounding Prebuild v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-26  
+**Related FRS Addendum**: `Maturion/prebuild/runtime-knowledge-grounding/MRKG-FRS-addendum-v0.1.md`  
+**Related TRS Addendum**: `Maturion/prebuild/runtime-knowledge-grounding/MRKG-TRS-supabase-aimc-metadata-v0.1.md`
+
+---
+
+## 1. Purpose
+
+This QA-to-Red artifact defines failure-first validation expectations for Runtime Maturion knowledge grounding.
+
+The goal is to make future implementation prove that retrieval blocks unsafe knowledge use before any builder makes the behaviour green.
+
+---
+
+## 2. QA-to-Red Principle
+
+```text
+Knowledge retrieval must fail closed when metadata, authority, permission, source hierarchy or tenant scope is missing or unsafe.
+```
+
+---
+
+## 3. Test Categories
+
+### QA-MRKG-CAT-001 — Public-Safe Retrieval
+
+Public Maturion must retrieve only public-safe sources.
+
+Red cases:
+
+1. public APW request retrieves object with `visibility = internal`;
+2. public APW request retrieves object with `public_safe = false`;
+3. public APW request retrieves object with `requires_authentication = true`;
+4. public APW request retrieves object with `tenant_id` populated;
+5. public APW request retrieves private strategy not marked public-safe;
+6. public APW request retrieves internal governance commentary as public advice.
+
+Expected red result:
+
+- source blocked;
+- no tenant/private/internal leakage;
+- Maturion answers from allowed public sources only or gives limitation/handoff.
+
+### QA-MRKG-CAT-002 — Tenant Isolation
+
+Tenant-scoped retrieval must never cross tenant boundaries.
+
+Red cases:
+
+1. tenant A user retrieves tenant B record;
+2. tenant-scoped request lacks `tenant_id`;
+3. tenant source has `requires_tenant_match = true` but context has no tenant;
+4. tenant source has organisation mismatch;
+5. user role lacks access to tenant source;
+6. specialist receives tenant source outside its allowed knowledge planes.
+
+Expected red result:
+
+- retrieval blocked;
+- cross-tenant data not exposed;
+- audit trace records mismatch/block reason;
+- safe fallback or escalation used.
+
+### QA-MRKG-CAT-003 — Missing Metadata
+
+Missing metadata must not default to safe.
+
+Red cases:
+
+1. source has no `visibility`;
+2. source has no `public_safe` field;
+3. source has no `tenant_id` but claims tenant visibility;
+4. source has `retrieval_allowed` missing;
+5. source has contradictory visibility and public-safe flags;
+6. source has no source class or authority level.
+
+Expected red result:
+
+- object blocked;
+- no specialist receives the object;
+- Maturion discloses limitation or uses other approved sources.
+
+### QA-MRKG-CAT-004 — Source Hierarchy and Conflict
+
+Higher authority must override lower authority.
+
+Red cases:
+
+1. public content conflicts with canon and public content wins;
+2. old strategy conflicts with newer prebuild and old strategy wins;
+3. module document conflicts with canon and module document wins;
+4. general model knowledge conflicts with approved APGI knowledge and model knowledge wins;
+5. external source overrides APGI canon without explicit approval.
+
+Expected red result:
+
+- lower-authority source is not used as controlling authority;
+- Maturion discloses conflict if unresolved;
+- escalation triggered where appropriate.
+
+### QA-MRKG-CAT-005 — Supersession and Staleness
+
+Expired or superseded knowledge must not drive current governed answers.
+
+Red cases:
+
+1. expired source is used as current authority;
+2. superseded source is used over superseding source;
+3. stale source used despite newer higher-authority conflict;
+4. source checksum/integrity failure is ignored;
+5. unreviewed restricted source is treated as current.
+
+Expected red result:
+
+- source blocked for current answer;
+- historical mention allowed only when explicitly framed as historical;
+- audit trace records stale/superseded reason.
+
+### QA-MRKG-CAT-006 — Specialist Knowledge Limits
+
+Specialists must not receive disallowed knowledge planes.
+
+Red cases:
+
+1. APW specialist receives tenant context in public mode;
+2. report writer receives private tenant evidence without tenant permission;
+3. domain specialist requests memory when memory is disallowed;
+4. retrieval/ranking specialist bypasses context envelope;
+5. specialist self-expands source class beyond registry limits.
+
+Expected red result:
+
+- knowledge not passed to specialist;
+- Maturion blocks or degrades;
+- specialist output is not trusted if it relied on disallowed source.
+
+### QA-MRKG-CAT-007 — Fallback Behaviour
+
+Fallback must not become hidden unsafe retrieval.
+
+Red cases:
+
+1. missing metadata triggers unrestricted vector search;
+2. unavailable tenant source falls back to another tenant;
+3. missing APGI source causes confident invented APGI facts;
+4. general model knowledge is presented as approved APGI policy;
+5. fallback memory is used in public mode.
+
+Expected red result:
+
+- fallback limited to allowed sources;
+- limitation disclosed;
+- no invented governed APGI fact;
+- escalation or user-source request where required.
+
+### QA-MRKG-CAT-008 — Secret and Restricted Knowledge
+
+Secret or restricted sources must not be retrieved unless a later secret-handling architecture approves it.
+
+Red cases:
+
+1. object marked `secret` is retrieved by Runtime Maturion;
+2. restricted source retrieved in public mode;
+3. secret source passed to specialist;
+4. source contains credentials or tokens and is used in prompt context;
+5. audit trace stores raw secret content.
+
+Expected red result:
+
+- source blocked;
+- no secret content in prompt or trace;
+- incident/escalation path defined in later implementation wave.
+
+---
+
+## 4. Minimum Future Test Fixtures
+
+Future implementation should include fixtures for:
+
+- public-safe APW knowledge object;
+- internal APGI strategy object;
+- tenant A record;
+- tenant B record;
+- missing metadata object;
+- contradictory metadata object;
+- expired source;
+- superseded source;
+- canon source;
+- lower-authority conflicting public source;
+- secret source;
+- user-supplied current-session content.
+
+---
+
+## 5. Red Evidence Required Before Build-to-Green
+
+Before implementation builders are appointed, a future implementation wave must define tests or validation scripts that initially fail for the red cases above.
+
+Evidence must show:
+
+1. the unsafe retrieval attempt;
+2. the expected blocked/degraded/fallback behaviour;
+3. the metadata/filter/authority rule being tested;
+4. the intended green behaviour;
+5. the artifact requirement traced back to FRS/TRS.
+
+---
+
+## 6. Batch 2 QA Disposition
+
+This QA-to-Red artifact is prebuild-only. It does not create tests, code, migrations, retrieval services, metadata records, embeddings, Supabase policies or runtime functionality.
+
+It creates the validation expectation that future implementation must satisfy.

--- a/Maturion/prebuild/runtime-knowledge-grounding/MRKG-TRS-supabase-aimc-metadata-v0.1.md
+++ b/Maturion/prebuild/runtime-knowledge-grounding/MRKG-TRS-supabase-aimc-metadata-v0.1.md
@@ -1,0 +1,254 @@
+# TRS Addendum — Supabase/AIMC Metadata, Filters and Source Hierarchy v0.1
+
+**Artifact ID**: MRKG-TRS-ADD-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — Technical Requirements Addendum  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Maturion Runtime Knowledge Grounding Prebuild v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-26  
+**Parent TRS**: `Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md`  
+**Related FRS Addendum**: `Maturion/prebuild/runtime-knowledge-grounding/MRKG-FRS-addendum-v0.1.md`
+
+---
+
+## 1. Purpose
+
+This addendum defines the technical prebuild requirements for safe Runtime Maturion knowledge grounding across Supabase/AIMC knowledge sources.
+
+It specifies metadata requirements, source hierarchy, public/private/tenant filtering, missing metadata handling and audit expectations.
+
+This is a prebuild document only. It does not create tables, migrations, functions, policies, embeddings, retrieval services or production behaviour.
+
+---
+
+## 2. Technical Principle
+
+```text
+Retrieval is allowed only when metadata, authority, permission scope and source class all agree.
+```
+
+If the system cannot prove that retrieval is permitted, it must block or degrade.
+
+---
+
+## 3. Knowledge Object Metadata Model
+
+Every retrievable knowledge object must eventually carry metadata equivalent to the following fields:
+
+```json
+{
+  "knowledge_id": "string",
+  "title": "string",
+  "source_class": "canon|strategy|prebuild|module_authority|approved_kb|public_content|tenant_document|tenant_record|user_session|memory|external_reference",
+  "visibility": "public|authenticated|tenant|restricted|internal|secret",
+  "authority_level": "constitutional|cs2_approved|module_owner_approved|tenant_owner_approved|user_supplied|unverified",
+  "app_scope": ["APW", "ISMS", "MMM", "MAT", "PIT", "XDETECT", "AMC"],
+  "tenant_id": "string|null",
+  "organisation_id": "string|null",
+  "framework_scope": ["ISO27001", "NIST_CSF", "COSO_ERM", "ISO42001"],
+  "knowledge_planes": ["canon", "subject", "app_context", "framework_context", "tenant_context", "user_session", "memory"],
+  "public_safe": "boolean",
+  "retrieval_allowed": "boolean",
+  "requires_authentication": "boolean",
+  "requires_tenant_match": "boolean",
+  "requires_role": ["string"],
+  "effective_from": "date|null",
+  "expires_at": "date|null",
+  "supersedes": ["knowledge_id"],
+  "source_uri": "string|null",
+  "checksum": "string|null",
+  "approved_by": "string|null",
+  "last_reviewed": "date|null"
+}
+```
+
+These fields describe required behaviour. Batch 2 does not implement storage.
+
+---
+
+## 4. Source Hierarchy
+
+Runtime retrieval must evaluate source hierarchy in this order unless a later canon overrides it:
+
+1. Canon / constitutional authority.
+2. CS2-approved strategy or prebuild artifacts.
+3. Module authority documents.
+4. Approved knowledge-base records.
+5. Public app or public website content.
+6. Tenant-owner approved tenant records.
+7. Current-session user-supplied content.
+8. General model knowledge as fallback only.
+9. External references only where explicitly allowed and cited/verified.
+
+Higher-authority sources override lower-authority sources within their applicable scope.
+
+---
+
+## 5. Retrieval Decision Inputs
+
+A retrieval decision must consider:
+
+- validated context envelope;
+- runtime registry record;
+- user authentication state;
+- permission scope;
+- tenant/organisation scope;
+- requested task purpose;
+- specialist authority limits;
+- source metadata;
+- source hierarchy;
+- expiry/supersession state;
+- guardrails and safety overlays.
+
+---
+
+## 6. Filter Requirements
+
+### 6.1 Public Filter
+
+Public retrieval may include a knowledge object only if:
+
+- `visibility = public`;
+- `public_safe = true`;
+- `retrieval_allowed = true`;
+- `requires_authentication = false`;
+- `requires_tenant_match = false`;
+- `tenant_id = null`;
+- `organisation_id = null`, unless deliberately marked as public organisational profile content;
+- object is not expired or superseded.
+
+### 6.2 Authenticated Filter
+
+Authenticated retrieval may include a knowledge object only if:
+
+- user is authenticated;
+- object visibility allows authenticated access;
+- object app scope matches current app or is global;
+- role requirements are satisfied;
+- object is not expired or superseded.
+
+Authenticated mode alone does not permit tenant-private retrieval.
+
+### 6.3 Tenant Filter
+
+Tenant retrieval may include a knowledge object only if:
+
+- user is authenticated;
+- context envelope includes tenant/organisation scope;
+- object `tenant_id` or `organisation_id` matches the active scope;
+- `requires_tenant_match = true` is satisfied;
+- user role/permission allows the object;
+- object visibility is tenant/restricted and not secret unless specifically authorised;
+- object is not expired or superseded.
+
+### 6.4 Internal/Governance Filter
+
+Internal/governance retrieval may include internal governance records only where the context envelope allows governance scope and the runtime authority model permits the use.
+
+Governance retrieval does not grant action authority. It only provides information for governed reasoning.
+
+### 6.5 Secret Filter
+
+Objects marked `secret` must not be retrieved into Runtime Maturion unless a separate secret-handling architecture exists and has been approved.
+
+Batch 2 does not approve secret retrieval.
+
+---
+
+## 7. Missing Metadata Behaviour
+
+If any required metadata field is missing, ambiguous or contradictory:
+
+- public retrieval must block the object;
+- tenant retrieval must block the object;
+- specialist retrieval must not receive the object;
+- audit trace must record missing metadata;
+- Maturion may answer only from other allowed sources or degrade.
+
+Missing metadata must never default to public-safe.
+
+---
+
+## 8. Supersession and Staleness
+
+A knowledge object must be treated as stale or blocked when:
+
+- `expires_at` has passed;
+- `supersedes` indicates another active object replaces it;
+- checksum/source integrity fails;
+- authority source is older than a conflicting higher-authority source;
+- last review is outside the required review cycle for that source class.
+
+The system may still mention a stale object only as historical context when explicitly appropriate.
+
+---
+
+## 9. Specialist Retrieval Contract
+
+Before a specialist receives knowledge, the orchestrator must check:
+
+1. specialist registry status permits invocation;
+2. specialist allowed knowledge planes include the candidate source;
+3. context envelope allows the knowledge plane;
+4. metadata filters allow the source;
+5. task purpose matches specialist mandate;
+6. audit trace can record the retrieval decision.
+
+Specialists must not directly bypass the retrieval gate.
+
+---
+
+## 10. Audit Trace Requirements
+
+A future retrieval audit trace should record:
+
+```json
+{
+  "request_id": "string",
+  "retrieval_decision": "allowed|blocked|degraded|fallback",
+  "permission_scope": "public|authenticated|tenant_scoped|superuser|governance",
+  "source_class": "string|null",
+  "knowledge_planes_used": ["string"],
+  "filter_applied": "public|authenticated|tenant|governance|secret_block",
+  "blocked_reason": "string|null",
+  "fallback_used": "none|public_only|user_supplied|general_model|escalation",
+  "metadata_complete": "boolean",
+  "tenant_match": "boolean|null",
+  "specialist_id": "string|null"
+}
+```
+
+Audit traces must avoid storing secrets, raw confidential documents or unnecessary private tenant content.
+
+---
+
+## 11. Fallback Decision Matrix
+
+| Condition | Allowed Behaviour |
+|---|---|
+| Public request, public-safe source available | Use public-safe source. |
+| Public request, only private/tenant source available | Block private source; provide limitation or handoff. |
+| Authenticated request, app context available | Use authorised app context. |
+| Authenticated request, tenant source requested but no tenant scope | Block tenant source; request proper context or escalate. |
+| Tenant request, matching tenant source available | Use source if role and metadata checks pass. |
+| Tenant request, tenant mismatch | Block and record isolation event. |
+| Missing metadata | Block source; use allowed fallback only. |
+| Conflicting sources | Prefer highest authority; escalate if unresolved. |
+| Expired or superseded source | Block for current governed answer; mention as historical only if suitable. |
+
+---
+
+## 12. Batch 2 Technical Acceptance
+
+Batch 2 is technically acceptable if it defines:
+
+- minimum knowledge metadata;
+- source hierarchy;
+- public, authenticated, tenant, governance and secret filters;
+- missing metadata behaviour;
+- supersession/staleness behaviour;
+- specialist retrieval contract;
+- audit trace expectations;
+- fallback matrix;
+- no implementation before later builder waves.

--- a/Maturion/prebuild/runtime-knowledge-grounding/MRKG-TRS-supabase-aimc-metadata-v0.1.md
+++ b/Maturion/prebuild/runtime-knowledge-grounding/MRKG-TRS-supabase-aimc-metadata-v0.1.md
@@ -67,21 +67,70 @@ These fields describe required behaviour. Batch 2 does not implement storage.
 
 ---
 
-## 4. Source Hierarchy
+## 4. Scope-Specific Source Hierarchy
 
-Runtime retrieval must evaluate source hierarchy in this order unless a later canon overrides it:
+Runtime retrieval must evaluate source hierarchy by permission scope unless a later canon overrides it.
+
+### 4.1 Universal Authority Rule
+
+Canon / constitutional authority remains the highest applicable source for governance boundaries, authority, agent separation, activation rules, safety rules and non-negotiable controls.
+
+Higher-authority sources override lower-authority sources within their applicable scope. Public content must never override tenant-scoped records for tenant-specific answers.
+
+### 4.2 Public Scope Hierarchy
+
+For public or unauthenticated answers:
+
+1. Canon / constitutional authority, where public-safe to disclose.
+2. CS2-approved public strategy or public-safe prebuild artifacts.
+3. Public module authority documents.
+4. Approved public knowledge-base records.
+5. Public app or public website content.
+6. Current-session user-supplied content.
+7. General model knowledge as fallback only.
+8. External references only where explicitly allowed and cited/verified.
+
+### 4.3 Authenticated App Scope Hierarchy
+
+For authenticated app-context answers that are not tenant-private:
+
+1. Canon / constitutional authority.
+2. CS2-approved strategy or prebuild artifacts applicable to the app.
+3. Module authority documents.
+4. Approved authenticated knowledge-base records.
+5. Authenticated app context and current workflow/page state.
+6. Current-session user-supplied content.
+7. Public app or public website content as supplementary context only.
+8. General model knowledge as fallback only.
+9. External references only where explicitly allowed and cited/verified.
+
+### 4.4 Tenant Scope Hierarchy
+
+For tenant- or organisation-scoped answers:
+
+1. Canon / constitutional authority.
+2. CS2-approved strategy or prebuild artifacts applicable to tenant handling and safety.
+3. Tenant-owner approved tenant records and documents within the active scope.
+4. Module authority documents applicable to the tenant workflow.
+5. Approved tenant-scoped or organisation-scoped knowledge-base records.
+6. Current-session user-supplied content within the same tenant/session scope.
+7. Authenticated app context and current workflow/page state.
+8. Public app or public website content as supplementary context only, never as controlling authority over tenant records.
+9. General model knowledge as fallback only.
+10. External references only where explicitly allowed and cited/verified.
+
+### 4.5 Governance/Internal Scope Hierarchy
+
+For governance/internal reasoning:
 
 1. Canon / constitutional authority.
 2. CS2-approved strategy or prebuild artifacts.
 3. Module authority documents.
-4. Approved knowledge-base records.
-5. Public app or public website content.
-6. Tenant-owner approved tenant records.
-7. Current-session user-supplied content.
-8. General model knowledge as fallback only.
-9. External references only where explicitly allowed and cited/verified.
-
-Higher-authority sources override lower-authority sources within their applicable scope.
+4. Governance records and approved knowledge-base records.
+5. Current-session user-supplied content.
+6. Public content as supplementary context only.
+7. General model knowledge as fallback only.
+8. External references only where explicitly allowed and cited/verified.
 
 ---
 
@@ -97,7 +146,7 @@ A retrieval decision must consider:
 - requested task purpose;
 - specialist authority limits;
 - source metadata;
-- source hierarchy;
+- scope-specific source hierarchy;
 - expiry/supersession state;
 - guardrails and safety overlays.
 
@@ -123,6 +172,7 @@ Public retrieval may include a knowledge object only if:
 Authenticated retrieval may include a knowledge object only if:
 
 - user is authenticated;
+- `retrieval_allowed = true`;
 - object visibility allows authenticated access;
 - object app scope matches current app or is global;
 - role requirements are satisfied;
@@ -135,6 +185,7 @@ Authenticated mode alone does not permit tenant-private retrieval.
 Tenant retrieval may include a knowledge object only if:
 
 - user is authenticated;
+- `retrieval_allowed = true`;
 - context envelope includes tenant/organisation scope;
 - object `tenant_id` or `organisation_id` matches the active scope;
 - `requires_tenant_match = true` is satisfied;
@@ -144,7 +195,12 @@ Tenant retrieval may include a knowledge object only if:
 
 ### 6.4 Internal/Governance Filter
 
-Internal/governance retrieval may include internal governance records only where the context envelope allows governance scope and the runtime authority model permits the use.
+Internal/governance retrieval may include internal governance records only if:
+
+- `retrieval_allowed = true`;
+- the context envelope allows governance scope;
+- the runtime authority model permits the use;
+- object is not expired or superseded.
 
 Governance retrieval does not grant action authority. It only provides information for governed reasoning.
 
@@ -161,12 +217,14 @@ Batch 2 does not approve secret retrieval.
 If any required metadata field is missing, ambiguous or contradictory:
 
 - public retrieval must block the object;
+- authenticated retrieval must block the object;
 - tenant retrieval must block the object;
+- governance/internal retrieval must block the object unless the missing field is proven irrelevant by a later approved contract;
 - specialist retrieval must not receive the object;
 - audit trace must record missing metadata;
 - Maturion may answer only from other allowed sources or degrade.
 
-Missing metadata must never default to public-safe.
+Missing metadata must never default to public-safe, tenant-safe, authenticated-safe, governance-safe or retrieval-allowed.
 
 ---
 
@@ -191,9 +249,10 @@ Before a specialist receives knowledge, the orchestrator must check:
 1. specialist registry status permits invocation;
 2. specialist allowed knowledge planes include the candidate source;
 3. context envelope allows the knowledge plane;
-4. metadata filters allow the source;
-5. task purpose matches specialist mandate;
-6. audit trace can record the retrieval decision.
+4. source metadata has `retrieval_allowed = true`;
+5. metadata filters allow the source;
+6. task purpose matches specialist mandate;
+7. audit trace can record the retrieval decision.
 
 Specialists must not directly bypass the retrieval gate.
 
@@ -214,6 +273,7 @@ A future retrieval audit trace should record:
   "blocked_reason": "string|null",
   "fallback_used": "none|public_only|user_supplied|general_model|escalation",
   "metadata_complete": "boolean",
+  "retrieval_allowed": "boolean|null",
   "tenant_match": "boolean|null",
   "specialist_id": "string|null"
 }
@@ -229,12 +289,14 @@ Audit traces must avoid storing secrets, raw confidential documents or unnecessa
 |---|---|
 | Public request, public-safe source available | Use public-safe source. |
 | Public request, only private/tenant source available | Block private source; provide limitation or handoff. |
-| Authenticated request, app context available | Use authorised app context. |
+| Authenticated request, app context available and `retrieval_allowed = true` | Use authorised app context. |
+| Authenticated request, source has `retrieval_allowed = false` | Block source; use allowed fallback only. |
 | Authenticated request, tenant source requested but no tenant scope | Block tenant source; request proper context or escalate. |
-| Tenant request, matching tenant source available | Use source if role and metadata checks pass. |
+| Tenant request, matching tenant source available and `retrieval_allowed = true` | Use source if role and metadata checks pass. |
 | Tenant request, tenant mismatch | Block and record isolation event. |
 | Missing metadata | Block source; use allowed fallback only. |
-| Conflicting sources | Prefer highest authority; escalate if unresolved. |
+| Conflicting sources | Prefer highest authority within the active permission scope; escalate if unresolved. |
+| Public content conflicts with tenant-approved record in tenant scope | Tenant-approved record controls if tenant filter passes; public content may be supplementary only. |
 | Expired or superseded source | Block for current governed answer; mention as historical only if suitable. |
 
 ---
@@ -244,8 +306,9 @@ Audit traces must avoid storing secrets, raw confidential documents or unnecessa
 Batch 2 is technically acceptable if it defines:
 
 - minimum knowledge metadata;
-- source hierarchy;
+- scope-specific source hierarchy;
 - public, authenticated, tenant, governance and secret filters;
+- retrieval-allowed kill switch across all non-secret retrieval paths;
 - missing metadata behaviour;
 - supersession/staleness behaviour;
 - specialist retrieval contract;


### PR DESCRIPTION
## Summary

Creates Batch 2 prebuild artifacts for Maturion Runtime Knowledge Grounding.

Artifacts added:

- `.agent-admin/scope-declarations/maturion-runtime-knowledge-grounding-prebuild-v01.md`
- `Maturion/prebuild/runtime-knowledge-grounding/MRKG-FRS-addendum-v0.1.md`
- `Maturion/prebuild/runtime-knowledge-grounding/MRKG-TRS-supabase-aimc-metadata-v0.1.md`
- `Maturion/prebuild/runtime-knowledge-grounding/MRKG-QA-to-Red-v0.1.md`
- `.agent-admin/assurance/iaa-wave-record-mrkg-prebuild-v01-20260626.md`

## Purpose

Defines how Runtime Maturion and governed specialists may use Supabase/AIMC knowledge safely: knowledge planes, source hierarchy, public/private/tenant filters, missing metadata behaviour, fallback behaviour, and QA-to-Red expectations.

## Boundary

Prebuild only. No runtime code, database changes, Supabase mutation, migrations, embeddings, retrieval service, specialist activation, `.github/agents` changes, or Maturion CS2 authority changes.