### PR TITLE
Fix MMM subscription routing

### DIFF
--- a/.agent-admin/assurance/iaa-wave-record-wave-isms-mmm-subscription-routing-20260701.md
+++ b/.agent-admin/assurance/iaa-wave-record-wave-isms-mmm-subscription-routing-20260701.md
@@ -1,0 +1,39 @@
+# IAA Wave Record - ISMS MMM Subscription Routing Fix
+
+Wave: `wave-isms-mmm-subscription-routing-20260701`
+Date: 2026-07-01
+PR: #1884
+Scope record: `.agent-admin/scope-declarations/wave-isms-mmm-subscription-routing-20260701.md`
+
+## PRE-BRIEF
+
+PR: #1884
+WAVE: wave-isms-mmm-subscription-routing-20260701
+BRANCH: isms-mmm-subscription-routing
+ISSUE: Maturity Roadmap marketing subscription path enters the PIT checkout flow because the ISMS subscription catalogue only exposes Project Implementation Tracker.
+
+EXPECTED_QA_SCOPE:
+- Maturity Roadmap marketing CTA opens checkout with `modules=maturity-roadmap`.
+- Static ISMS subscription catalogue includes `maturity-roadmap`.
+- PIT subscription and runtime behavior are unchanged.
+- MMM runtime is untouched.
+
+EXPECTED_FAILURE_MODES:
+- Maturity Roadmap still routes to generic `/subscribe` and defaults to PIT.
+- Checkout records `project-implementation` instead of `maturity-roadmap`.
+- ISMS implements MMM runtime behavior.
+- PIT runtime or PIT routing changes accidentally.
+
+FOREMAN_INSTRUCTIONS:
+- Verify the diff remains limited to ISMS subscription/marketing routing and governance evidence.
+- Verify no MMM runtime, PIT runtime, Supabase, or deployment workflow files are changed.
+
+IAA_WILL_QA:
+- Confirm PR #1884 has scope, IAA, builder appointment, and delegation-order records.
+- Confirm CI and governance gates pass before merge disposition.
+
+RESULT: PREFLIGHT_BRIEF_COMPLETE
+
+## FINAL ASSURANCE
+
+PENDING.

--- a/.agent-admin/builder-appointments/wave-isms-mmm-subscription-routing-20260701.md
+++ b/.agent-admin/builder-appointments/wave-isms-mmm-subscription-routing-20260701.md
@@ -1,0 +1,25 @@
+# Builder Appointment - ISMS MMM Subscription Routing Fix
+
+Wave: `wave-isms-mmm-subscription-routing-20260701`
+Date: 2026-07-01
+Repository: `APGI-cmy/maturion-isms`
+PR: #1884
+CS2 Authority: Johan Ras
+Appointed builder: `ui-builder`
+Appointment status: `APPOINTED`
+
+## Preconditions
+
+IAA pre-brief is recorded in `.agent-admin/assurance/iaa-wave-record-wave-isms-mmm-subscription-routing-20260701.md`.
+
+## Task
+
+Fix the ISMS-owned Maturity Roadmap subscription route so Maturity Roadmap acquisition carries `maturity-roadmap` through checkout instead of defaulting to Project Implementation Tracker.
+
+## Boundary
+
+- ISMS marketing/subscription/checkout routing only.
+- MMM runtime untouched.
+- PIT runtime untouched.
+
+RESULT: BUILDER_APPOINTED

--- a/.agent-admin/control/delegation-order.json
+++ b/.agent-admin/control/delegation-order.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.0.0",
-  "wave_id": "APW-SPEC-BUILD-GREEN-V01",
-  "pr_number": 1881,
-  "prebrief_commit_sha": "b4c02e81809569473eddf3685075b45a32af9a5b",
-  "builder_appointment_timestamp": "2026-06-30T12:55:00Z",
-  "builder_appointment_commit_sha": "dc408eb9eef55d276a9ab6212e674735746d8218",
-  "builder_agent": "apw-specialist-build-to-green-builder",
-  "builder_task_ref": ".agent-admin/builder-appointments/apw-specialist-build-to-green-builder-appointment-v0.1.md",
-  "first_implementation_commit_sha": "3e4395837eaba7bfef8dfd366b11b3190c98c47c",
-  "qp_review_timestamp": "2026-06-30T13:05:00Z",
+  "wave_id": "wave-isms-mmm-subscription-routing-20260701",
+  "pr_number": 1884,
+  "prebrief_commit_sha": "610a7b0430e2881eadd10518b654a69625f2457c",
+  "builder_appointment_timestamp": "2026-07-01T08:50:00Z",
+  "builder_appointment_commit_sha": "f470cec5cc66cb3870854d1863c1e00307ea661a",
+  "builder_agent": "ui-builder",
+  "builder_task_ref": ".agent-admin/builder-appointments/wave-isms-mmm-subscription-routing-20260701.md",
+  "first_implementation_commit_sha": "e1c9d3bb96749d0460a1ca0e2a4b1cb441e244b1",
+  "qp_review_timestamp": "2026-07-01T08:55:00Z",
   "result": "DELEGATION_ORDER_VERIFIED"
 }

--- a/.agent-admin/control/delegation-order.json
+++ b/.agent-admin/control/delegation-order.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.0.0",
-  "wave_id": "wave-isms-mmm-subscription-routing-20260701",
-  "pr_number": 1884,
-  "prebrief_commit_sha": "610a7b0430e2881eadd10518b654a69625f2457c",
-  "builder_appointment_timestamp": "2026-07-01T08:50:00Z",
-  "builder_appointment_commit_sha": "f470cec5cc66cb3870854d1863c1e00307ea661a",
-  "builder_agent": "ui-builder",
-  "builder_task_ref": ".agent-admin/builder-appointments/wave-isms-mmm-subscription-routing-20260701.md",
-  "first_implementation_commit_sha": "e1c9d3bb96749d0460a1ca0e2a4b1cb441e244b1",
-  "qp_review_timestamp": "2026-07-01T08:55:00Z",
+  "wave_id": "APW-SPEC-BUILD-GREEN-V01",
+  "pr_number": 1881,
+  "prebrief_commit_sha": "b4c02e81809569473eddf3685075b45a32af9a5b",
+  "builder_appointment_timestamp": "2026-06-30T12:55:00Z",
+  "builder_appointment_commit_sha": "dc408eb9eef55d276a9ab6212e674735746d8218",
+  "builder_agent": "apw-specialist-build-to-green-builder",
+  "builder_task_ref": ".agent-admin/builder-appointments/apw-specialist-build-to-green-builder-appointment-v0.1.md",
+  "first_implementation_commit_sha": "3e4395837eaba7bfef8dfd366b11b3190c98c47c",
+  "qp_review_timestamp": "2026-06-30T13:05:00Z",
   "result": "DELEGATION_ORDER_VERIFIED"
 }

--- a/.agent-admin/control/delegation-orders/pr-1884.json
+++ b/.agent-admin/control/delegation-orders/pr-1884.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "1.0.0",
+  "wave_id": "wave-isms-mmm-subscription-routing-20260701",
+  "pr_number": 1884,
+  "prebrief_commit_sha": "610a7b0430e2881eadd10518b654a69625f2457c",
+  "builder_appointment_timestamp": "2026-07-01T08:50:00Z",
+  "builder_appointment_commit_sha": "f470cec5cc66cb3870854d1863c1e00307ea661a",
+  "builder_agent": "ui-builder",
+  "builder_task_ref": ".agent-admin/builder-appointments/wave-isms-mmm-subscription-routing-20260701.md",
+  "first_implementation_commit_sha": "e1c9d3bb96749d0460a1ca0e2a4b1cb441e244b1",
+  "qp_review_timestamp": "2026-07-01T08:55:00Z",
+  "result": "DELEGATION_ORDER_VERIFIED"
+}

--- a/.agent-admin/scope-declarations/wave-isms-mmm-subscription-routing-20260701.md
+++ b/.agent-admin/scope-declarations/wave-isms-mmm-subscription-routing-20260701.md
@@ -1,0 +1,32 @@
+# Scope Declaration - ISMS MMM Subscription Routing Fix
+
+Wave: `wave-isms-mmm-subscription-routing-20260701`
+Date: 2026-07-01
+Repository: `APGI-cmy/maturion-isms`
+PR: #1884
+Module lane: ISMS platform shell
+Runtime owner: MMM
+CS2 Authority: Johan Ras
+
+## Objective
+
+Fix the ISMS-owned Maturity Roadmap subscription/acquisition route so a non-entitled user selecting Maturity Roadmap does not enter the Project Implementation Tracker checkout flow.
+
+## Boundaries
+
+- ISMS owns the public marketing page, subscription module catalogue, checkout selection, onboarding, dashboard, and entitlement handoff.
+- MMM owns MMM runtime after an entitled handoff.
+- Do not implement MMM runtime, scoring, assessment, descriptor, evidence, or deployment behavior.
+- Do not change PIT runtime or PIT routing.
+
+## Allowed files
+
+- `apps/isms-portal/src/pages/MaturityRoadmapInfo.tsx`
+- `apps/isms-portal/src/hooks/useSubscriptionModules.ts`
+- `modules/isms/11-build/isms-mmm-subscription-routing-fix-20260630.md`
+- `.agent-admin/control/delegation-order.json`
+- `.agent-admin/scope-declarations/wave-isms-mmm-subscription-routing-20260701.md`
+- `.agent-admin/assurance/iaa-wave-record-wave-isms-mmm-subscription-routing-20260701.md`
+- `.agent-admin/builder-appointments/wave-isms-mmm-subscription-routing-20260701.md`
+
+RESULT: SCOPE_DECLARED

--- a/apps/isms-portal/src/hooks/useSubscriptionModules.ts
+++ b/apps/isms-portal/src/hooks/useSubscriptionModules.ts
@@ -7,6 +7,12 @@ export interface SubscriptionModule {
 
 const STATIC_SUBSCRIPTION_MODULES: SubscriptionModule[] = [
   {
+    id: 'maturity-roadmap',
+    name: 'Maturity Roadmap',
+    monthly_price: 250,
+    yearly_discount_percentage: 10,
+  },
+  {
     id: 'project-implementation',
     name: 'Project Implementation Tracker',
     monthly_price: 150,

--- a/apps/isms-portal/src/pages/MaturityRoadmapInfo.tsx
+++ b/apps/isms-portal/src/pages/MaturityRoadmapInfo.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { TrendingUp, CheckCircle, ArrowLeft, ChevronRight } from 'lucide-react';
+import { createCheckoutSearch } from '@/lib/subscription';
 import { ROUTES } from '@/lib/routes';
 
 const features = [
@@ -35,6 +36,12 @@ const benefits = [
 
 const MaturityRoadmapInfo: React.FC = () => {
   const navigate = useNavigate();
+  const maturityCheckoutSearch = createCheckoutSearch({
+    selectedModules: ['maturity-roadmap'],
+    isBundle: false,
+    isYearly: false,
+    source: 'maturity-roadmap-marketing',
+  });
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20">
@@ -46,7 +53,7 @@ const MaturityRoadmapInfo: React.FC = () => {
               <ArrowLeft className="h-4 w-4 mr-2" />
               Back to Home
             </Button>
-            <Button size="sm" onClick={() => navigate(ROUTES.SUBSCRIBE)}>
+            <Button size="sm" onClick={() => navigate(`${ROUTES.SUBSCRIBE_CHECKOUT}?${maturityCheckoutSearch}`)}>
               Get Started
               <ChevronRight className="h-4 w-4 ml-1" />
             </Button>
@@ -76,7 +83,7 @@ const MaturityRoadmapInfo: React.FC = () => {
             <Button size="lg" onClick={() => navigate(ROUTES.FREE_ASSESSMENT)}>
               Start Free Assessment
             </Button>
-            <Button size="lg" variant="outline" onClick={() => navigate(ROUTES.SUBSCRIBE)}>
+            <Button size="lg" variant="outline" onClick={() => navigate(`${ROUTES.SUBSCRIBE_CHECKOUT}?${maturityCheckoutSearch}`)}>
               View Plans
             </Button>
           </div>
@@ -130,7 +137,7 @@ const MaturityRoadmapInfo: React.FC = () => {
           <Button
             size="lg"
             className="bg-emerald-600 hover:bg-emerald-700 text-white"
-            onClick={() => navigate(ROUTES.SUBSCRIBE)}
+            onClick={() => navigate(`${ROUTES.SUBSCRIBE_CHECKOUT}?${maturityCheckoutSearch}`)}
           >
             Subscribe to Maturity Roadmap
             <ChevronRight className="h-4 w-4 ml-2" />

--- a/modules/isms/11-build/isms-mmm-subscription-routing-fix-20260630.md
+++ b/modules/isms/11-build/isms-mmm-subscription-routing-fix-20260630.md
@@ -1,0 +1,33 @@
+# ISMS MMM Subscription Routing Fix Evidence
+
+Date: 2026-06-30
+Module lane: ISMS platform shell
+Related runtime owner: MMM
+Status: Build-to-green correction evidence
+
+## Defect observed
+
+After PR #1879 deployment, clicking Maturity Roadmap from the ISMS landing page correctly opened the ISMS Maturity Roadmap marketing page for a non-entitled user. However, clicking `Subscribe to Maturity Roadmap` navigated to the generic subscription page, where the subscription catalogue only exposed Project Implementation Tracker.
+
+The user then entered the PIT checkout/onboarding flow instead of a Maturity Roadmap subscription flow.
+
+## Correction
+
+- Maturity Roadmap marketing CTAs now navigate directly to checkout with `modules=maturity-roadmap` and source `maturity-roadmap-marketing`.
+- The ISMS static subscription catalogue now includes `maturity-roadmap` so checkout can represent the intended selection.
+
+## Boundary discipline
+
+- ISMS owns this marketing/subscription/checkout routing correction.
+- MMM runtime remains untouched.
+- PIT runtime remains untouched.
+
+## Verification expectation
+
+After deployment:
+
+1. Non-entitled user clicks Maturity Roadmap on ISMS landing page.
+2. User lands on ISMS Maturity Roadmap marketing page.
+3. User clicks `Subscribe to Maturity Roadmap`.
+4. User lands on checkout with `modules=maturity-roadmap`, not PIT.
+5. After mock checkout/onboarding, entitled Maturity Roadmap handoff can proceed to the MMM app host.


### PR DESCRIPTION
Fixes the ISMS-side Maturity Roadmap subscription path after PR #1879.

Scope:
- Maturity Roadmap marketing CTAs now go directly to checkout with modules=maturity-roadmap.
- ISMS subscription catalogue now includes Maturity Roadmap.
- Records build evidence for the ISMS routing correction.

No MMM runtime, PIT runtime, Supabase, or deployment workflow changes.