### PR TITLE
Runtime Activation Readiness Pack v0.1

### DIFF
--- a/.agent-admin/assurance/iaa-wave-record-runtime-activation-readiness-v01-20260629.md
+++ b/.agent-admin/assurance/iaa-wave-record-runtime-activation-readiness-v01-20260629.md
@@ -1,0 +1,64 @@
+# IAA Wave Record — Runtime Activation Readiness Pack v0.1
+
+**Wave ID**: MRAR-PREBUILD-V01  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Date**: 2026-06-29  
+**Scope Declaration**: `.agent-admin/scope-declarations/pr-1863.md`
+
+---
+
+IAA_PREFLIGHT_BRIEF:
+
+schema_version: 1.0.0
+result: PREFLIGHT_BRIEF_COMPLETE
+wave_id: MRAR-PREBUILD-V01
+repository: APGI-cmy/maturion-isms
+PR: 1863
+CURRENT_HEAD_SHA: dc30751256a9274cdb479af47a3846db2f839430
+scope_summary: Batch 4 readiness pack consolidating Batches 1-3 before any APW Specialist implementation or activation.
+authority: CS2 — Johan Ras
+
+EXPECTED_QA_SCOPE:
+
+- Review readiness matrix, implementation FRS, implementation TRS, QA-to-Red test plan and builder appointment conditions.
+- Confirm traceability to Batch 1 runtime network, Batch 2 knowledge grounding and Batch 3 APW Specialist contract.
+- Confirm this PR is readiness-only.
+- Confirm the next wave is limited to red tests, stubs, resolver abstractions and validation design unless separately approved.
+- Confirm activation remains a separate later wave.
+
+EXPECTED_FAILURE_MODES:
+
+- Readiness approval is treated as implementation approval.
+- Builder appointment conditions are treated as current coding authorisation.
+- Red-first tests are skipped.
+- APW Specialist is treated as active before a later activation decision.
+- Public APW mode receives private or tenant-specific context.
+- Activation is bundled into the next implementation wave.
+
+FOREMAN_INSTRUCTIONS:
+
+- Treat this wave as readiness-only.
+- Do not implement runtime behaviour in this PR.
+- Do not create active specialist state in this PR.
+- Do not change APW public behaviour in this PR.
+- Do not change build/governance agent contracts in this PR.
+- Use IAA findings to correct readiness artifacts before any implementation PR is created.
+- Keep implementation and activation waves separate.
+
+IAA_WILL_QA:
+
+- IAA will check traceability from Batches 1-3 to Batch 4 readiness conditions.
+- IAA will check that FRS/TRS are specific enough to guide the next wave without authorising runtime changes now.
+- IAA will check QA-to-Red coverage for context envelope, registry resolver, metadata filter, mandate boundary, output validation and fallback.
+- IAA will check that builder appointment conditions are explicit and future-only.
+- IAA will check that no activation permission is implied by readiness approval.
+
+RESULT: PREFLIGHT_BRIEF_COMPLETE
+
+---
+
+## REQUESTED IAA OUTPUT
+
+IAA should provide a later independent assurance verdict or rejection package after reviewing the readiness artifact set.
+
+This file records the pre-brief only. It does not contain IAA final assurance, a merge verdict, or CS2 approval.

--- a/.agent-admin/builder-appointments/apw-specialist-implementation-wave-active-builder-appointment-v0.1.md
+++ b/.agent-admin/builder-appointments/apw-specialist-implementation-wave-active-builder-appointment-v0.1.md
@@ -1,0 +1,120 @@
+# Builder Appointment Package — APW Specialist Implementation Wave v0.1
+
+**Artifact ID**: MRAR-BUILDER-APPOINTMENT-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — Implementation Appointment Conditions  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Batch 4 — Runtime Activation Readiness Pack v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-26
+
+---
+
+## 1. Purpose
+
+This package defines the conditions for appointing a builder in the next APW Specialist implementation wave.
+
+It is not a current instruction to code. It prepares the appointment contract that must be explicitly accepted in a later implementation PR.
+
+---
+
+## 2. Appointment Status
+
+| Field | Value |
+|---|---|
+| Current status | NOT APPOINTED / NOT STARTED |
+| Next possible wave | APW Specialist Implementation — Red Tests + Stubs |
+| Runtime implementation allowed in Batch 4 | No |
+| Specialist activation allowed in Batch 4 | No |
+| Registry mutation allowed in Batch 4 | No |
+| Database mutation allowed in Batch 4 | No |
+| Public APW behaviour change allowed in Batch 4 | No |
+
+---
+
+## 3. Future Builder Mandate
+
+A future builder may be appointed to implement only a red-tests-and-stubs wave first.
+
+Permitted future implementation tasks may include:
+
+- creating red test fixtures;
+- creating a context-envelope validation stub;
+- creating a route-classifier stub;
+- creating a runtime registry resolver stub or abstraction;
+- creating a public-safe filter adapter stub;
+- creating an APW Specialist invocation adapter stub;
+- creating output validation stubs;
+- proving unsafe cases fail red;
+- documenting remaining build-to-green work.
+
+---
+
+## 4. Future Builder Must Not Do Initially
+
+The first implementation builder must not:
+
+- activate APW Specialist;
+- create a production ACTIVE registry record;
+- expose APW Specialist directly to users;
+- change public APW behaviour;
+- deploy public chat;
+- query or mutate Supabase directly from APW Specialist;
+- pass tenant, private, internal or secret context to the specialist;
+- bypass Maturion final synthesis;
+- change `.github/agents` contracts;
+- grant CS2 authority to Maturion or APW Specialist.
+
+---
+
+## 5. Required Appointment Inputs
+
+Before the next implementation PR is opened, the appointment must include:
+
+1. builder identity;
+2. implementation branch name;
+3. exact allowed file paths;
+4. forbidden paths;
+5. runtime registry storage decision or temporary stub decision;
+6. public APW context source decision;
+7. knowledge filter integration decision;
+8. QA-to-Red fixture list;
+9. audit trace storage decision or temporary stub decision;
+10. rollback plan;
+11. IAA preflight brief;
+12. CS2 approval checkpoint.
+
+---
+
+## 6. Suggested Next Implementation Wave Boundary
+
+Recommended next wave:
+
+```text
+Batch 5 — APW Specialist Implementation: Red Tests + Stubs
+```
+
+Recommended allowed scope:
+
+- test fixtures;
+- validation stubs;
+- resolver abstractions;
+- route decision stubs;
+- no production activation.
+
+Recommended forbidden scope:
+
+- production registry activation;
+- public APW UI changes;
+- Supabase migrations unless separately approved;
+- production retrieval services;
+- `.github/agents` changes;
+- release/deployment changes.
+
+---
+
+## 7. Handover to Later Builder
+
+The later builder must begin with the readiness matrix, implementation FRS, implementation TRS and QA-to-Red implementation test plan.
+
+The builder must not infer permission from this package alone. A separate PR scope and CS2 instruction are required.

--- a/.agent-admin/scope-declarations/maturion-runtime-activation-readiness-pack-v01.md
+++ b/.agent-admin/scope-declarations/maturion-runtime-activation-readiness-pack-v01.md
@@ -3,7 +3,7 @@
 **Scope ID**: MRAR-PREBUILD-V01  
 **Repository**: `APGI-cmy/maturion-isms`  
 **Wave**: Batch 4 — Runtime Activation Readiness Pack v0.1  
-**Date**: 2026-06-26  
+**Date**: 2026-06-29  
 **Authority**: CS2 — Johan Ras  
 **Operating Role**: Foreman-led governed delivery  
 **Task Type**: readiness consolidation and implementation-prep artifacts only  
@@ -53,8 +53,8 @@ This wave creates:
 3. `Maturion/prebuild/runtime-activation-readiness/MRAR-APW-Specialist-Implementation-TRS-v0.1.md`
 4. `Maturion/prebuild/runtime-activation-readiness/MRAR-QA-to-Red-Implementation-Test-Plan-v0.1.md`
 5. `.agent-admin/builder-appointments/apw-specialist-implementation-wave-active-builder-appointment-v0.1.md`
-6. `.agent-admin/assurance/iaa-wave-record-runtime-activation-readiness-v01-20260626.md`
-7. this scope declaration.
+6. `.agent-admin/assurance/iaa-wave-record-runtime-activation-readiness-v01-20260629.md`
+7. this wave scope declaration.
 
 ---
 

--- a/.agent-admin/scope-declarations/maturion-runtime-activation-readiness-pack-v01.md
+++ b/.agent-admin/scope-declarations/maturion-runtime-activation-readiness-pack-v01.md
@@ -1,0 +1,95 @@
+# Scope Declaration — Runtime Activation Readiness Pack v0.1
+
+**Scope ID**: MRAR-PREBUILD-V01  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Batch 4 — Runtime Activation Readiness Pack v0.1  
+**Date**: 2026-06-26  
+**Authority**: CS2 — Johan Ras  
+**Operating Role**: Foreman-led governed delivery  
+**Task Type**: readiness consolidation and implementation-prep artifacts only  
+**Affected Scope**: Runtime Maturion / APW Specialist activation readiness  
+**Implementation Status**: No implementation, no activation, no production routing
+
+---
+
+## 1. Purpose
+
+This wave consolidates Batches 1–3 into a controlled readiness pack before any APW Specialist implementation or activation starts.
+
+It answers:
+
+```text
+What exactly must be true before APW-specialist can be built, registered, tested, and safely activated?
+```
+
+---
+
+## 2. Source Authority
+
+This scope is governed by:
+
+- `FOREMAN_OPERATING_MODEL.md`;
+- `.github/agents/foreman-v2-agent.md`;
+- `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`;
+- `Maturion/strategy/Maturion_agent_network_organigram_strategy.md`;
+- `Maturion/prebuild/runtime-agent-network/MRAN-FRS-v0.1.md`;
+- `Maturion/prebuild/runtime-agent-network/MRAN-TRS-context-envelope-runtime-registry-v0.1.md`;
+- `Maturion/prebuild/runtime-knowledge-grounding/MRKG-FRS-addendum-v0.1.md`;
+- `Maturion/prebuild/runtime-knowledge-grounding/MRKG-TRS-supabase-aimc-metadata-v0.1.md`;
+- `Maturion/prebuild/runtime-knowledge-grounding/MRKG-QA-to-Red-v0.1.md`;
+- `Maturion/prebuild/apw-specialist/APW-Specialist-Scope-Contract-v0.1.md`;
+- `Maturion/prebuild/apw-specialist/APW-Maturion-FRS-TRS-addendum-v0.1.md`;
+- `Maturion/prebuild/apw-specialist/APW-QA-to-Red-specialist-routing-v0.1.md`;
+- `.agent-admin/builder-appointments/apw-specialist-implementation-wave-builder-appointment-v0.1.md`.
+
+---
+
+## 3. In Scope
+
+This wave creates:
+
+1. `Maturion/prebuild/runtime-activation-readiness/MRAR-Readiness-Matrix-v0.1.md`
+2. `Maturion/prebuild/runtime-activation-readiness/MRAR-APW-Specialist-Implementation-FRS-v0.1.md`
+3. `Maturion/prebuild/runtime-activation-readiness/MRAR-APW-Specialist-Implementation-TRS-v0.1.md`
+4. `Maturion/prebuild/runtime-activation-readiness/MRAR-QA-to-Red-Implementation-Test-Plan-v0.1.md`
+5. `.agent-admin/builder-appointments/apw-specialist-implementation-wave-active-builder-appointment-v0.1.md`
+6. `.agent-admin/assurance/iaa-wave-record-runtime-activation-readiness-v01-20260626.md`
+7. this scope declaration.
+
+---
+
+## 4. Out of Scope
+
+This wave does not:
+
+- create runtime code;
+- activate APW Specialist;
+- create or mutate runtime registry records;
+- create Supabase tables, policies, functions, migrations or data;
+- create embeddings or retrieval services;
+- change APW public app behaviour;
+- implement public chat;
+- change `.github/agents` contracts;
+- grant Maturion or APW Specialist CS2 authority;
+- appoint a builder to start coding immediately;
+- deploy anything to preview or production.
+
+---
+
+## 5. Success Criteria
+
+This wave succeeds when:
+
+1. Batches 1–3 are mapped into readiness conditions;
+2. implementation FRS and TRS are defined without code;
+3. red-first test expectations are defined;
+4. builder appointment conditions are explicit but not yet executed;
+5. activation prerequisites are listed and gated;
+6. IAA pre-brief exists in gate-readable format;
+7. no runtime behaviour changes are introduced.
+
+---
+
+## 6. Follow-On Work
+
+The next wave may be APW Specialist Implementation — Red Tests + Stubs only after CS2 approves the readiness pack and a separate implementation PR scope is opened.

--- a/.agent-admin/scope-declarations/pr-1863.md
+++ b/.agent-admin/scope-declarations/pr-1863.md
@@ -1,0 +1,85 @@
+# Scope Declaration — PR #1863
+
+**Scope ID**: PR-1863-MRAR-PREBUILD-V01  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Pull Request**: #1863  
+**Wave**: Batch 4 — Runtime Activation Readiness Pack v0.1  
+**Date**: 2026-06-29  
+**Authority**: CS2 — Johan Ras  
+**Operating Role**: Foreman-led governed delivery  
+**Task Type**: readiness consolidation and implementation-prep artifacts only  
+**Affected Scope**: Runtime Maturion / APW Specialist activation readiness  
+**Implementation Status**: No implementation in this PR
+
+---
+
+## 1. Active PR Scope
+
+This is the active per-PR scope declaration for PR #1863.
+
+It mirrors the wave scope declaration and exists so PR-level scope/diff parity gates can discover the active changed-file set.
+
+---
+
+## 2. Changed Files in Scope
+
+This PR is limited to these files:
+
+1. `.agent-admin/scope-declarations/maturion-runtime-activation-readiness-pack-v01.md`
+2. `.agent-admin/scope-declarations/pr-1863.md`
+3. `Maturion/prebuild/runtime-activation-readiness/MRAR-Readiness-Matrix-v0.1.md`
+4. `Maturion/prebuild/runtime-activation-readiness/MRAR-APW-Specialist-Implementation-FRS-v0.1.md`
+5. `Maturion/prebuild/runtime-activation-readiness/MRAR-APW-Specialist-Implementation-TRS-v0.1.md`
+6. `Maturion/prebuild/runtime-activation-readiness/MRAR-QA-to-Red-Implementation-Test-Plan-v0.1.md`
+7. `.agent-admin/builder-appointments/apw-specialist-implementation-wave-active-builder-appointment-v0.1.md`
+8. `.agent-admin/assurance/iaa-wave-record-runtime-activation-readiness-v01-20260629.md`
+
+---
+
+## 3. Source Authority
+
+This scope is governed by:
+
+- Batch 1 Runtime Agent Network prebuild;
+- Batch 2 Knowledge Grounding prebuild;
+- Batch 3 APW Specialist prebuild;
+- `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`;
+- Foreman operating model and PR scope discipline.
+
+---
+
+## 4. In Scope
+
+This PR creates Batch 4 readiness artifacts:
+
+- runtime activation readiness matrix;
+- APW Specialist implementation FRS;
+- APW Specialist implementation TRS;
+- QA-to-Red implementation test plan;
+- future implementation builder appointment conditions;
+- IAA pre-brief;
+- scope declarations.
+
+---
+
+## 5. Out of Scope
+
+This PR does not:
+
+- create runtime code;
+- activate APW Specialist;
+- create or mutate runtime registry records;
+- create Supabase tables, policies, functions, migrations or data;
+- create embeddings or retrieval services;
+- change APW public app behaviour;
+- implement public chat;
+- change `.github/agents` contracts;
+- grant Maturion or APW Specialist CS2 authority;
+- appoint a builder to start coding immediately;
+- deploy anything to preview or production.
+
+---
+
+## 6. Gate Note
+
+This file is the active PR-level scope declaration. The wave-named scope declaration remains the durable wave artifact, while this file supports PR-level scope/diff validation.

--- a/Maturion/prebuild/runtime-activation-readiness/MRAR-APW-Specialist-Implementation-FRS-v0.1.md
+++ b/Maturion/prebuild/runtime-activation-readiness/MRAR-APW-Specialist-Implementation-FRS-v0.1.md
@@ -1,0 +1,124 @@
+# APW Specialist Implementation FRS v0.1
+
+**Artifact ID**: MRAR-APW-FRS-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — Implementation Readiness FRS  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Batch 4 — Runtime Activation Readiness Pack v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-26
+
+---
+
+## 1. Purpose
+
+This Functional Requirements Specification defines the user-visible and orchestration behaviour expected from a later APW Specialist implementation wave.
+
+It does not implement that behaviour.
+
+---
+
+## 2. Functional Principle
+
+```text
+Public APW users talk to Maturion.
+Maturion may use APW Specialist only as a governed behind-the-scenes helper.
+Maturion remains responsible for the final public answer.
+```
+
+---
+
+## 3. Public APW User Behaviour
+
+### MRAR-FRS-001 — Public APW Maturion Entry Point
+
+Public APW users must see Maturion as the single assistant. APW Specialist must not be exposed as a separate public assistant in the initial implementation.
+
+### MRAR-FRS-002 — Public APW Question Types
+
+Maturion may consider APW Specialist support for:
+
+- APW product explanation;
+- APW public module explanation;
+- onboarding guidance;
+- public navigation support;
+- capability explanation;
+- safe contact/demo/login signposting;
+- clarification of APW boundaries and limitations.
+
+### MRAR-FRS-003 — Private Question Refusal or Handoff
+
+If a user asks for tenant, customer, account, internal, secret, incident, investigation, audit, evidence or authenticated context, Maturion must not route the question to APW Specialist in public mode.
+
+### MRAR-FRS-004 — Public-Safe Knowledge Only
+
+Maturion may answer public APW questions only from public-safe sources or current-session user-provided content, with limitations clearly disclosed where source coverage is incomplete.
+
+### MRAR-FRS-005 — No Invention of APW Facts
+
+Where approved public APW knowledge is missing, Maturion must not invent product facts. It must either answer generally with clear limitation language or provide a safe handoff.
+
+### MRAR-FRS-006 — Specialist Output Is Draft Support
+
+APW Specialist output must be treated as draft support for Maturion. Maturion must validate and synthesise the final answer.
+
+### MRAR-FRS-007 — Safe Handoff Routes
+
+Maturion may offer only approved safe handoff routes such as contact, demo, login, onboarding enquiry or human review. Handoff language must not imply guaranteed acceptance, delivery, pricing or contractual commitment.
+
+### MRAR-FRS-008 — No Authority Escalation
+
+APW Specialist must not approve, commit, quote binding pricing, promise delivery, sign off governance work, speak as CS2, or change app state.
+
+---
+
+## 4. Routing Functional Requirements
+
+### MRAR-FRS-009 — Route Classification
+
+Maturion must classify a public APW request as one of:
+
+| Route | Meaning |
+|---|---|
+| `maturion_only` | Answer without APW Specialist. |
+| `apw_specialist_candidate` | Request is eligible for specialist support if all gates pass. |
+| `blocked_private_context` | Request needs private/authenticated/tenant context. |
+| `blocked_unsafe_source` | Required source is not public-safe. |
+| `handoff` | Human/contact/login/demo route is safer. |
+| `cannot_answer` | Insufficient approved knowledge. |
+
+### MRAR-FRS-010 — Route Eligibility
+
+A request is eligible for APW Specialist only when:
+
+1. app context is APW;
+2. embodiment is public web or later-approved public APW surface;
+3. permission scope is public;
+4. user is unauthenticated or has no tenant context in public mode;
+5. task is within APW Specialist mandate;
+6. required sources pass public-safe filters;
+7. future registry permits invocation.
+
+### MRAR-FRS-011 — Degraded Public Answer
+
+When a route is blocked, Maturion must degrade safely. Degraded answers may include:
+
+- limitation disclosure;
+- public-only explanation;
+- contact/demo/login signpost;
+- request for the user to authenticate where appropriate;
+- refusal to provide private or internal information.
+
+---
+
+## 5. Acceptance Criteria
+
+A later implementation is functionally acceptable only if:
+
+- public APW users interact with Maturion, not APW Specialist directly;
+- APW Specialist is invoked only for eligible public APW requests;
+- private/tenant/internal/secret requests are blocked in public mode;
+- no APW fact is invented when source coverage is missing;
+- Maturion validates specialist output before final response;
+- safe handoff works;
+- activation remains separate from implementation unless a separate activation PR is approved.

--- a/Maturion/prebuild/runtime-activation-readiness/MRAR-APW-Specialist-Implementation-TRS-v0.1.md
+++ b/Maturion/prebuild/runtime-activation-readiness/MRAR-APW-Specialist-Implementation-TRS-v0.1.md
@@ -1,0 +1,200 @@
+# APW Specialist Implementation TRS v0.1
+
+**Artifact ID**: MRAR-APW-TRS-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — Implementation Readiness TRS  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Batch 4 — Runtime Activation Readiness Pack v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-26
+
+---
+
+## 1. Purpose
+
+This Technical Requirements Specification defines the minimum implementation design for a later APW Specialist implementation wave.
+
+It does not create code, schemas, migrations, registry rows, Supabase changes, retrieval services or runtime activation.
+
+---
+
+## 2. Technical Principle
+
+```text
+No valid context envelope, no routing.
+No active registry permission, no specialist invocation.
+No public-safe metadata, no public answer from that source.
+No Maturion validation, no final response.
+```
+
+---
+
+## 3. Required Implementation Components
+
+A later implementation wave must define or build these components:
+
+1. public APW context envelope provider;
+2. route classifier;
+3. runtime registry resolver;
+4. public-safe knowledge filter;
+5. APW Specialist invocation adapter;
+6. APW Specialist output validator;
+7. Maturion final synthesis layer;
+8. audit trace writer;
+9. degraded/handoff responder;
+10. red-first test suite.
+
+---
+
+## 4. Context Envelope Requirements
+
+A public APW request must satisfy the Batch 1 public APW envelope:
+
+```json
+{
+  "app": "APW",
+  "embodiment": "public-web",
+  "permission_scope": "public",
+  "user": {
+    "authenticated": false,
+    "id": null,
+    "organisation_id": null,
+    "tenant_id": null
+  },
+  "knowledge_scope": {
+    "subject_allowed": true,
+    "app_context_allowed": true,
+    "framework_context_allowed": false,
+    "tenant_context_allowed": false,
+    "memory_allowed": false
+  }
+}
+```
+
+Implementation must reject or degrade if public APW mode contains tenant identifiers, private memory permission, governance scope, or secret/internal retrieval permissions.
+
+---
+
+## 5. Registry Resolver Requirements
+
+A later implementation must not hard-code specialist availability. It must resolve APW Specialist through a runtime registry or registry abstraction.
+
+Minimum required resolver checks:
+
+1. `runtime_agent_id = apw-specialist` exists;
+2. `status` permits invocation;
+3. `orchestrator = maturion`;
+4. `allowed_apps` contains `APW`;
+5. `allowed_embodiments` contains `public-web`;
+6. `allowed_permission_scopes` contains `public`;
+7. required knowledge planes are allowed;
+8. forbidden knowledge planes are absent;
+9. authority limits do not block the task;
+10. audit is enabled.
+
+The first implementation wave may create a registry abstraction/stub for tests only. Production activation must remain blocked until a later activation wave approves the registry state.
+
+---
+
+## 6. Knowledge Filter Requirements
+
+Before any APW Specialist invocation, Maturion must filter candidate sources using Batch 2 metadata requirements.
+
+Minimum public-safe filter:
+
+```text
+visibility = public
+public_safe = true
+retrieval_allowed = true
+requires_authentication = false
+requires_tenant_match = false
+tenant_id = null
+not expired
+not superseded
+not secret/restricted/internal
+```
+
+If any required metadata is missing, the source fails closed.
+
+---
+
+## 7. Specialist Invocation Adapter
+
+The invocation adapter must pass only:
+
+- current user question;
+- validated public APW context envelope;
+- public-safe source snippets already filtered by Maturion;
+- public page/workflow label where available;
+- approved safe handoff options.
+
+The adapter must not pass tenant records, private memory, internal governance records, secrets, raw Supabase handles, unrestricted search credentials or build/governance agent instructions.
+
+---
+
+## 8. Output Validation
+
+Maturion must validate APW Specialist output before final response.
+
+Validation must reject or degrade if the specialist output:
+
+- claims private or tenant knowledge;
+- exposes internal governance or secret material;
+- invents APW product facts;
+- promises delivery, pricing, legal, security or compliance commitments;
+- claims CS2 or APGI binding authority;
+- instructs direct access to internal systems;
+- lacks limitation disclosure when source coverage is weak.
+
+---
+
+## 9. Audit Trace Requirements
+
+A later implementation must produce an audit trace without storing secrets or raw confidential documents.
+
+Minimum trace fields:
+
+```json
+{
+  "request_id": "string",
+  "app": "APW",
+  "embodiment": "public-web",
+  "permission_scope": "public",
+  "route_decision": "maturion_only|apw_specialist|blocked|degraded|handoff",
+  "specialist_id": "apw-specialist|null",
+  "registry_decision": "allowed|blocked|missing|not_active",
+  "knowledge_filter_decision": "passed|blocked|missing_metadata",
+  "knowledge_planes_used": ["subject", "app_context", "user_session"],
+  "final_synthesizer": "maturion",
+  "degradation_reason": "string|null"
+}
+```
+
+---
+
+## 10. Storage Decisions Still Required
+
+This readiness pack does not choose final storage for:
+
+- runtime registry;
+- audit traces;
+- route decisions;
+- test fixtures;
+- public-safe source catalogues.
+
+A later implementation PR must state each storage choice before build-to-green.
+
+---
+
+## 11. Technical Acceptance Conditions
+
+A later implementation can proceed only when:
+
+- context envelope validation is testable;
+- registry resolution is testable;
+- public-safe filtering is testable;
+- APW Specialist invocation is adapter-based, not direct retrieval;
+- output validation is testable;
+- audit trace is produced;
+- degraded mode is testable;
+- activation remains separate.

--- a/Maturion/prebuild/runtime-activation-readiness/MRAR-QA-to-Red-Implementation-Test-Plan-v0.1.md
+++ b/Maturion/prebuild/runtime-activation-readiness/MRAR-QA-to-Red-Implementation-Test-Plan-v0.1.md
@@ -1,0 +1,164 @@
+# QA-to-Red Implementation Test Plan — APW Specialist v0.1
+
+**Artifact ID**: MRAR-QA-RED-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — Test Plan  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Batch 4 — Runtime Activation Readiness Pack v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-26
+
+---
+
+## 1. Purpose
+
+This plan turns the Batch 3 QA-to-Red concepts into concrete implementation test expectations for a later APW Specialist implementation wave.
+
+It does not create tests or code in this readiness PR.
+
+---
+
+## 2. Red-First Principle
+
+```text
+Unsafe APW Specialist routing must fail before builders make valid public routing pass.
+```
+
+---
+
+## 3. Required Future Test Groups
+
+### MRAR-RED-001 — Context Envelope Tests
+
+Future implementation must include tests proving APW Specialist is not invoked when:
+
+- app is not `APW`;
+- embodiment is not `public-web` or approved public APW surface;
+- permission scope is not `public`;
+- `tenant_id` is present;
+- `organisation_id` is present in public mode;
+- private memory is enabled;
+- governance scope is present.
+
+Expected result: route blocked or degraded; no specialist invocation.
+
+### MRAR-RED-002 — Registry Resolver Tests
+
+Future implementation must include tests proving APW Specialist is not invoked when:
+
+- registry record is missing;
+- status is not invocation-permitted;
+- orchestrator is not `maturion`;
+- app/embodiment/permission scope is not allowed;
+- required knowledge planes are not allowed;
+- authority limits block the request.
+
+Expected result: registry decision blocks route.
+
+### MRAR-RED-003 — Public-Safe Metadata Tests
+
+Future implementation must include test sources for:
+
+- valid public source;
+- `public_safe = false`;
+- `retrieval_allowed = false`;
+- missing metadata;
+- tenant source;
+- internal source;
+- secret/restricted source;
+- expired source;
+- superseded source.
+
+Expected result: only valid public source reaches APW Specialist.
+
+### MRAR-RED-004 — Mandate Boundary Tests
+
+Future implementation must block or degrade requests asking for:
+
+- tenant audit findings;
+- customer-specific configuration;
+- incident/investigation/evidence details;
+- internal governance gate details not public-safe;
+- binding pricing or delivery commitments;
+- CS2 approval or sign-off;
+- runtime registry internals.
+
+Expected result: specialist not invoked or returns `cannot_answer`; Maturion final answer remains safe.
+
+### MRAR-RED-005 — Direct Retrieval Bypass Tests
+
+Future implementation must prove APW Specialist cannot:
+
+- query Supabase directly;
+- run unrestricted vector search;
+- request additional private context;
+- override Maturion filters;
+- use blocked metadata.
+
+Expected result: bypass blocked, output rejected, audit trace records failure or degradation.
+
+### MRAR-RED-006 — Output Validation Tests
+
+Future implementation must reject specialist output that:
+
+- invents APW facts;
+- claims private knowledge;
+- exposes internal governance;
+- promises pricing/delivery/compliance;
+- claims CS2 or APGI binding authority;
+- returns unsafe handoff language;
+- omits source limitation when required.
+
+Expected result: Maturion rejects, constrains or degrades before final response.
+
+### MRAR-RED-007 — Safe Fallback Tests
+
+Future implementation must prove safe behaviour when:
+
+- no valid public source exists;
+- source coverage is incomplete;
+- specialist cannot answer;
+- user should log in;
+- user should contact/demo/human-review.
+
+Expected result: no invented facts; limitation or safe handoff is delivered.
+
+---
+
+## 4. Minimum Fixture Pack
+
+A later implementation wave must create fixtures for:
+
+1. valid public APW question;
+2. valid public APW source;
+3. non-APW question;
+4. public request with tenant_id;
+5. public request with memory enabled;
+6. missing registry record;
+7. non-active registry record;
+8. unsafe source metadata;
+9. missing source metadata;
+10. private tenant source;
+11. specialist output claiming authority;
+12. specialist output inventing fact;
+13. safe handoff scenario.
+
+---
+
+## 5. Evidence Required Before Build-to-Green
+
+Before implementation turns green, evidence must show:
+
+- each red group fails before implementation;
+- implementation changes make only valid cases pass;
+- invalid cases remain blocked;
+- route and audit decisions are captured;
+- no production activation occurs.
+
+---
+
+## 6. Batch 4 Disposition
+
+This is a readiness test plan only.
+
+It does not create executable tests, runtime routing, registry records, Supabase changes, retrieval services, public chat, app behaviour or specialist activation.

--- a/Maturion/prebuild/runtime-activation-readiness/MRAR-Readiness-Matrix-v0.1.md
+++ b/Maturion/prebuild/runtime-activation-readiness/MRAR-Readiness-Matrix-v0.1.md
@@ -1,0 +1,89 @@
+# Runtime Activation Readiness Matrix v0.1
+
+**Artifact ID**: MRAR-MATRIX-001  
+**Version**: 0.1.0  
+**Status**: PREBUILD — Readiness Matrix  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Batch 4 — Runtime Activation Readiness Pack v0.1  
+**Authority**: CS2 — Johan Ras  
+**Date**: 2026-06-26  
+**Scope Declaration**: `.agent-admin/scope-declarations/maturion-runtime-activation-readiness-pack-v01.md`
+
+---
+
+## 1. Purpose
+
+This matrix consolidates the outputs of Batches 1–3 into readiness conditions for a later APW Specialist implementation wave.
+
+It does not approve implementation or activation. It identifies what is ready, what is blocked, and what must be proven before build-to-green begins.
+
+---
+
+## 2. Readiness Principle
+
+```text
+Prebuild artifacts are not runtime permission.
+A specialist can be implemented only after its context, registry, knowledge, tests, audit, fallback and authority boundaries are explicit and testable.
+```
+
+---
+
+## 3. Readiness Status Legend
+
+| Status | Meaning |
+|---|---|
+| READY_FOR_IMPLEMENTATION_DESIGN | Enough is defined to design implementation tasks. |
+| NEEDS_TEST_FIXTURES | Concept is defined but test data/scripts must be created. |
+| NEEDS_SCHEMA_DECISION | Concept is defined but storage or schema location is not yet chosen. |
+| BLOCKED_UNTIL_IMPLEMENTATION_WAVE | Must not be changed in this readiness PR. |
+| BLOCKED_UNTIL_ACTIVATION_WAVE | May be built later but cannot be activated until a separate gate passes. |
+
+---
+
+## 4. Consolidated Matrix
+
+| Area | Source Batch | Current State | Readiness | Required Next Evidence |
+|---|---|---:|---|---|
+| Runtime agent network | Batch 1 | Context envelope and registry architecture defined | READY_FOR_IMPLEMENTATION_DESIGN | Implementation task breakdown with file boundaries |
+| Public APW context envelope | Batch 1 + Batch 3 | Required public envelope shape defined | NEEDS_TEST_FIXTURES | Valid/invalid APW envelope fixtures |
+| Runtime registry | Batch 1 + Batch 3 | Minimum registry record defined as future constraint | NEEDS_SCHEMA_DECISION | Storage decision: database, JSON registry, or hybrid |
+| Specialist lifecycle | Batch 1 + Batch 3 | APW Specialist limited to prebuild/stub contracted | BLOCKED_UNTIL_ACTIVATION_WAVE | Separate activation PR and CS2 decision |
+| Knowledge planes | Batch 1 + Batch 2 | Subject, app context, framework/context, tenant, memory and session boundaries defined | READY_FOR_IMPLEMENTATION_DESIGN | Mapping between metadata records and runtime knowledge planes |
+| Public-safe retrieval | Batch 2 + Batch 3 | Public filters defined | NEEDS_TEST_FIXTURES | Metadata fixture pack covering public/unsafe/missing cases |
+| Tenant isolation | Batch 2 + Batch 3 | Public APW mode must not receive tenant context | NEEDS_TEST_FIXTURES | Negative tests with tenant_id and tenant sources |
+| APW Specialist mandate | Batch 3 | Public APW explanation/navigation/onboarding/signposting defined | READY_FOR_IMPLEMENTATION_DESIGN | Route classifier criteria and examples |
+| APW Specialist prohibited knowledge | Batch 3 | Tenant/private/internal/secret/protected knowledge prohibited | NEEDS_TEST_FIXTURES | Leakage and prompt-injection style negative fixtures |
+| Maturion final synthesis | Batch 1 + Batch 3 | Specialist output is draft only | READY_FOR_IMPLEMENTATION_DESIGN | Output validation contract and tests |
+| Direct retrieval prevention | Batch 2 + Batch 3 | Specialist must not query Supabase directly | NEEDS_TEST_FIXTURES | Test proving specialist cannot bypass filtered context |
+| Audit trace | Batch 1 + Batch 3 | Required fields defined at concept level | NEEDS_SCHEMA_DECISION | Storage and retention decision |
+| Degraded mode | Batch 1 + Batch 3 | Block/degrade/handoff defined | NEEDS_TEST_FIXTURES | Handoff and limitation scenarios |
+| Builder appointment | Batch 3 + Batch 4 | Future appointment package exists; active readiness package to be defined | BLOCKED_UNTIL_IMPLEMENTATION_WAVE | CS2 approval of next PR scope |
+
+---
+
+## 5. Minimum Conditions Before Implementation Wave
+
+Before an APW Specialist implementation wave begins, the following must be true:
+
+1. CS2 approves the readiness pack.
+2. Implementation scope declares exact files allowed and forbidden.
+3. Runtime registry storage decision is recorded.
+4. Context envelope source for public APW is identified.
+5. Public-safe knowledge-filter integration point is identified.
+6. Red-first test fixtures are created or specified.
+7. Builder appointment is current-head bound.
+8. IAA preflight is recorded for the implementation PR.
+9. No production activation is included in the implementation PR.
+
+---
+
+## 6. Activation Remains Separate
+
+Even after implementation, APW Specialist must not be activated until a later activation PR proves:
+
+- implementation tests pass;
+- registry status transition is approved;
+- public APW preview behaviour is validated;
+- audit trace is captured;
+- rollback is defined;
+- CS2 approves activation.


### PR DESCRIPTION
## Summary

Creates Batch 4 readiness artifacts for the APW Specialist runtime activation path.

Artifacts added:

- readiness matrix
- APW Specialist implementation FRS
- APW Specialist implementation TRS
- implementation QA-to-Red test plan
- implementation-wave builder appointment conditions
- wave scope declaration

## Purpose

Consolidates Batches 1-3 into a readiness pack before any APW Specialist implementation or activation starts.

## Boundary

Documentation/readiness only. This PR does not implement runtime behaviour, activate APW Specialist, change registry state, change app code, change database state, or change agent contracts.

After the PR number is assigned, this branch will receive the PR-level scope declaration and IAA preflight record.