### PR TITLE
Draft: MMM descriptor reasoning and governed learning retrieval pre-build

### DIFF
--- a/modules/MMM/02-frs/descriptor-reasoning-learning-frs-addendum.md
+++ b/modules/MMM/02-frs/descriptor-reasoning-learning-frs-addendum.md
@@ -1,0 +1,408 @@
+# MMM Descriptor Reasoning and Governed Learning Retrieval — FRS Addendum
+
+| Field | Value |
+|---|---|
+| Module | MMM — Maturity Model Management |
+| Artifact Type | Functional Requirements / Pre-Build Addendum |
+| Addendum ID | `MMM-FRS-DRGL-20260702` |
+| Status | PRE-BUILD ADDENDUM — CS2-requested descriptor reasoning and governed learning retrieval scope |
+| Authority | CS2 — Johan Ras |
+| Created | 2026-07-02 |
+| Scope | Descriptor generation reasoning, source-mode handling, user correction learning, governed retrieval, and learning hygiene |
+| Non-Scope | Runtime code, schema migration, production learning registry mutation, ISMS public route work, signoff route implementation, PIT/RADAM/Risk module work |
+| Related Active Wave | `wave-mmm-descriptor-grammar-closure-2026-06-30` / issue #1871 |
+| QA Expansion | `modules/MMM/05-qa-to-red/descriptor-reasoning-learning-qa-to-red.md` |
+
+---
+
+## 1. Purpose
+
+This addendum expands the MMM descriptor-generation pre-build baseline from grammar closure into a governed reasoning and learning retrieval capability.
+
+The defect being closed is not only bad wording. The deeper defect is that MMM can treat verbatim uploaded criteria as clean criterion grammar and mechanically wrap the uploaded wording into maturity descriptors.
+
+That is wrong for Verbatim source mode.
+
+In Verbatim source mode, uploaded Domains, MPSs, intent statements, and Criteria are preserved from the source material. The uploaded criterion may therefore be incomplete, nominal, awkward, guidance-heavy, or written as a heading rather than as a clean auditable requirement. Maturion must reason over that source material before descriptor generation.
+
+---
+
+## 2. Core Product Rule
+
+### DRGL-CORE-001 — Descriptor reasoning before maturity wording
+
+Before MMM generates Basic, Reactive, Compliant, Proactive, and Resilient maturity descriptors, Maturion MUST reconstruct the criterion into an observable evidence-state clause.
+
+Maturion MUST NOT copy the raw criterion into each descriptor level.
+
+Required transformation pattern:
+
+```text
+Uploaded / raw criterion source
+  -> cleaned actionable requirement
+    -> actor/action/object extraction
+      -> evidence-state clause
+        -> maturity-level operating state descriptors
+```
+
+Example:
+
+```text
+Raw criterion:
+Review and approval of facility design changes for adequate Security measures.
+
+Invalid evidence lead:
+Evidence that Review and approval of facility design changes for adequate Security measures...
+
+Required evidence lead:
+Evidence that facility design changes are reviewed and approved for adequate Security measures...
+```
+
+---
+
+## 3. Source-Mode Requirement
+
+### DRGL-FR-001 — Source mode must govern reasoning behaviour
+
+MMM descriptor generation MUST detect and respect the selected framework source mode:
+
+1. `verbatim_source`
+2. `hybrid_source`
+3. `new_generation_context`
+
+The selected source mode MUST be included in the descriptor-generation context and in any learning retrieval query.
+
+### DRGL-FR-002 — Verbatim source mode is interpretive, not generative rewriting
+
+When source mode is `verbatim_source`, Maturion MUST treat uploaded criteria as preserved source material that may require interpretation before descriptor generation.
+
+Maturion MUST:
+
+1. preserve the raw criterion as the auditable source statement;
+2. avoid rewriting the saved criterion unless the user explicitly edits it;
+3. derive a clean descriptor subject from the raw criterion;
+4. strip descriptor-irrelevant guidance from the descriptor subject while retaining it as context;
+5. preserve the criterion-specific actor/action/object in the maturity descriptors;
+6. avoid generic policy/control wording unless that is genuinely the criterion object.
+
+### DRGL-FR-003 — Hybrid source mode must merge source fidelity and Maturion improvement
+
+When source mode is `hybrid_source`, Maturion MAY improve wording more actively than in verbatim mode, but MUST still retain traceability to uploaded source material and user-approved framework structure.
+
+### DRGL-FR-004 — New generation context mode may use full methodology generation
+
+When source mode is `new_generation_context`, Maturion MAY generate cleaner criteria and descriptors using approved subject knowledge, methodology, and customer context. The same descriptor reasoning pipeline still applies, but the raw uploaded-source constraint is lower because the criterion may already be Maturion-authored.
+
+---
+
+## 4. Descriptor Reasoning Pipeline
+
+### DRGL-FR-005 — Descriptor pipeline stages
+
+Maturion MUST use the following descriptor reasoning pipeline before saving or presenting generated descriptors:
+
+```text
+1. Detect source mode.
+2. Load approved descriptor methodology and maturity-level definitions.
+3. Load current framework context: domain, MPS, intent, criterion, source metadata.
+4. Clean the criterion for descriptor purposes.
+5. Retrieve governed descriptor-learning memory.
+6. Reconstruct an evidence-state clause.
+7. Generate five maturity-level descriptors.
+8. Validate the descriptors against product rules.
+9. Present editable descriptors to the user.
+10. On user edit, request learning consent before writing any learning event.
+```
+
+### DRGL-FR-006 — Criterion cleaning
+
+Criterion cleaning MUST:
+
+1. remove or ignore descriptor-subject guidance blocks such as `Note:`, `Guidance:`, and `Reference:`;
+2. preserve those guidance blocks as context for interpretation only;
+3. remove upload/source suffixes such as `[uploaded_source]` from descriptor subjects;
+4. identify and preserve contextual qualifiers where they materially affect the requirement;
+5. avoid collapsing multi-sentence guidance into the evidence lead.
+
+### DRGL-FR-007 — Actionable-clause reconstruction
+
+Maturion MUST reconstruct malformed or non-sentence criteria into auditable clauses.
+
+Required examples:
+
+| Raw Pattern | Required Descriptor Subject Pattern |
+|---|---|
+| `Review and approval of X` | `X is reviewed and approved` |
+| `Assessing X for Y` | `X is assessed for Y` |
+| `X are to be clearly defined` | `X are clearly defined` |
+| `X should be displayed` | `X is displayed` |
+| `X will be incorporated` | `X is incorporated` |
+| `To establish X` | `X is established` or `Evidence establishing X`, depending on grammar |
+
+### DRGL-FR-008 — Actor/action/object preservation
+
+Each descriptor MUST preserve the criterion-specific actor/action/object where available.
+
+For example, a criterion about facility design changes must remain about facility design changes. It must not collapse into generic wording such as:
+
+- `policy ownership, communication, display, and awareness control`;
+- `generic control requirement`;
+- `governance forum mandate`;
+- `procedure execution and control workflow`;
+
+unless that wording is genuinely the criterion object.
+
+---
+
+## 5. Governed Learning Capture
+
+### DRGL-FR-009 — Learning consent required
+
+When a user manually edits a generated descriptor, MMM MAY ask whether Maturion should remember the correction.
+
+Maturion MUST NOT write a reusable descriptor-learning record unless the user explicitly consents.
+
+Acceptable consent wording:
+
+```text
+Thank you for the guidance. I can use this correction to improve future descriptor generation. Would you like me to record this as a Maturion learning preference?
+
+[Yes, record it] [No, do not record it]
+```
+
+### DRGL-FR-010 — Learning record must capture transformation, not only final text
+
+A descriptor-learning record MUST capture the reasoning transformation, not merely the edited descriptor text.
+
+At minimum, the learning record must include:
+
+```text
+learning_type: descriptor_generation_correction
+source_mode
+framework_id
+organisation_id / tenant scope where applicable
+domain_id
+mps_id
+criterion_id
+criterion_code
+criterion_original_text
+criterion_cleaned_actionable_clause
+descriptor_level
+maturion_original_descriptor
+user_corrected_descriptor
+correction_reason_category
+approved_for_reuse_scope
+consent_status
+review_status
+created_by
+created_at
+supersedes_learning_id where applicable
+conflict_status
+```
+
+### DRGL-FR-011 — Correction reason categories
+
+The implementation MUST support correction reason classification. Initial categories:
+
+```text
+note_block_removed
+gerund_rewritten
+nominal_phrase_reconstructed
+passive_state_reconstructed
+instruction_word_normalised
+actor_action_object_restored
+maturity_state_too_generic
+customer_context_preserved
+evidence_clause_improved
+grammar_only
+scope_limited_preference
+other
+```
+
+### DRGL-FR-012 — Learning scope must be explicit
+
+Every descriptor-learning record MUST have an explicit reuse scope:
+
+```text
+this_criterion_only
+this_framework
+this_organisation
+same_source_mode_pattern
+anonymised_global_pattern_candidate
+approved_global_methodology_pattern
+```
+
+No tenant-specific or customer-specific correction may be promoted to global methodology without governed review and explicit approval.
+
+---
+
+## 6. Governed Learning Retrieval
+
+### DRGL-FR-013 — Learning retrieval before descriptor generation
+
+Before generating descriptors, MMM MUST retrieve applicable descriptor-learning records where a governed learning store is available.
+
+Retrieval inputs must include:
+
+```text
+source_mode
+task_type = descriptor_generation
+criterion_original_text
+criterion_cleaned_actionable_clause
+criterion grammar shape
+domain / MPS context
+framework_id
+organisation_id / tenant scope
+approved learning statuses only
+```
+
+### DRGL-FR-014 — Retrieval priority
+
+Learning retrieval MUST apply this priority order:
+
+```text
+1. Same criterion, same framework, same organisation, approved/active learning.
+2. Same framework and similar criterion grammar pattern.
+3. Same organisation and similar source-mode pattern.
+4. Same source mode and approved anonymised global pattern.
+5. Approved global methodology pattern.
+```
+
+Lower-priority learning MUST NOT override higher-priority learning where they conflict.
+
+### DRGL-FR-015 — Retrieval limit and scoring
+
+Descriptor generation MUST use a small, high-signal learning set rather than dumping all historical corrections into context.
+
+Initial retrieval target:
+
+```text
+minimum: 0
+preferred maximum: 3 to 7 learning examples
+hard maximum: 10 learning examples unless CS2 approves otherwise
+```
+
+Each learning candidate should be scored against:
+
+```text
+source-mode match
+criterion grammar-shape match
+same criterion/framework/organisation proximity
+approval status
+freshness
+reuse success count
+conflict status
+specialist/methodology confidence
+```
+
+### DRGL-FR-016 — Memory unavailable fallback
+
+If governed learning retrieval is unavailable, empty, blocked, or below confidence threshold, Maturion MUST still use the deterministic approved descriptor methodology fallback.
+
+The system MUST NOT pretend that learning was applied when no learning record was used.
+
+---
+
+## 7. Learning Hygiene and Conflict Control
+
+### DRGL-FR-017 — Learning lifecycle status
+
+Descriptor-learning records MUST support lifecycle status:
+
+```text
+candidate
+active
+validated
+superseded
+rejected
+retired
+conflict_flagged
+```
+
+Only records with allowed statuses may influence generation. Initial generation should use `active` and `validated` records only, unless a later CS2-approved rule allows candidate use.
+
+### DRGL-FR-018 — Conflict handling
+
+If retrieved learning records conflict, Maturion MUST NOT silently merge them.
+
+Conflict handling priority:
+
+```text
+1. Approved methodology pattern beats ordinary preference.
+2. Same organisation/framework beats cross-organisation/global pattern.
+3. Same criterion beats similar criterion.
+4. Latest validated correction beats older active correction at the same scope.
+5. Conflict_flagged records are excluded unless explicitly selected for review.
+```
+
+Where conflict could affect descriptor correctness, Maturion must surface the issue for human review rather than choose silently.
+
+### DRGL-FR-019 — Tenant isolation
+
+Descriptor-learning retrieval MUST enforce tenant and organisation boundaries.
+
+Customer-specific correction records MUST NOT be retrieved for another organisation unless they have been anonymised, reviewed, and promoted into an approved global methodology pattern.
+
+### DRGL-FR-020 — No uncontrolled globalisation
+
+User corrections from customer frameworks may not automatically become Subject Knowledge Domain content or global Maturion doctrine.
+
+Promotion to global methodology requires governed approval consistent with Maturion self-learning governance.
+
+---
+
+## 8. Runtime Specialist Alignment
+
+### DRGL-FR-021 — Orchestrator/specialist reasoning model
+
+Descriptor generation is a runtime Maturion orchestration task, not a single UI string operation.
+
+The intended runtime reasoning chain is:
+
+```text
+Runtime Maturion
+  -> loads source mode and current MMM state
+  -> retrieves Subject Knowledge Domain methodology
+  -> retrieves Framework / Context Domain material where applicable
+  -> consults document-parser logic for uploaded/verbatim source interpretation where needed
+  -> consults criteria-generator logic for clean requirement reconstruction where needed
+  -> consults maturity-scoring / MMM methodology logic for maturity state differentiation
+  -> validates output against descriptor guardrails
+  -> presents editable descriptors to the user
+```
+
+This addendum does not activate runtime specialist agents by itself. It defines the functional behaviour that later runtime implementation must satisfy.
+
+---
+
+## 9. Output Validation Rules
+
+### DRGL-FR-022 — Descriptor validation gate
+
+Before presentation, generated descriptors MUST be checked for:
+
+1. no raw malformed criterion stem at evidence lead;
+2. no forbidden instruction wording where evidence-state wording is required;
+3. no copied `Note:`, `Guidance:`, or `Reference:` block in descriptor subject;
+4. actor/action/object preserved;
+5. Basic, Reactive, Compliant, Proactive, and Resilient states are meaningfully distinct;
+6. source mode respected;
+7. learning records used only where consent, scope, and lifecycle status allow;
+8. descriptor editing remains available after save until a future explicit signoff lock exists.
+
+---
+
+## 10. Build Boundary
+
+This addendum authorises only pre-build and QA alignment for descriptor reasoning and governed learning retrieval.
+
+Implementation remains blocked until QA-to-red exists and the builder is appointed under the normal MMM governance sequence.
+
+No implementation may use this addendum to build:
+
+- ISMS public journey changes;
+- subscription/auth/onboarding/dashboard routes;
+- PIT, RADAM, Risk, or other module behaviour;
+- signoff-route implementation;
+- production learning registry mutation without explicit schema/API pre-build coverage;
+- direct AI provider calls outside AIMC governance.

--- a/modules/MMM/05-qa-to-red/descriptor-reasoning-learning-qa-to-red.md
+++ b/modules/MMM/05-qa-to-red/descriptor-reasoning-learning-qa-to-red.md
@@ -1,0 +1,503 @@
+# MMM Descriptor Reasoning and Governed Learning Retrieval — QA-to-RED Expansion
+
+| Field | Value |
+|---|---|
+| Module | MMM — Maturity Model Management |
+| QA Type | Descriptor reasoning, source-mode handling, governed learning capture, governed learning retrieval |
+| Status | RED expectations — no implementation in this artifact |
+| Authority | CS2 — Johan Ras |
+| Created | 2026-07-02 |
+| Related FRS Addendum | `modules/MMM/02-frs/descriptor-reasoning-learning-frs-addendum.md` |
+| Related Existing QA | `modules/MMM/05-qa-to-red/descriptor-grammar-closure-qa-to-red.md` |
+| Related Active Wave | `wave-mmm-descriptor-grammar-closure-2026-06-30` / issue #1871 |
+
+---
+
+## 1. Purpose
+
+This QA-to-RED expansion defines executable expectations for the next MMM descriptor generation correction.
+
+The existing descriptor grammar closure QA remains valid. This file expands that QA from simple grammar normalisation into source-mode-aware descriptor reasoning and governed learning retrieval.
+
+A builder must not satisfy this work by adding only hard-coded one-off string replacements. The implementation must prove the product behaviour required by the FRS addendum.
+
+---
+
+## 2. Test Boundary
+
+This QA expansion authorises tests only for:
+
+1. descriptor reasoning pipeline behaviour;
+2. verbatim/hybrid/new-generation source-mode handling;
+3. criterion cleaning and actionable-clause reconstruction;
+4. user correction learning consent;
+5. descriptor-learning record shape and scope;
+6. governed learning retrieval and fallback;
+7. learning conflict hygiene;
+8. editability after descriptor save.
+
+This QA expansion does not authorise tests or code for:
+
+- ISMS public routes;
+- subscription, authentication, onboarding, dashboard, or entitlement handoff;
+- PIT, RADAM, Risk, Incident, APW, or other module implementation;
+- signoff-route implementation;
+- direct AI provider integration outside AIMC governance.
+
+---
+
+## 3. RED Test Group: T-MMM-DRGL-001 — Verbatim nominal phrase is reconstructed
+
+Given source mode is `verbatim_source`
+
+And the raw criterion statement is:
+
+```text
+Review and approval of facility design changes for adequate Security measures.
+```
+
+When maturity descriptors are generated,
+
+Then the Basic descriptor evidence lead must begin with:
+
+```text
+Evidence that facility design changes are reviewed and approved for adequate Security measures
+```
+
+And it must not contain:
+
+```text
+Evidence that Review and approval of facility design changes
+```
+
+And it must not collapse to generic wording such as:
+
+```text
+generic control requirement
+policy ownership, communication, display, and awareness control
+procedure execution and control workflow
+```
+
+---
+
+## 4. RED Test Group: T-MMM-DRGL-002 — Verbatim source mode preserves raw criterion but reasons over it
+
+Given source mode is `verbatim_source`
+
+And the saved criterion text is awkward, nominal, or heading-like,
+
+When descriptors are generated,
+
+Then the saved criterion statement must remain unchanged unless the user explicitly edits the criterion,
+
+And the descriptor subject must be reconstructed into a clean evidence-state clause,
+
+And the generated descriptor must preserve traceability to the raw criterion.
+
+Minimum assertion:
+
+```text
+savedCriterion.statement === originalRawCriterion.statement
+basicDescriptor.descriptor_text includes reconstructed evidence-state clause
+basicDescriptor.descriptor_text does not begin with raw malformed criterion stem
+```
+
+---
+
+## 5. RED Test Group: T-MMM-DRGL-003 — Source mode is included in generation context and retrieval query
+
+Given descriptor generation is triggered from each supported source mode:
+
+```text
+verbatim_source
+hybrid_source
+new_generation_context
+```
+
+When the generation context is assembled,
+
+Then the context object passed to descriptor generation and learning retrieval must include the selected `source_mode`,
+
+And source mode must influence reasoning behaviour.
+
+Minimum assertions:
+
+```text
+generationContext.source_mode === selectedSourceMode
+learningRetrievalQuery.source_mode === selectedSourceMode
+```
+
+---
+
+## 6. RED Test Group: T-MMM-DRGL-004 — Notes and guidance are stripped from descriptor subject but retained as context
+
+Given a verbatim criterion containing a parenthetical or bracketed guidance block such as:
+
+```text
+Specific Security accountabilities and performance measures should be documented within role descriptions. (Note: This is especially important during high-risk diamond handling activities.)
+```
+
+When descriptors are generated,
+
+Then the evidence lead must be based on the actionable requirement only,
+
+And the `Note:` content must not appear as the descriptor subject,
+
+And the `Note:` content may remain available as contextual interpretation material.
+
+Minimum negative assertion:
+
+```text
+descriptorEvidenceLead does not include "Note:"
+descriptorEvidenceLead does not include "This is especially important"
+```
+
+---
+
+## 7. RED Test Group: T-MMM-DRGL-005 — Gerund and instruction wording remain covered
+
+Given source mode is `verbatim_source`
+
+And the raw criterion contains one of these patterns:
+
+```text
+Assessing incentive schemes and measures for their impact on Security;
+Security roles and responsibilities are to be clearly defined and presented in the form of a RACI chart.
+The policy should be prominently displayed.
+The requirement will be incorporated into site procedures.
+```
+
+When descriptors are generated,
+
+Then the evidence lead must use evidence-state phrasing:
+
+```text
+incentive schemes and measures are assessed for their impact on Security
+Security roles and responsibilities are clearly defined and presented in the form of a RACI chart
+the policy is prominently displayed
+the requirement is incorporated into site procedures
+```
+
+And the descriptor must not preserve the raw instruction wording as the evidence subject.
+
+---
+
+## 8. RED Test Group: T-MMM-DRGL-006 — Learning consent gates memory write
+
+Given a user edits a generated descriptor,
+
+When the edit is saved,
+
+Then MMM may display a learning consent prompt,
+
+And no reusable descriptor-learning record may be created unless the user selects an affirmative consent action.
+
+Minimum assertions:
+
+```text
+if userConsent === false:
+  descriptor is saved
+  descriptor_learning record is not created
+
+if userConsent === true:
+  descriptor is saved
+  descriptor_learning record is created with consent_status = "granted"
+```
+
+---
+
+## 9. RED Test Group: T-MMM-DRGL-007 — Learning record stores transformation evidence
+
+Given the user consents to recording a descriptor correction,
+
+When the learning event is created,
+
+Then the record must store before/after and reasoning metadata, not only the final corrected descriptor text.
+
+Minimum expected fields:
+
+```text
+learning_type
+source_mode
+framework_id
+organisation_id or tenant scope
+domain_id
+mps_id
+criterion_id
+criterion_code
+criterion_original_text
+criterion_cleaned_actionable_clause
+descriptor_level
+maturion_original_descriptor
+user_corrected_descriptor
+correction_reason_category
+approved_for_reuse_scope
+consent_status
+review_status
+created_by
+created_at
+conflict_status
+```
+
+The test must fail if only `user_corrected_descriptor` is persisted.
+
+---
+
+## 10. RED Test Group: T-MMM-DRGL-008 — Learning reuse scope prevents uncontrolled globalisation
+
+Given a descriptor-learning record is created from a customer or organisation-specific framework,
+
+When that learning is saved,
+
+Then it must have an explicit reuse scope,
+
+And it must not be available as global methodology unless reviewed and promoted through governed approval.
+
+Minimum assertions:
+
+```text
+learning.approved_for_reuse_scope is not null
+learning.approved_for_reuse_scope !== "approved_global_methodology_pattern" unless review_status === "approved_global"
+```
+
+---
+
+## 11. RED Test Group: T-MMM-DRGL-009 — Prior accepted correction influences similar future descriptor
+
+Given an approved descriptor-learning record exists for source mode `verbatim_source`
+
+And the learning pattern records that a nominal phrase such as:
+
+```text
+Review and approval of X
+```
+
+must become:
+
+```text
+X is reviewed and approved
+```
+
+When a later similar criterion is processed:
+
+```text
+Review and approval of emergency response changes for adequate Security measures.
+```
+
+Then descriptor generation must retrieve the prior learning or apply the equivalent deterministic methodology fallback,
+
+And the generated descriptor must begin with:
+
+```text
+Evidence that emergency response changes are reviewed and approved for adequate Security measures
+```
+
+And it must not begin with:
+
+```text
+Evidence that Review and approval of emergency response changes
+```
+
+---
+
+## 12. RED Test Group: T-MMM-DRGL-010 — Learning retrieval uses priority order
+
+Given multiple learning records match a descriptor generation request,
+
+When learning retrieval ranks candidates,
+
+Then the priority order must be:
+
+```text
+1. Same criterion, same framework, same organisation.
+2. Same framework and similar criterion grammar pattern.
+3. Same organisation and similar source-mode pattern.
+4. Same source mode and approved anonymised global pattern.
+5. Approved global methodology pattern.
+```
+
+Minimum assertion:
+
+```text
+rankedLearningCandidates[0] is the highest-priority permitted match
+```
+
+Lower-priority global patterns must not override higher-priority same-framework learning.
+
+---
+
+## 13. RED Test Group: T-MMM-DRGL-011 — Retrieval is bounded to high-signal examples
+
+Given many historical descriptor-learning records exist,
+
+When descriptor generation requests learning examples,
+
+Then the retrieval result must be bounded.
+
+Minimum assertions:
+
+```text
+retrievedLearningExamples.length <= 10
+preferredLearningExamples.length <= 7 where scoring supports it
+```
+
+The test must fail if all matching historical records are injected into descriptor context without ranking or limit.
+
+---
+
+## 14. RED Test Group: T-MMM-DRGL-012 — Conflicting learning is not silently merged
+
+Given two applicable learning records conflict,
+
+When descriptor generation retrieves both records,
+
+Then MMM must either:
+
+1. select the record that wins under the governed priority rules; or
+2. exclude conflict-flagged records; or
+3. surface the conflict for human review.
+
+MMM must not silently blend contradictory corrections into one descriptor.
+
+Minimum assertions:
+
+```text
+conflict_flagged records are not used for generation by default
+conflicting same-priority records trigger review/selection path
+```
+
+---
+
+## 15. RED Test Group: T-MMM-DRGL-013 — Tenant isolation governs learning retrieval
+
+Given a descriptor-learning record belongs to Organisation A,
+
+When Organisation B generates descriptors,
+
+Then Organisation B must not retrieve Organisation A's tenant-specific learning unless that learning has been anonymised, reviewed, and promoted to an approved global methodology pattern.
+
+Minimum assertion:
+
+```text
+retrievedLearningRecords.every(record =>
+  record.organisation_id === currentOrganisationId ||
+  record.approved_for_reuse_scope in ["approved_global_methodology_pattern", "anonymised_global_pattern_candidate"] && record.review_status permits use
+)
+```
+
+---
+
+## 16. RED Test Group: T-MMM-DRGL-014 — Memory unavailable fallback is honest and deterministic
+
+Given descriptor-learning retrieval is unavailable, blocked, empty, or below confidence threshold,
+
+When descriptors are generated,
+
+Then MMM must use deterministic approved descriptor methodology fallback,
+
+And it must not claim that prior learning was applied.
+
+Minimum assertions:
+
+```text
+generation.learningApplied === false
+fallbackMethodologyApplied === true
+descriptor still passes evidence-state grammar checks
+```
+
+---
+
+## 17. RED Test Group: T-MMM-DRGL-015 — Maturity levels remain distinct operating states
+
+Given a reconstructed evidence-state clause,
+
+When five descriptors are generated,
+
+Then each maturity level must represent a different observable operating state:
+
+```text
+Basic: absent / weak / inconsistent / person-dependent
+Reactive: exists but mainly after incidents, audits, pressure, or visible failures
+Compliant: approved, implemented, recorded, and evidenced at minimum standard
+Proactive: risk-based, owner-led, measured, trended, and improved
+Resilient: embedded, system-supported, monitored, exception-driven, recoverable, and independent of single individuals
+```
+
+The test must fail if the same descriptor is copied across levels with only the level label changed.
+
+---
+
+## 18. RED Test Group: T-MMM-DRGL-016 — Descriptor editing remains available after save
+
+Given descriptors have been generated and saved,
+
+When the save completes,
+
+Then descriptor edit controls must remain available for another edit/save cycle unless a future explicit signoff lock exists.
+
+This prevents the reasoning/learning work from reintroducing the earlier edit-lock defect.
+
+---
+
+## 19. RED Test Group: T-MMM-DRGL-017 — Learning capture does not self-promote to Subject Knowledge Domain
+
+Given a user correction is recorded as descriptor learning,
+
+When the learning record is saved,
+
+Then it must not automatically become Subject Knowledge Domain content or approved global methodology.
+
+Minimum assertions:
+
+```text
+newLearning.review_status in ["candidate", "active"]
+newLearning.approved_for_reuse_scope !== "approved_global_methodology_pattern" unless explicit governed approval evidence exists
+```
+
+---
+
+## 20. RED Test Group: T-MMM-DRGL-018 — Descriptor generation context includes current framework state
+
+Given descriptors are generated for a criterion,
+
+When the descriptor reasoning context is assembled,
+
+Then it must include:
+
+```text
+framework_id
+domain_id
+domain name or code where available
+mps_id
+mps name or code where available
+intent statement where available
+criterion_id
+criterion_code
+criterion_original_text
+source_mode
+```
+
+This ensures Maturion reasons from the current MMM state rather than isolated criterion text only.
+
+---
+
+## 21. Required Builder Evidence
+
+A future implementation builder must provide evidence showing:
+
+1. executable tests were added or updated for these RED groups before or with the implementation;
+2. descriptor generation passes the verbatim nominal phrase example;
+3. learning consent prevents memory writes when declined;
+4. learning records store transformation metadata;
+5. retrieval is scoped, ranked, and bounded;
+6. tenant-specific learning cannot bleed into another organisation;
+7. deterministic fallback still produces valid descriptors when learning retrieval is unavailable;
+8. no ISMS/PIT/RADAM/Risk/signoff-route scope was touched.
+
+---
+
+## 22. Acceptance Boundary
+
+This QA expansion is satisfied only when the runtime behaviour is proven through executable tests or explicitly documented pre-build-only status.
+
+A documentation-only PR may add this QA artifact without implementation, but it must not claim descriptor runtime completion, production readiness, merge readiness, or user-facing fix completion.

--- a/modules/MMM/05-qa-to-red/descriptor-reasoning-learning-qa-to-red.md
+++ b/modules/MMM/05-qa-to-red/descriptor-reasoning-learning-qa-to-red.md
@@ -381,9 +381,11 @@ Minimum assertion:
 ```text
 retrievedLearningRecords.every(record =>
   record.organisation_id === currentOrganisationId ||
-  record.approved_for_reuse_scope in ["approved_global_methodology_pattern", "anonymised_global_pattern_candidate"] && record.review_status permits use
+  record.approved_for_reuse_scope === "approved_global_methodology_pattern" && record.review_status === "approved_global"
 )
 ```
+
+Candidate or pending anonymised global patterns must not pass this cross-tenant retrieval assertion. A learning record with `approved_for_reuse_scope === "anonymised_global_pattern_candidate"` remains review-stage material and must not be retrieved for another organisation until promoted to `approved_global_methodology_pattern`.
 
 ---
 

--- a/modules/MMM/BUILD_PROGRESS_TRACKER.md
+++ b/modules/MMM/BUILD_PROGRESS_TRACKER.md
@@ -66,8 +66,8 @@ Conditional extension only if justified:
 
 Future implementation under issue #1871 or a successor descriptor-reasoning issue must verify:
 
-1. `are to be clearly defined` is normalized to `are clearly defined` in evidence clauses.
-2. `Assessing incentive schemes and measures for their impact on Security` is normalized to `incentive schemes and measures are assessed for their impact on Security`.
+1. `are to be clearly defined` is normalised to `are clearly defined` in evidence clauses.
+2. `Assessing incentive schemes and measures for their impact on Security` is normalised to `incentive schemes and measures are assessed for their impact on Security`.
 3. Instruction wording such as `should be`, `will be`, `shall be`, and `must be` is converted into evidence-state phrasing before maturity-state text is attached.
 4. The criterion-specific actor/action/object remains visible and is not replaced with generic policy/control wording.
 5. Accepted user descriptor edits are used as future generation examples where learning records are available, or deterministic grammar normalization covers the observed examples until retrieval is separately wired.

--- a/modules/MMM/BUILD_PROGRESS_TRACKER.md
+++ b/modules/MMM/BUILD_PROGRESS_TRACKER.md
@@ -3,7 +3,7 @@
 **Module**: MMM (Maturity Management Module)  
 **Module Slug**: MMM  
 **Last Updated**: 2026-07-02  
-**Updated By**: ChatGPT Foreman support (wave: wave-mmm-descriptor-reasoning-learning-prebuild-2026-07-02 — CS2-requested pre-build/QA expansion for descriptor reasoning and governed learning retrieval)
+**Updated By**: foreman-v2-agent (wave: wave-mmm-descriptor-reasoning-learning-prebuild-2026-07-02 — CS2-requested pre-build/QA expansion for descriptor reasoning and governed learning retrieval)
 
 > **Classification**: ACTIVE — DESCRIPTOR REASONING AND GOVERNED LEARNING RETRIEVAL PRE-BUILD / QA EXPANSION OPEN BEFORE RUNTIME IMPLEMENTATION
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT — CS2 should use this document as the main live progress dashboard.

--- a/modules/MMM/BUILD_PROGRESS_TRACKER.md
+++ b/modules/MMM/BUILD_PROGRESS_TRACKER.md
@@ -8,7 +8,7 @@
 > **Classification**: ACTIVE — DESCRIPTOR REASONING AND GOVERNED LEARNING RETRIEVAL PRE-BUILD / QA EXPANSION OPEN BEFORE RUNTIME IMPLEMENTATION
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT — CS2 should use this document as the main live progress dashboard.
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0
-> **Issue**: [maturion-isms#1871](https://github.com/APGI-cmy/maturion-isms/issues/1871)
+> **Baseline Issue**: [maturion-isms#1871](https://github.com/APGI-cmy/maturion-isms/issues/1871) — original descriptor grammar closure issue; the DRGL lane is a CS2-requested successor pre-build scope and should receive a successor implementation issue before runtime build work starts.
 > **Update Rule**: This document MUST be updated immediately after every MMM stage issue, wave completion, approval, or readiness/blocker change.
 
 ## Current Live Status
@@ -21,7 +21,8 @@ Current active MMM descriptor lane:
 
 - Wave: `wave-mmm-descriptor-reasoning-learning-prebuild-2026-07-02`
 - Branch: `foreman/mmm-descriptor-reasoning-learning`
-- Builds on: `wave-mmm-descriptor-grammar-closure-2026-06-30` / issue `#1871`
+- Builds on: `wave-mmm-descriptor-grammar-closure-2026-06-30` / baseline issue `#1871`
+- Tracking note: `#1871` remains the baseline descriptor grammar closure issue. The descriptor reasoning and governed learning retrieval lane is a successor pre-build scope; open a successor issue before any runtime implementation is appointed.
 - Purpose: extend the descriptor grammar closure lane into a governed descriptor reasoning and learning retrieval design so Maturion reasons over verbatim source criteria, consults consented descriptor-learning records, and avoids repeating corrected failures.
 - Status: pre-build artifact and QA-to-red expansion only; no runtime implementation claim.
 
@@ -64,13 +65,13 @@ Conditional extension only if justified:
 
 ## Descriptor Grammar / Reasoning QA Obligations
 
-Future implementation under issue #1871 or a successor descriptor-reasoning issue must verify:
+Future implementation under the baseline issue #1871 or a successor descriptor-reasoning issue must verify:
 
 1. `are to be clearly defined` is normalised to `are clearly defined` in evidence clauses.
 2. `Assessing incentive schemes and measures for their impact on Security` is normalised to `incentive schemes and measures are assessed for their impact on Security`.
 3. Instruction wording such as `should be`, `will be`, `shall be`, and `must be` is converted into evidence-state phrasing before maturity-state text is attached.
 4. The criterion-specific actor/action/object remains visible and is not replaced with generic policy/control wording.
-5. Accepted user descriptor edits are used as future generation examples where learning records are available, or deterministic grammar normalization covers the observed examples until retrieval is separately wired.
+5. Accepted user descriptor edits are used as future generation examples where learning records are available, or deterministic grammar normalisation covers the observed examples until retrieval is separately wired.
 6. Descriptor editing remains available after save until a future explicit signoff lock exists.
 7. Verbatim nominal phrases such as `Review and approval of facility design changes...` are reconstructed as `facility design changes are reviewed and approved...`.
 8. Learning is not recorded unless the user consents.

--- a/modules/MMM/BUILD_PROGRESS_TRACKER.md
+++ b/modules/MMM/BUILD_PROGRESS_TRACKER.md
@@ -2,10 +2,10 @@
 
 **Module**: MMM (Maturity Management Module)  
 **Module Slug**: MMM  
-**Last Updated**: 2026-06-30  
-**Updated By**: foreman-v2-agent (wave: wave-mmm-descriptor-grammar-closure-2026-06-30 — issue #1871 opened for focused descriptor grammar closure)
+**Last Updated**: 2026-07-02  
+**Updated By**: ChatGPT Foreman support (wave: wave-mmm-descriptor-reasoning-learning-prebuild-2026-07-02 — CS2-requested pre-build/QA expansion for descriptor reasoning and governed learning retrieval)
 
-> **Classification**: ACTIVE — DESCRIPTOR GRAMMAR CLOSURE WAVE OPEN BEFORE SIGNOFF ROUTE IMPLEMENTATION
+> **Classification**: ACTIVE — DESCRIPTOR REASONING AND GOVERNED LEARNING RETRIEVAL PRE-BUILD / QA EXPANSION OPEN BEFORE RUNTIME IMPLEMENTATION
 > **Document Role**: PRIMARY LIVE CONTROL DOCUMENT — CS2 should use this document as the main live progress dashboard.
 > **Canon Reference**: `PRE_BUILD_STAGE_MODEL_CANON.md` v1.0.0
 > **Issue**: [maturion-isms#1871](https://github.com/APGI-cmy/maturion-isms/issues/1871)
@@ -17,23 +17,43 @@ MMM approval workflow pre-build and QA-to-red work for Steps 1-8 is complete and
 
 PR #1850 introduced shared ISMS/module boundary authority. PR #1854 aligned MMM pre-build artifacts to that authority. Runtime public journey/linkup work remains ISMS/MMM boundary-governed and must not be mixed into MMM descriptor grammar closure.
 
-Current active MMM wave:
+Current active MMM descriptor lane:
 
-- Wave: `wave-mmm-descriptor-grammar-closure-2026-06-30`
-- Branch: `foreman/mmm-descriptor-grammar-closure`
-- Issue: `#1871`
-- Purpose: close the remaining descriptor grammar gap where generated maturity descriptors preserve instruction wording or gerund starts instead of reconstructing criteria into clean auditable evidence clauses.
+- Wave: `wave-mmm-descriptor-reasoning-learning-prebuild-2026-07-02`
+- Branch: `foreman/mmm-descriptor-reasoning-learning`
+- Builds on: `wave-mmm-descriptor-grammar-closure-2026-06-30` / issue `#1871`
+- Purpose: extend the descriptor grammar closure lane into a governed descriptor reasoning and learning retrieval design so Maturion reasons over verbatim source criteria, consults consented descriptor-learning records, and avoids repeating corrected failures.
+- Status: pre-build artifact and QA-to-red expansion only; no runtime implementation claim.
+
+## Descriptor Reasoning + Governed Learning Retrieval Authority
+
+Active pre-build / QA artifacts added for CS2 review:
+
+- `modules/MMM/02-frs/descriptor-reasoning-learning-frs-addendum.md`
+- `modules/MMM/05-qa-to-red/descriptor-reasoning-learning-qa-to-red.md`
+
+These artifacts expand the descriptor grammar closure lane from string-level grammar correction into a reasoning pipeline:
+
+1. detect source mode (`verbatim_source`, `hybrid_source`, `new_generation_context`);
+2. preserve raw verbatim criteria while deriving clean descriptor subjects;
+3. strip `Note:`, `Guidance:`, and `Reference:` material from the descriptor evidence subject while preserving it as context;
+4. reconstruct nominal, gerund, passive, and instruction-style criteria into evidence-state clauses;
+5. retrieve consented descriptor-learning records before generation where a governed learning store is available;
+6. rank and bound retrieved learning examples;
+7. prevent tenant-specific learning from bleeding into other organisations;
+8. prevent uncontrolled globalisation of customer-specific corrections;
+9. keep descriptor editing available after save until a future explicit signoff lock exists.
 
 ## Descriptor Grammar Closure Authority
 
-Active wave artifacts:
+Previously active wave artifacts:
 
 - `.agent-admin/scope-declarations/wave-mmm-descriptor-grammar-closure-2026-06-30.md`
 - `modules/MMM/05-qa-to-red/descriptor-grammar-closure-qa-to-red.md`
 - `.agent-admin/assurance/iaa-wave-record-wave-mmm-descriptor-grammar-closure-2026-06-30.md`
 - `.agent-admin/builder-appointments/wave-mmm-descriptor-grammar-closure-2026-06-30.md`
 
-Primary intended implementation files:
+Primary intended implementation files remain:
 
 - `apps/mmm/src/components/assessment/CriteriaManagement.tsx`
 - `modules/MMM/tests/B4-framework/domain-workflow-behavior.test.tsx`
@@ -42,9 +62,9 @@ Conditional extension only if justified:
 
 - Supabase edge-function or descriptor-learning retrieval logic related to reusable accepted descriptor corrections.
 
-## Descriptor Grammar Closure QA Obligations
+## Descriptor Grammar / Reasoning QA Obligations
 
-Future implementation under issue #1871 must verify:
+Future implementation under issue #1871 or a successor descriptor-reasoning issue must verify:
 
 1. `are to be clearly defined` is normalized to `are clearly defined` in evidence clauses.
 2. `Assessing incentive schemes and measures for their impact on Security` is normalized to `incentive schemes and measures are assessed for their impact on Security`.
@@ -52,6 +72,12 @@ Future implementation under issue #1871 must verify:
 4. The criterion-specific actor/action/object remains visible and is not replaced with generic policy/control wording.
 5. Accepted user descriptor edits are used as future generation examples where learning records are available, or deterministic grammar normalization covers the observed examples until retrieval is separately wired.
 6. Descriptor editing remains available after save until a future explicit signoff lock exists.
+7. Verbatim nominal phrases such as `Review and approval of facility design changes...` are reconstructed as `facility design changes are reviewed and approved...`.
+8. Learning is not recorded unless the user consents.
+9. Descriptor-learning records store the transformation pattern, before/after text, correction category, scope, lifecycle, and consent metadata.
+10. Learning retrieval is scoped, ranked, bounded, and tenant-safe.
+11. Conflicting descriptor-learning records are not silently merged.
+12. If learning retrieval is unavailable, Maturion uses deterministic methodology fallback and does not claim learning was applied.
 
 ## Boundary Authority Still Adopted
 
@@ -84,6 +110,7 @@ Operating principle:
 | Boundary | #1850 | Merged | Shared ISMS/module boundary linkup authority |
 | MMM Boundary | #1854 | Merged | MMM-side boundary pre-build alignment baseline |
 | Descriptor Grammar | Issue #1871 | Active | Focused descriptor grammar closure before signoff route build |
+| Descriptor Reasoning + Learning | Pre-build branch | Open | CS2-requested reasoning pipeline and governed learning retrieval expansion |
 
 ## Boundary-Aligned Pre-Build References
 
@@ -115,19 +142,21 @@ Future MMM/ISMS linkup QA-to-red must verify:
 
 ## Active Build-to-GREEN Constraint
 
-Issue #1871 may proceed only as a focused MMM descriptor grammar closure wave.
+Descriptor reasoning and learning retrieval may proceed only as a focused MMM descriptor runtime lane after pre-build / QA-to-red alignment.
 
-No ISMS public journey, subscription, auth, onboarding, dashboard, entitlement handoff, signoff-route, Vercel workflow, PIT, Risk Management, RADAM, or other module implementation is authorized by the descriptor grammar closure wave.
+No ISMS public journey, subscription, auth, onboarding, dashboard, entitlement handoff, signoff-route, Vercel workflow, PIT, Risk Management, RADAM, or other module implementation is authorized by the descriptor reasoning / learning expansion.
 
 ## Claim Restriction
 
-No completion, release, production-readiness, fully functional, handover, ready-for-review, or merge-ready claim may be made from the descriptor grammar closure setup artifacts alone.
+No completion, release, production-readiness, fully functional, handover, ready-for-review, or merge-ready claim may be made from the descriptor reasoning / learning setup artifacts alone.
 
 ## Required Build Sequence
 
-1. Keep issue #1871 bounded to descriptor grammar closure.
-2. Use the descriptor grammar QA-to-red artifact before implementation.
+1. Keep the current lane bounded to MMM descriptor reasoning and governed learning retrieval.
+2. Use both descriptor QA-to-red artifacts before implementation:
+   - `modules/MMM/05-qa-to-red/descriptor-grammar-closure-qa-to-red.md`
+   - `modules/MMM/05-qa-to-red/descriptor-reasoning-learning-qa-to-red.md`
 3. Preserve IAA pre-brief -> builder appointment -> first implementation commit ordering.
-4. Build only the authorized MMM descriptor runtime grammar behavior to green.
+4. Build only the authorized MMM descriptor runtime behaviour to green.
 5. Capture Foreman QP after builder implementation.
 6. Invoke ECAP/IAA/CS2 review only in the appropriate lane and order.


### PR DESCRIPTION
## Scope

Creates the CS2-requested MMM pre-build and QA-to-red expansion for Descriptor Reasoning + Governed Learning Retrieval.

This is documentation/pre-build only. It does not implement runtime code, schema migrations, edge functions, signoff routes, or ISMS/PIT/RADAM/Risk module work.

## Files changed

- `modules/MMM/02-frs/descriptor-reasoning-learning-frs-addendum.md`
- `modules/MMM/05-qa-to-red/descriptor-reasoning-learning-qa-to-red.md`
- `modules/MMM/BUILD_PROGRESS_TRACKER.md`

## Product intent captured

- Verbatim source criteria must be treated as preserved source material requiring interpretation before descriptor generation.
- Maturion must reconstruct criteria into observable evidence-state clauses before applying Basic / Reactive / Compliant / Proactive / Resilient descriptors.
- User-corrected descriptors may be remembered only after explicit consent.
- Descriptor learning must capture before/after transformation metadata, correction category, scope, lifecycle, and tenant-safe reuse controls.
- Future descriptor generation must retrieve relevant governed learning records where available, rank and bound retrieval, avoid conflicts, and fall back honestly when no learning is available.

## Claim restriction

No runtime descriptor fix, production-readiness, handover, or merge-ready claim is made by this PR. This PR only establishes the pre-build/QA authority required before builder implementation.