### PR TITLE
APW Specialist Prebuild v0.1

### DIFF
--- a/.agent-admin/assurance/iaa-wave-record-apw-specialist-prebuild-v01-20260626.md
+++ b/.agent-admin/assurance/iaa-wave-record-apw-specialist-prebuild-v01-20260626.md
@@ -1,0 +1,100 @@
+# IAA Wave Record — APW Specialist Prebuild v0.1
+
+**Wave ID**: APW-SPEC-PREBUILD-V01  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Date**: 2026-06-26  
+**Scope Declaration**: `.agent-admin/scope-declarations/pr-1862.md`  
+**Related Artifacts**:
+
+- `.agent-admin/scope-declarations/maturion-apw-specialist-prebuild-v01.md`
+- `.agent-admin/scope-declarations/pr-1862.md`
+- `Maturion/prebuild/apw-specialist/APW-Specialist-Scope-Contract-v0.1.md`
+- `Maturion/prebuild/apw-specialist/APW-Maturion-FRS-TRS-addendum-v0.1.md`
+- `Maturion/prebuild/apw-specialist/APW-QA-to-Red-specialist-routing-v0.1.md`
+- `.agent-admin/builder-appointments/apw-specialist-implementation-wave-builder-appointment-v0.1.md`
+
+---
+
+## PRE-BRIEF
+
+IAA_PREFLIGHT_BRIEF:
+
+schema_version: 1.0.0
+result: PREFLIGHT_BRIEF_COMPLETE
+wave_id: APW-SPEC-PREBUILD-V01
+repository: APGI-cmy/maturion-isms
+PR: 1862
+CURRENT_HEAD_SHA: e8dd8c9ff272496387db9d3a44a17854682b56d4
+scope_summary: Batch 3 prebuild-only APW Specialist contract and public Maturion routing artifacts.
+authority: CS2 — Johan Ras
+
+EXPECTED_QA_SCOPE:
+
+- Review APW Specialist contract, APW public Maturion FRS/TRS addendum, QA-to-Red, and future builder appointment package.
+- Confirm APW Specialist is defined only as a runtime app specialist candidate behind Maturion.
+- Confirm the work is prebuild-only and does not implement runtime code, public chat, APW behaviour, Supabase changes, embeddings, retrieval services, runtime registry records, specialist activation or `.github/agents` changes.
+- Confirm APW Specialist cannot receive tenant, internal, secret, private memory or authority-bound knowledge.
+- Confirm public APW routing requires context-envelope, registry, metadata/filter and Maturion final-synthesis preconditions.
+- Confirm QA-to-Red covers unsafe public routing, tenant/private leakage, direct retrieval bypass, premature activation, and authority claims.
+- Confirm builder appointment package prepares a later implementation wave but does not appoint a builder to start now.
+
+EXPECTED_FAILURE_MODES:
+
+- APW Specialist is treated as active or invokable from prebuild documentation alone.
+- APW Specialist receives tenant, internal, secret, private memory or customer-specific knowledge.
+- Public APW Maturion routes to APW Specialist without valid context envelope or future ACTIVE registry record.
+- Missing or unsafe metadata defaults to public-safe specialist input.
+- APW Specialist performs direct retrieval or bypasses Maturion filtering.
+- APW Specialist becomes the final public responder or claims CS2/APGI binding authority.
+- Future builder appointment package is misread as current implementation authorisation.
+
+FOREMAN_INSTRUCTIONS:
+
+- Treat this wave as prebuild-only.
+- Do not appoint a builder to start implementation from this wave.
+- Do not implement code, migrations, schemas, retrieval services, embeddings, metadata storage, Supabase policies, runtime routing, memory writes or specialist activation.
+- Do not modify `.github/agents` files.
+- Do not create a runtime registry record.
+- Use IAA findings to correct prebuild artifacts before any implementation wave is created.
+- Keep later implementation and activation waves separate from this prebuild.
+
+IAA_WILL_QA:
+
+- IAA will compare Batch 3 artifacts against Batch 1 runtime agent network and Batch 2 knowledge grounding artifacts.
+- IAA will check that APW Specialist remains behind Maturion and cannot become a public standalone authority.
+- IAA will check public-safe knowledge boundaries and forbidden knowledge lists.
+- IAA will check context-envelope, runtime registry and metadata/filter preconditions.
+- IAA will check QA-to-Red coverage for public routing, private leakage, direct retrieval bypass, premature activation, final authority and unsafe fallback.
+- IAA will check that the builder appointment package is future-only and does not trigger implementation.
+- IAA will not issue final assurance inside this pre-brief block.
+
+RESULT: PREFLIGHT_BRIEF_COMPLETE
+
+---
+
+## NON-IMPLEMENTATION BOUNDARY
+
+This wave does not:
+
+- create runtime code;
+- alter application behaviour;
+- create or mutate Supabase tables;
+- run migrations;
+- create embeddings;
+- create retrieval services;
+- create a runtime registry record;
+- activate APW Specialist;
+- create APW public chat;
+- alter tenant isolation;
+- write or read production tenant data;
+- change `.github/agents` files;
+- grant Maturion or APW Specialist CS2 authority;
+- appoint a builder to start implementation now.
+
+---
+
+## REQUESTED IAA OUTPUT
+
+IAA should provide a later independent assurance verdict or rejection package after reviewing the prebuild artifact set.
+
+This file records the pre-brief only. It does not contain IAA final assurance, a merge verdict, or CS2 approval.

--- a/.agent-admin/builder-appointments/apw-specialist-implementation-wave-builder-appointment-v0.1.md
+++ b/.agent-admin/builder-appointments/apw-specialist-implementation-wave-builder-appointment-v0.1.md
@@ -1,0 +1,126 @@
+# Builder Appointment Package — APW Specialist Later Implementation Wave v0.1
+
+**Artifact ID**: APW-BUILDER-APPOINTMENT-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — Future Builder Appointment Package  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: First Specialist Prebuild — APW Specialist v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-26  
+**Current Wave Scope**: `.agent-admin/scope-declarations/maturion-apw-specialist-prebuild-v01.md`
+
+---
+
+## 1. Purpose
+
+This package defines the appointment conditions for a later implementation builder wave for APW Specialist.
+
+It does not appoint a builder to start work now. It does not authorise implementation, runtime activation, registry mutation, public deployment, Supabase changes or APW public behaviour changes in Batch 3.
+
+---
+
+## 2. Appointment Status
+
+| Field | Value |
+|---|---|
+| Appointment type | Future implementation wave appointment package |
+| Current status | NOT APPOINTED / NOT STARTED |
+| Runtime implementation allowed now | No |
+| Specialist activation allowed now | No |
+| Registry mutation allowed now | No |
+| Supabase mutation allowed now | No |
+| Public APW behaviour change allowed now | No |
+
+---
+
+## 3. Future Builder Mandate
+
+A future builder may be appointed only to implement approved APW Specialist behaviour after this prebuild is accepted.
+
+The future builder mandate may include:
+
+- context-envelope enforcement for public APW specialist routing;
+- runtime registry record design and controlled activation workflow;
+- public-safe knowledge-filter integration;
+- Maturion-to-APW-Specialist routing contract;
+- APW Specialist input/output validation;
+- routing/audit trace creation;
+- QA-to-Red test implementation;
+- safe degraded and handoff behaviour.
+
+---
+
+## 4. Builder Must Not Do Without Separate Approval
+
+A future builder must not:
+
+- activate APW Specialist without registry and CS2 approval;
+- bypass Maturion final synthesis;
+- expose APW Specialist as a direct public assistant;
+- pass tenant, internal, secret or private memory context to APW Specialist;
+- query or mutate Supabase outside approved retrieval architecture;
+- change `.github/agents` contracts;
+- grant Maturion or APW Specialist CS2 authority;
+- use general model knowledge as approved APW fact;
+- implement production public chat without release governance.
+
+---
+
+## 5. Required Inputs Before Appointment
+
+Before any later implementation builder starts, the following must exist and be current:
+
+1. approved APW Specialist scope/contract;
+2. approved APW public Maturion FRS/TRS addendum;
+3. approved APW QA-to-Red routing artifact;
+4. approved runtime registry/context-envelope architecture;
+5. approved knowledge-grounding metadata/filter architecture;
+6. implementation branch scope declaration;
+7. builder brief with explicit file boundaries;
+8. QA-to-Red fixture plan;
+9. IAA preflight brief;
+10. CS2 authorisation for implementation wave.
+
+---
+
+## 6. Builder Appointment Conditions
+
+A future appointment must include:
+
+- builder identity;
+- exact branch and PR scope;
+- files allowed to change;
+- files prohibited from change;
+- runtime registry migration plan, if any;
+- Supabase impact statement;
+- public behaviour impact statement;
+- QA-to-Red expected failures;
+- rollback plan;
+- IAA review plan;
+- CS2 approval checkpoint.
+
+---
+
+## 7. Gate Conditions Before Build-to-Green
+
+The later implementation wave must fail red first for:
+
+- invalid context envelope;
+- missing registry record;
+- non-ACTIVE registry state;
+- public-safe metadata failure;
+- tenant/private source passed to specialist;
+- direct retrieval bypass;
+- specialist final authority claim;
+- Maturion output-validation failure;
+- unsafe fallback/invention.
+
+Only after red evidence is captured may implementation proceed to green.
+
+---
+
+## 8. Batch 3 Disposition
+
+This package is an appointment design artifact only.
+
+It prepares a later implementation appointment but does not appoint, authorise, start or complete that implementation.

--- a/.agent-admin/scope-declarations/maturion-apw-specialist-prebuild-v01.md
+++ b/.agent-admin/scope-declarations/maturion-apw-specialist-prebuild-v01.md
@@ -1,0 +1,131 @@
+# Scope Declaration — APW Specialist Prebuild v0.1
+
+**Scope ID**: APW-SPEC-PREBUILD-V01  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: First Specialist Prebuild — APW Specialist v0.1  
+**Date**: 2026-06-26  
+**Authority**: CS2 — Johan Ras  
+**Operating Role**: Foreman-led governed delivery  
+**Task Type**: Specialist prebuild contract and implementation-prep artifacts only  
+**Affected Scope**: Runtime Maturion / APW public specialist behaviour  
+**Implementation Status**: No implementation and no activation in this wave
+
+---
+
+## 1. Purpose
+
+This wave defines the first runtime specialist candidate for Maturion: APW Specialist.
+
+It answers:
+
+```text
+What does APW-specialist do, what may it not know, and how does public Maturion use it safely?
+```
+
+The wave creates a prebuild scope/contract, functional and technical addenda for public APW Maturion behaviour, QA-to-Red expectations for specialist routing, a later-builder appointment package, and IAA pre-brief evidence.
+
+---
+
+## 2. Source Authority
+
+This scope is governed by:
+
+- `FOREMAN_OPERATING_MODEL.md`;
+- `.github/agents/foreman-v2-agent.md`;
+- `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`;
+- `Maturion/strategy/Maturion_agent_network_organigram_strategy.md`;
+- `Maturion/prebuild/runtime-agent-network/MRAN-FRS-v0.1.md`;
+- `Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md`;
+- `Maturion/prebuild/runtime-knowledge-grounding/MRKG-FRS-addendum-v0.1.md`;
+- `Maturion/prebuild/runtime-knowledge-grounding/MRKG-TRS-supabase-aimc-metadata-v0.1.md`;
+- `Maturion/prebuild/runtime-knowledge-grounding/MRKG-QA-to-Red-v0.1.md`.
+
+---
+
+## 3. In Scope
+
+This wave creates:
+
+1. `Maturion/prebuild/apw-specialist/APW-Specialist-Scope-Contract-v0.1.md`
+2. `Maturion/prebuild/apw-specialist/APW-Maturion-FRS-TRS-addendum-v0.1.md`
+3. `Maturion/prebuild/apw-specialist/APW-QA-to-Red-specialist-routing-v0.1.md`
+4. `.agent-admin/builder-appointments/apw-specialist-implementation-wave-builder-appointment-v0.1.md`
+5. `.agent-admin/assurance/iaa-wave-record-apw-specialist-prebuild-v01-20260626.md`
+6. this wave scope declaration.
+
+The artifacts define:
+
+- APW Specialist mandate and prohibited knowledge;
+- public APW Maturion invocation behaviour;
+- context-envelope preconditions;
+- runtime registry preconditions;
+- public-safe knowledge rules;
+- fallback and degraded behaviour;
+- QA-to-Red cases for public specialist routing;
+- a non-active builder appointment package for a later implementation wave.
+
+---
+
+## 4. Out of Scope
+
+This wave does not:
+
+- create runtime code;
+- alter APW public app behaviour;
+- create a runtime registry record;
+- mark APW Specialist as ACTIVE;
+- create or modify `.github/agents` files;
+- modify build/governance agent contracts;
+- create retrieval services;
+- query or mutate Supabase;
+- create embeddings;
+- alter public website content;
+- alter tenant isolation;
+- read or write production tenant data;
+- implement public chat;
+- grant Maturion CS2 authority;
+- appoint a builder to start implementation now.
+
+---
+
+## 5. Specialist Lifecycle Boundary
+
+APW Specialist may be described only as a candidate runtime app specialist.
+
+Its maximum lifecycle state after this wave is:
+
+```text
+STUB_CONTRACTED / PREBUILD_DEFINED
+```
+
+It must not be treated as:
+
+- runtime registered;
+- active;
+- invokable in production;
+- a `.github/agents` build/governance agent;
+- a source of CS2 authority;
+- a direct retriever of tenant, internal or secret knowledge.
+
+---
+
+## 6. Success Criteria
+
+This wave succeeds when:
+
+1. APW Specialist scope/contract exists;
+2. public APW Maturion FRS/TRS addendum exists;
+3. QA-to-Red covers unsafe public routing and specialist knowledge leakage;
+4. later-builder appointment package exists but does not start implementation;
+5. IAA pre-brief is recorded in gate-readable format;
+6. no implementation files are changed;
+7. no runtime specialist is activated;
+8. no runtime registry is created or mutated;
+9. no Supabase mutation occurs;
+10. no Maturion-as-CS2 authority is granted.
+
+---
+
+## 7. Follow-On Work
+
+Future implementation remains blocked until separate implementation-wave governance is complete, including current-head bound builder appointment, QP package, ECAP review, IAA assurance, QA-to-Red evidence, and CS2 merge/release decision.

--- a/.agent-admin/scope-declarations/pr-1862.md
+++ b/.agent-admin/scope-declarations/pr-1862.md
@@ -1,0 +1,88 @@
+# Scope Declaration — PR #1862
+
+**Scope ID**: PR-1862-APW-SPEC-PREBUILD-V01  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Pull Request**: #1862  
+**Wave**: First Specialist Prebuild — APW Specialist v0.1  
+**Date**: 2026-06-26  
+**Authority**: CS2 — Johan Ras  
+**Operating Role**: Foreman-led governed delivery  
+**Task Type**: Specialist prebuild contract and implementation-prep artifacts only  
+**Affected Scope**: Runtime Maturion / APW public specialist behaviour  
+**Implementation Status**: No implementation in this PR
+
+---
+
+## 1. Active PR Scope
+
+This is the active per-PR scope declaration for PR #1862.
+
+It mirrors the wave scope declaration and exists so PR-level scope/diff parity gates can discover the active changed-file set.
+
+---
+
+## 2. Changed Files in Scope
+
+This PR is limited to these files:
+
+1. `.agent-admin/scope-declarations/maturion-apw-specialist-prebuild-v01.md`
+2. `.agent-admin/scope-declarations/pr-1862.md`
+3. `Maturion/prebuild/apw-specialist/APW-Specialist-Scope-Contract-v0.1.md`
+4. `Maturion/prebuild/apw-specialist/APW-Maturion-FRS-TRS-addendum-v0.1.md`
+5. `Maturion/prebuild/apw-specialist/APW-QA-to-Red-specialist-routing-v0.1.md`
+6. `.agent-admin/builder-appointments/apw-specialist-implementation-wave-builder-appointment-v0.1.md`
+7. `.agent-admin/assurance/iaa-wave-record-apw-specialist-prebuild-v01-20260626.md`
+
+---
+
+## 3. Source Authority
+
+This scope is governed by:
+
+- `FOREMAN_OPERATING_MODEL.md`;
+- `.github/agents/foreman-v2-agent.md`;
+- `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`;
+- `Maturion/strategy/Maturion_agent_network_organigram_strategy.md`;
+- Batch 1 Runtime Agent Network prebuild artifacts;
+- Batch 2 Knowledge Grounding prebuild artifacts.
+
+---
+
+## 4. In Scope
+
+This PR creates Batch 3 prebuild artifacts for APW Specialist:
+
+- APW Specialist scope/contract;
+- FRS/TRS addendum for APW public Maturion behaviour;
+- QA-to-Red for APW public specialist routing;
+- later implementation builder appointment package;
+- IAA pre-brief;
+- scope declarations.
+
+---
+
+## 5. Out of Scope
+
+This PR does not:
+
+- create runtime code;
+- alter APW public app behaviour;
+- create a runtime registry record;
+- mark APW Specialist as ACTIVE;
+- create or modify `.github/agents` files;
+- modify build/governance agent contracts;
+- create retrieval services;
+- query or mutate Supabase;
+- create embeddings;
+- alter public website content;
+- alter tenant isolation;
+- read or write production tenant data;
+- implement public chat;
+- grant Maturion or APW Specialist CS2 authority;
+- appoint a builder to start implementation now.
+
+---
+
+## 6. Gate Note
+
+This file is the active PR-level scope declaration. The wave-named scope declaration remains the durable wave artifact, while this file supports PR-level scope/diff validation.

--- a/Maturion/prebuild/apw-specialist/APW-Maturion-FRS-TRS-addendum-v0.1.md
+++ b/Maturion/prebuild/apw-specialist/APW-Maturion-FRS-TRS-addendum-v0.1.md
@@ -65,7 +65,7 @@ APW Specialist must not approve, commit, quote pricing, bind APGI, act as CS2, c
 
 ### APW-TRS-001 — Context Envelope Preconditions
 
-A future APW Specialist route requires a validated context envelope equivalent to:
+A future APW Specialist route requires a validated context envelope equivalent to the Batch 1 public APW context envelope:
 
 ```json
 {
@@ -74,43 +74,62 @@ A future APW Specialist route requires a validated context envelope equivalent t
   "permission_scope": "public",
   "user": {
     "authenticated": false,
-    "tenant_id": null,
-    "organisation_id": null
+    "id": null,
+    "organisation_id": null,
+    "tenant_id": null
   },
   "knowledge_scope": {
-    "public_allowed": true,
+    "subject_allowed": true,
+    "app_context_allowed": true,
+    "framework_context_allowed": false,
     "tenant_context_allowed": false,
-    "memory_allowed": false,
-    "secret_allowed": false
+    "memory_allowed": false
   }
 }
 ```
 
-The values above describe the public APW baseline. Other embodiments require separate approval.
+The values above describe the public APW baseline. Other embodiments require separate approval. Secret, restricted, internal and tenant sources remain blocked by the Batch 2 metadata/filter rules rather than enabled through the public context envelope.
 
 ### APW-TRS-002 — Runtime Registry Preconditions
 
 APW Specialist may not be invoked until a future runtime registry record exists and permits invocation.
 
-Minimum future registry constraints:
+Minimum future registry constraints must use the Batch 1 registry field names and Batch 2 knowledge-plane vocabulary:
 
 ```json
 {
   "runtime_agent_id": "apw-specialist",
+  "display_name": "APW Specialist",
   "agent_class": "app_specialist",
   "status": "ACTIVE",
-  "orchestrator": "Maturion",
+  "orchestrator": "maturion",
   "allowed_apps": ["APW"],
   "allowed_embodiments": ["public-web"],
   "allowed_permission_scopes": ["public"],
-  "allowed_knowledge_planes": ["public_app_context", "public_subject", "current_session_user_supplied"],
-  "forbidden_knowledge_planes": ["tenant_context", "private_memory", "secret", "internal_governance"],
+  "allowed_knowledge_planes": ["subject", "app_context", "user_session"],
+  "forbidden_knowledge_planes": ["framework_context", "tenant_context", "memory"],
+  "forbidden_visibility": ["authenticated", "tenant", "restricted", "internal", "secret"],
+  "input_contract_ref": "Maturion/prebuild/apw-specialist/APW-Specialist-Scope-Contract-v0.1.md",
+  "output_contract_ref": "Maturion/prebuild/apw-specialist/APW-Specialist-Scope-Contract-v0.1.md#8-output-contract",
+  "guardrail_refs": [
+    "Maturion/prebuild/runtime-knowledge-grounding/MRKG-TRS-supabase-aimc-metadata-v0.1.md",
+    "Maturion/prebuild/apw-specialist/APW-QA-to-Red-specialist-routing-v0.1.md"
+  ],
+  "authority_limits": [
+    "no_cs2_authority",
+    "no_final_response_authority",
+    "no_tenant_context",
+    "no_direct_retrieval",
+    "no_supabase_mutation"
+  ],
   "final_response_authority": false,
-  "audit_required": true
+  "audit_required": true,
+  "owner": "CS2 — Johan Ras",
+  "last_reviewed": "date|null"
 }
 ```
 
-Batch 3 does not create this registry record.
+Batch 3 does not create this registry record. The example above is a future minimum constraint set only; later implementation must validate it against the current runtime registry schema before activation.
 
 ### APW-TRS-003 — Knowledge Filter Preconditions
 
@@ -137,7 +156,7 @@ Future implementation must record at least:
   "context_envelope_valid": "boolean",
   "public_filter_passed": "boolean",
   "blocked_reason": "string|null",
-  "final_synthesizer": "Maturion"
+  "final_synthesizer": "maturion"
 }
 ```
 

--- a/Maturion/prebuild/apw-specialist/APW-Maturion-FRS-TRS-addendum-v0.1.md
+++ b/Maturion/prebuild/apw-specialist/APW-Maturion-FRS-TRS-addendum-v0.1.md
@@ -1,0 +1,199 @@
+# FRS/TRS Addendum — APW Public Maturion Behaviour v0.1
+
+**Artifact ID**: APW-MATURION-FRS-TRS-ADD-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — FRS/TRS Addendum  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: First Specialist Prebuild — APW Specialist v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-26  
+**Related Contract**: `Maturion/prebuild/apw-specialist/APW-Specialist-Scope-Contract-v0.1.md`
+
+---
+
+## 1. Purpose
+
+This addendum defines how public APW Maturion may use the proposed APW Specialist safely in a later implementation wave.
+
+It combines functional and technical requirements because this Batch 3 wave is a specialist prebuild and does not implement runtime behaviour.
+
+---
+
+## 2. Public APW Principle
+
+```text
+Public APW Maturion may explain public APW knowledge.
+It may not expose private, tenant, internal, secret or authority-bound knowledge.
+APW Specialist supports Maturion; it does not replace Maturion.
+```
+
+---
+
+## 3. Functional Requirements
+
+### APW-FRS-001 — Single Public Interface
+
+Public APW users must interact with Maturion as the user-facing assistant. APW Specialist, if later activated, must operate behind Maturion.
+
+### APW-FRS-002 — Public-Safe Answering
+
+Public APW Maturion may answer only from public-safe sources, current-session user-provided content, or safe general explanations clearly separated from approved APW fact.
+
+### APW-FRS-003 — Specialist Routing Only When Useful
+
+Maturion should route to APW Specialist only when the user asks a public APW product, module, onboarding, navigation, explanation or capability question that falls inside the APW Specialist mandate.
+
+### APW-FRS-004 — No Specialist Routing for Private Questions
+
+Maturion must not route to APW Specialist when the request requires tenant, customer, authenticated, internal governance, secret, incident, evidence or private memory context.
+
+### APW-FRS-005 — Maturion Final Synthesis
+
+APW Specialist must return draft support only. Maturion must validate, constrain, synthesise and deliver the final answer.
+
+### APW-FRS-006 — Safe Handoff
+
+When public knowledge is insufficient, Maturion may hand off to contact/demo/login/human-review routes instead of inventing APW facts.
+
+### APW-FRS-007 — No Authority Escalation by Specialist
+
+APW Specialist must not approve, commit, quote pricing, bind APGI, act as CS2, change app state, or promise implementation behaviour.
+
+---
+
+## 4. Technical Requirements
+
+### APW-TRS-001 — Context Envelope Preconditions
+
+A future APW Specialist route requires a validated context envelope equivalent to:
+
+```json
+{
+  "app": "APW",
+  "embodiment": "public-web",
+  "permission_scope": "public",
+  "user": {
+    "authenticated": false,
+    "tenant_id": null,
+    "organisation_id": null
+  },
+  "knowledge_scope": {
+    "public_allowed": true,
+    "tenant_context_allowed": false,
+    "memory_allowed": false,
+    "secret_allowed": false
+  }
+}
+```
+
+The values above describe the public APW baseline. Other embodiments require separate approval.
+
+### APW-TRS-002 — Runtime Registry Preconditions
+
+APW Specialist may not be invoked until a future runtime registry record exists and permits invocation.
+
+Minimum future registry constraints:
+
+```json
+{
+  "runtime_agent_id": "apw-specialist",
+  "agent_class": "app_specialist",
+  "status": "ACTIVE",
+  "orchestrator": "Maturion",
+  "allowed_apps": ["APW"],
+  "allowed_embodiments": ["public-web"],
+  "allowed_permission_scopes": ["public"],
+  "allowed_knowledge_planes": ["public_app_context", "public_subject", "current_session_user_supplied"],
+  "forbidden_knowledge_planes": ["tenant_context", "private_memory", "secret", "internal_governance"],
+  "final_response_authority": false,
+  "audit_required": true
+}
+```
+
+Batch 3 does not create this registry record.
+
+### APW-TRS-003 — Knowledge Filter Preconditions
+
+Before any APW Specialist call, Maturion must filter candidate knowledge using Batch 2 public-safe rules:
+
+- `visibility = public`;
+- `public_safe = true`;
+- `retrieval_allowed = true`;
+- `requires_authentication = false`;
+- `requires_tenant_match = false`;
+- `tenant_id = null`;
+- no secret/restricted/internal source;
+- not expired or superseded.
+
+### APW-TRS-004 — Routing Decision Record
+
+Future implementation must record at least:
+
+```json
+{
+  "request_id": "string",
+  "route_decision": "apw_specialist|maturion_only|degraded|handoff",
+  "specialist_id": "apw-specialist|null",
+  "context_envelope_valid": "boolean",
+  "public_filter_passed": "boolean",
+  "blocked_reason": "string|null",
+  "final_synthesizer": "Maturion"
+}
+```
+
+### APW-TRS-005 — Specialist Input Contract
+
+Maturion may pass only:
+
+- user question;
+- public APW context;
+- public-safe retrieved snippets;
+- current public page/workflow label;
+- safe handoff options.
+
+Maturion must not pass raw tenant data, private memory, internal governance records or secrets.
+
+### APW-TRS-006 — Specialist Output Validation
+
+Maturion must validate that APW Specialist output:
+
+- does not claim private knowledge;
+- does not invent APGI facts;
+- does not promise unavailable functionality;
+- does not expose internal governance;
+- includes source limitations when appropriate;
+- returns safe handoff when knowledge is insufficient.
+
+### APW-TRS-007 — Degraded Mode
+
+If the context envelope, registry, public filter, specialist contract or output validation fails, Maturion must not invoke or trust APW Specialist. It may answer from allowed public sources or provide a limitation/handoff.
+
+---
+
+## 5. Explicit Non-Behaviour
+
+Public APW Maturion must not:
+
+- ask APW Specialist to retrieve data directly from Supabase;
+- use APW Specialist as a public shortcut to internal knowledge;
+- use APW Specialist to answer tenant/private/customer-specific questions;
+- leak internal governance or agent-system details;
+- use private memory in public mode;
+- treat APW Specialist output as final authority;
+- activate APW Specialist without a later registry and implementation wave.
+
+---
+
+## 6. Batch 3 Acceptance Conditions
+
+This addendum is acceptable if it defines:
+
+- public APW functional behaviour;
+- public APW technical routing preconditions;
+- context-envelope expectations;
+- registry preconditions;
+- knowledge filter preconditions;
+- routing audit expectations;
+- input/output validation;
+- degraded mode;
+- no implementation or activation in this wave.

--- a/Maturion/prebuild/apw-specialist/APW-QA-to-Red-specialist-routing-v0.1.md
+++ b/Maturion/prebuild/apw-specialist/APW-QA-to-Red-specialist-routing-v0.1.md
@@ -1,0 +1,205 @@
+# QA-to-Red — APW Public Specialist Routing v0.1
+
+**Artifact ID**: APW-QA-RED-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — QA-to-Red  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: First Specialist Prebuild — APW Specialist v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-26  
+**Related Contract**: `Maturion/prebuild/apw-specialist/APW-Specialist-Scope-Contract-v0.1.md`  
+**Related FRS/TRS**: `Maturion/prebuild/apw-specialist/APW-Maturion-FRS-TRS-addendum-v0.1.md`
+
+---
+
+## 1. Purpose
+
+This artifact defines failure-first validation expectations for future APW Specialist routing.
+
+It must make unsafe public specialist routing fail red before any later builder turns the behaviour green.
+
+---
+
+## 2. QA-to-Red Principle
+
+```text
+APW Specialist must never become a public bypass to private knowledge, tenant data, internal governance, direct retrieval, final authority or premature runtime activation.
+```
+
+---
+
+## 3. Test Categories
+
+### QA-APW-CAT-001 — Public Context Envelope
+
+Future routing must require a valid public APW context envelope.
+
+Red cases:
+
+1. APW Specialist invoked when app is not `APW`;
+2. APW Specialist invoked from non-approved embodiment;
+3. APW Specialist invoked when permission scope is not public or approved APW scope;
+4. APW Specialist invoked when tenant_id is populated in public mode;
+5. APW Specialist invoked when private memory is allowed in public mode.
+
+Expected red result:
+
+- route blocked;
+- Maturion answers safely without specialist or degrades;
+- routing trace records failed context envelope.
+
+### QA-APW-CAT-002 — Public-Safe Knowledge Filtering
+
+APW Specialist must receive only public-safe knowledge.
+
+Red cases:
+
+1. source has `visibility = internal`;
+2. source has `visibility = tenant`;
+3. source has `public_safe = false`;
+4. source has `retrieval_allowed = false`;
+5. source lacks required metadata;
+6. source is expired or superseded;
+7. source has tenant_id populated;
+8. source contains secret or restricted content.
+
+Expected red result:
+
+- source blocked;
+- APW Specialist not called with unsafe source;
+- Maturion discloses limitation or uses other approved public source.
+
+### QA-APW-CAT-003 — Specialist Mandate Boundary
+
+APW Specialist must not answer outside its mandate.
+
+Red cases:
+
+1. user asks for tenant audit findings;
+2. user asks for customer-specific implementation details;
+3. user asks for internal governance gate details not public-safe;
+4. user asks APW Specialist to approve a roadmap or architecture;
+5. user asks for pricing/contract commitment not approved as public content;
+6. user asks for runtime registry state or secret configuration.
+
+Expected red result:
+
+- specialist routing blocked or specialist returns `cannot_answer`;
+- no private or authority-bound content exposed;
+- handoff or limitation offered.
+
+### QA-APW-CAT-004 — Runtime Registry and Activation
+
+APW Specialist must not be invoked before later activation.
+
+Red cases:
+
+1. no runtime registry record exists but route proceeds;
+2. registry status is not ACTIVE but route proceeds;
+3. allowed_apps does not include APW but route proceeds;
+4. allowed_permission_scopes does not include public but route proceeds;
+5. forbidden knowledge plane is passed despite registry restriction.
+
+Expected red result:
+
+- route blocked;
+- activation failure logged;
+- Maturion uses safe fallback.
+
+### QA-APW-CAT-005 — Direct Retrieval Bypass
+
+APW Specialist must not retrieve directly from Supabase or AIMC.
+
+Red cases:
+
+1. APW Specialist performs direct vector search;
+2. APW Specialist queries Supabase directly;
+3. APW Specialist expands source class beyond Maturion-filtered sources;
+4. APW Specialist uses unrestricted model memory in public mode;
+5. APW Specialist ignores blocked metadata.
+
+Expected red result:
+
+- direct retrieval blocked;
+- specialist output rejected;
+- Maturion records bypass attempt and degrades.
+
+### QA-APW-CAT-006 — Final Response Authority
+
+APW Specialist must not become the final public responder.
+
+Red cases:
+
+1. APW Specialist response returned directly to user;
+2. APW Specialist claims final APGI authority;
+3. APW Specialist commits APGI to capability, price, delivery or compliance state;
+4. Maturion skips output validation;
+5. APW Specialist claims CS2 authority.
+
+Expected red result:
+
+- output rejected or constrained;
+- Maturion remains final synthesizer;
+- authority limitation disclosed where needed.
+
+### QA-APW-CAT-007 — Safe Handoff and Degraded Behaviour
+
+Fallback must stay safe when APW Specialist cannot answer.
+
+Red cases:
+
+1. missing public knowledge causes invented APW facts;
+2. unavailable public source falls back to internal strategy;
+3. public question falls back to tenant example;
+4. specialist says `cannot_answer` and Maturion fabricates anyway;
+5. handoff route implies guaranteed acceptance or commitment.
+
+Expected red result:
+
+- no invented APW fact;
+- limitation disclosed;
+- safe handoff to contact/demo/login/human-review where suitable.
+
+---
+
+## 4. Minimum Future Test Fixtures
+
+Future implementation should include fixtures for:
+
+- valid public APW question;
+- non-APW public question;
+- APW public source with valid metadata;
+- internal APGI strategy source;
+- tenant source;
+- missing metadata source;
+- retrieval_allowed=false source;
+- expired public source;
+- no registry record;
+- registry status not ACTIVE;
+- specialist output claiming CS2 authority;
+- specialist output containing invented APW fact.
+
+---
+
+## 5. Red Evidence Required Before Build-to-Green
+
+Before implementation builders start, a future implementation wave must define tests or validation scripts that fail for the red cases above.
+
+Evidence must show:
+
+1. unsafe routing attempt;
+2. expected blocked/degraded/fallback behaviour;
+3. context envelope condition;
+4. registry condition;
+5. metadata/filter condition;
+6. specialist mandate condition;
+7. final Maturion validation condition;
+8. traceability to APW Specialist contract and FRS/TRS addendum.
+
+---
+
+## 6. Batch 3 QA Disposition
+
+This QA-to-Red artifact is prebuild-only.
+
+It does not create tests, code, runtime routing, registry records, Supabase policies, retrieval services, embeddings, APW public behaviour, public chat, or specialist activation.

--- a/Maturion/prebuild/apw-specialist/APW-Specialist-Scope-Contract-v0.1.md
+++ b/Maturion/prebuild/apw-specialist/APW-Specialist-Scope-Contract-v0.1.md
@@ -1,0 +1,195 @@
+# APW Specialist Scope / Contract v0.1
+
+**Artifact ID**: APW-SPEC-CONTRACT-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — Specialist Scope Contract  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: First Specialist Prebuild — APW Specialist v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-26  
+**Scope Declaration**: `.agent-admin/scope-declarations/maturion-apw-specialist-prebuild-v01.md`
+
+---
+
+## 1. Purpose
+
+This contract defines APW Specialist as the first proposed runtime specialist behind public Maturion.
+
+It is a prebuild contract only. It does not create, register, activate, deploy or invoke APW Specialist.
+
+Core question:
+
+```text
+What does APW-specialist do, what may it not know, and how does public Maturion use it safely?
+```
+
+---
+
+## 2. Specialist Identity
+
+| Field | Value |
+|---|---|
+| Proposed runtime specialist ID | `apw-specialist` |
+| Display name | APW Specialist |
+| Specialist class | Runtime app specialist |
+| Orchestrator | Maturion |
+| Target app | APW public web / APW public Maturion |
+| Initial lifecycle state | `STUB_CONTRACTED / PREBUILD_DEFINED` |
+| Activation state | Not active |
+| Registry state | Not registered |
+| Production invokable | No |
+
+---
+
+## 3. Functional Mandate
+
+APW Specialist exists to help Maturion answer public APW questions safely.
+
+APW Specialist may be used later to support:
+
+- public APW product explanation;
+- public onboarding guidance;
+- public module navigation guidance;
+- high-level APGI/Maturion platform explanation;
+- safe signposting to contact, demo, onboarding or authenticated login paths;
+- public-safe comparison between APW modules where approved public knowledge exists;
+- clarification of what APW can and cannot do at public level.
+
+APW Specialist must remain behind Maturion. It must not become a separate user-facing authority unless a later architecture explicitly approves that behaviour.
+
+---
+
+## 4. Knowledge It May Use
+
+APW Specialist may use only knowledge that satisfies all applicable Batch 1 and Batch 2 requirements.
+
+For public APW mode, allowed knowledge is limited to:
+
+- public-safe APW content;
+- public-safe APGI/Maturion product descriptions;
+- public-safe app context;
+- public-safe subject knowledge approved for public use;
+- current-session user-provided content, only for answering that session's public question;
+- public-safe canon or strategy excerpts only where disclosure is approved and helpful.
+
+APW Specialist must not decide its own retrieval scope. Maturion must assemble and filter any context passed to it.
+
+---
+
+## 5. Knowledge It Must Not Know
+
+APW Specialist must not receive, retrieve, infer or expose:
+
+- tenant records;
+- customer names, account data or organisation-specific information;
+- private policies, findings, evidence or audit data;
+- incidents, investigations or operational assurance records;
+- private strategy or governance material not marked public-safe;
+- internal build/governance agent instructions;
+- secrets, keys, tokens or credentials;
+- private memory;
+- cross-tenant comparisons;
+- Supabase records without approved public-safe metadata;
+- any source where metadata is missing, contradictory or not retrieval-allowed.
+
+---
+
+## 6. Authority Limits
+
+APW Specialist must not:
+
+- approve, reject or sign off work;
+- act as CS2;
+- claim to represent CS2 authority;
+- modify runtime registry state;
+- create or activate specialists;
+- alter APW product behaviour;
+- alter public website content;
+- mutate Supabase;
+- provide legal, security, compliance or implementation commitments as binding APGI decisions;
+- bypass Maturion's final synthesis and safety check.
+
+---
+
+## 7. Invocation Preconditions
+
+Future Maturion may route to APW Specialist only when all of the following are true:
+
+1. context envelope is valid;
+2. app is APW or approved public APW surface;
+3. embodiment is public web or another approved public APW embodiment;
+4. permission scope is public or other explicitly approved APW scope;
+5. requested task falls inside APW Specialist mandate;
+6. runtime registry has APW Specialist record in an invocation-permitted state;
+7. knowledge grounding filters have produced only allowed public-safe sources;
+8. audit trace can record the routing decision;
+9. Maturion retains final response synthesis responsibility.
+
+Until those conditions exist, APW Specialist must not be invoked.
+
+---
+
+## 8. Output Contract
+
+APW Specialist output must be treated as advisory draft material for Maturion, not final user-facing authority.
+
+Expected output shape for later implementation:
+
+```json
+{
+  "specialist_id": "apw-specialist",
+  "status": "draft_response|cannot_answer|needs_public_source|handoff_recommended",
+  "answer_points": ["string"],
+  "source_limitations": ["string"],
+  "handoff": "none|contact|login|demo|human_review|cs2_escalation",
+  "safety_notes": ["string"]
+}
+```
+
+Maturion must validate the specialist output before answering the user.
+
+---
+
+## 9. Degraded and Refusal Behaviour
+
+APW Specialist must return a degraded result when:
+
+- public-safe knowledge is missing;
+- metadata is missing or contradictory;
+- the user asks for tenant/private/customer-specific information;
+- the request requires authenticated context;
+- the request requires CS2 or human authority;
+- the request is outside APW Specialist mandate.
+
+The safe degraded behaviour is to say what is missing, avoid invention, and hand back to Maturion for limitation disclosure or routing.
+
+---
+
+## 10. Lifecycle Progression
+
+APW Specialist may progress only through governed lifecycle gates:
+
+```text
+PROPOSED -> STRATEGY_DEFINED -> STUB_CONTRACTED -> KNOWLEDGE_BASED -> RUNTIME_REGISTERED -> ACTIVE
+```
+
+This wave permits only `STUB_CONTRACTED / PREBUILD_DEFINED`.
+
+Any later progression requires separate PR scope, registry contract, QA-to-Red evidence, builder appointment, implementation review, IAA assurance and CS2 approval.
+
+---
+
+## 11. Contract Acceptance
+
+This contract is acceptable if it clearly defines:
+
+- APW Specialist identity;
+- mandate;
+- allowed knowledge;
+- prohibited knowledge;
+- authority limits;
+- invocation preconditions;
+- output contract;
+- degraded behaviour;
+- lifecycle boundary;
+- no activation in this wave.


### PR DESCRIPTION
## Summary

Creates Batch 3 prebuild artifacts for the APW Specialist candidate.

Artifacts added:

- scope declaration
- APW Specialist scope contract
- APW public Maturion FRS/TRS addendum
- APW specialist routing QA-to-Red
- future implementation builder appointment package

## Purpose

Defines what APW Specialist does, what it may use, what it may not use, and how public APW Maturion should route to it safely in a later implementation wave.

## Boundary

Documentation prebuild only. This PR does not implement runtime behaviour, activate a specialist, change registry state, change app code, change database state, or change agent contracts.

After the PR number is assigned, this branch will receive the PR-level scope declaration and IAA preflight record.