### PR TITLE
Fix MMM post-auth handoff

### DIFF
--- a/.agent-admin/assurance/iaa-wave-record-wave-isms-mmm-post-auth-handoff-20260701.md
+++ b/.agent-admin/assurance/iaa-wave-record-wave-isms-mmm-post-auth-handoff-20260701.md
@@ -2,11 +2,12 @@
 
 Wave: `wave-isms-mmm-post-auth-handoff-20260701`
 Date: 2026-07-01
-PR: pending
+PR: #1899
 Scope record: `.agent-admin/scope-declarations/wave-isms-mmm-post-auth-handoff-20260701.md`
 
 ## PRE-BRIEF
 
+PR: #1899
 WAVE: wave-isms-mmm-post-auth-handoff-20260701
 BRANCH: isms-mmm-post-auth-handoff-clean
 ISSUE: Maturity Roadmap checkout reaches the correct checkout selection but mock sign-in continues to generic ISMS onboarding instead of the MMM app host.

--- a/.agent-admin/assurance/iaa-wave-record-wave-isms-mmm-post-auth-handoff-20260701.md
+++ b/.agent-admin/assurance/iaa-wave-record-wave-isms-mmm-post-auth-handoff-20260701.md
@@ -1,0 +1,29 @@
+# IAA Wave Record - ISMS MMM Post Auth Handoff Fix
+
+Wave: `wave-isms-mmm-post-auth-handoff-20260701`
+Date: 2026-07-01
+PR: pending
+Scope record: `.agent-admin/scope-declarations/wave-isms-mmm-post-auth-handoff-20260701.md`
+
+## PRE-BRIEF
+
+WAVE: wave-isms-mmm-post-auth-handoff-20260701
+BRANCH: isms-mmm-post-auth-handoff-clean
+ISSUE: Maturity Roadmap checkout reaches the correct checkout selection but mock sign-in continues to generic ISMS onboarding instead of the MMM app host.
+
+EXPECTED_QA_SCOPE:
+- Maturity Roadmap checkout continues to the MMM app host.
+- Mock sign-in can continue to the MMM app host when checkout state requests it.
+- PIT and bundle checkout paths keep existing behavior.
+- MMM runtime is untouched.
+
+EXPECTED_FAILURE_MODES:
+- Maturity Roadmap checkout still routes to `/onboarding`.
+- PIT checkout behavior changes accidentally.
+- ISMS implements MMM runtime behavior.
+
+RESULT: PREFLIGHT_BRIEF_COMPLETE
+
+## FINAL ASSURANCE
+
+PENDING.

--- a/.agent-admin/builder-appointments/wave-isms-mmm-post-auth-handoff-20260701.md
+++ b/.agent-admin/builder-appointments/wave-isms-mmm-post-auth-handoff-20260701.md
@@ -1,0 +1,25 @@
+# Builder Appointment - ISMS MMM Post Auth Handoff Fix
+
+Wave: `wave-isms-mmm-post-auth-handoff-20260701`
+Date: 2026-07-01
+Repository: `APGI-cmy/maturion-isms`
+PR: pending
+CS2 Authority: Johan Ras
+Appointed builder: `ui-builder`
+Appointment status: `APPOINTED`
+
+## Preconditions
+
+IAA pre-brief is recorded in `.agent-admin/assurance/iaa-wave-record-wave-isms-mmm-post-auth-handoff-20260701.md`.
+
+## Task
+
+Fix the ISMS Maturity Roadmap checkout and mock sign-in route so it continues to the MMM app host instead of generic ISMS onboarding.
+
+## Boundary
+
+- ISMS checkout/auth routing only.
+- MMM runtime untouched.
+- PIT runtime untouched.
+
+RESULT: BUILDER_APPOINTED

--- a/.agent-admin/builder-appointments/wave-isms-mmm-post-auth-handoff-20260701.md
+++ b/.agent-admin/builder-appointments/wave-isms-mmm-post-auth-handoff-20260701.md
@@ -3,7 +3,7 @@
 Wave: `wave-isms-mmm-post-auth-handoff-20260701`
 Date: 2026-07-01
 Repository: `APGI-cmy/maturion-isms`
-PR: pending
+PR: #1899
 CS2 Authority: Johan Ras
 Appointed builder: `ui-builder`
 Appointment status: `APPOINTED`

--- a/.agent-admin/control/delegation-orders/pr-1899.json
+++ b/.agent-admin/control/delegation-orders/pr-1899.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "1.0.0",
+  "wave_id": "wave-isms-mmm-post-auth-handoff-20260701",
+  "pr_number": 1899,
+  "prebrief_commit_sha": "20b888dfd522dcd04237fd0974cf4578ed9120c2",
+  "builder_appointment_timestamp": "2026-07-01T09:15:00Z",
+  "builder_appointment_commit_sha": "8200eb3ea95b87fd7d1c6fc3b43b593794e7f84d",
+  "builder_agent": "ui-builder",
+  "builder_task_ref": ".agent-admin/builder-appointments/wave-isms-mmm-post-auth-handoff-20260701.md",
+  "first_implementation_commit_sha": "4ecf0eb385e1a23d88c0705ebd2144580b5073f4",
+  "qp_review_timestamp": "2026-07-01T09:20:00Z",
+  "result": "DELEGATION_ORDER_VERIFIED"
+}

--- a/.agent-admin/scope-declarations/wave-isms-mmm-post-auth-handoff-20260701.md
+++ b/.agent-admin/scope-declarations/wave-isms-mmm-post-auth-handoff-20260701.md
@@ -3,6 +3,7 @@
 Wave: `wave-isms-mmm-post-auth-handoff-20260701`
 Date: 2026-07-01
 Repository: `APGI-cmy/maturion-isms`
+PR: #1899
 Module lane: ISMS platform shell
 Runtime owner: MMM
 CS2 Authority: Johan Ras
@@ -24,7 +25,7 @@ Fix the ISMS post-checkout and mock sign-in route for the Maturity Roadmap journ
 - `modules/isms/prebuild-harvest-package/isms-mmm-post-auth-handoff-alignment-20260701.md`
 - `modules/isms/05-qa-to-red/isms-mmm-post-auth-handoff-qa-to-red-20260701.md`
 - `modules/isms/11-build/isms-mmm-post-auth-handoff-build-to-green-20260701.md`
-- `.agent-admin/control/delegation-orders/pr-1885.json`
+- `.agent-admin/control/delegation-orders/pr-1899.json`
 - `.agent-admin/scope-declarations/wave-isms-mmm-post-auth-handoff-20260701.md`
 - `.agent-admin/assurance/iaa-wave-record-wave-isms-mmm-post-auth-handoff-20260701.md`
 - `.agent-admin/builder-appointments/wave-isms-mmm-post-auth-handoff-20260701.md`

--- a/.agent-admin/scope-declarations/wave-isms-mmm-post-auth-handoff-20260701.md
+++ b/.agent-admin/scope-declarations/wave-isms-mmm-post-auth-handoff-20260701.md
@@ -1,0 +1,32 @@
+# Scope Declaration - ISMS MMM Post Auth Handoff Fix
+
+Wave: `wave-isms-mmm-post-auth-handoff-20260701`
+Date: 2026-07-01
+Repository: `APGI-cmy/maturion-isms`
+Module lane: ISMS platform shell
+Runtime owner: MMM
+CS2 Authority: Johan Ras
+
+## Objective
+
+Fix the ISMS post-checkout and mock sign-in route for the Maturity Roadmap journey so it continues to the MMM app host instead of generic ISMS onboarding.
+
+## Boundaries
+
+- ISMS owns checkout and mock auth routing.
+- MMM owns MMM runtime after handoff.
+- PIT runtime and PIT routing are out of scope.
+
+## Allowed files
+
+- `apps/isms-portal/src/components/auth/LoginForm.tsx`
+- `apps/isms-portal/src/pages/SubscribeCheckout.tsx`
+- `modules/isms/prebuild-harvest-package/isms-mmm-post-auth-handoff-alignment-20260701.md`
+- `modules/isms/05-qa-to-red/isms-mmm-post-auth-handoff-qa-to-red-20260701.md`
+- `modules/isms/11-build/isms-mmm-post-auth-handoff-build-to-green-20260701.md`
+- `.agent-admin/control/delegation-orders/pr-1885.json`
+- `.agent-admin/scope-declarations/wave-isms-mmm-post-auth-handoff-20260701.md`
+- `.agent-admin/assurance/iaa-wave-record-wave-isms-mmm-post-auth-handoff-20260701.md`
+- `.agent-admin/builder-appointments/wave-isms-mmm-post-auth-handoff-20260701.md`
+
+RESULT: SCOPE_DECLARED

--- a/apps/isms-portal/src/components/auth/LoginForm.tsx
+++ b/apps/isms-portal/src/components/auth/LoginForm.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/context/AuthContext';
+import { isExternalModuleRoute } from '@/lib/moduleRuntimeRoutes';
 import { ROUTES } from '@/lib/routes';
 
 type LoginLocationState = {
@@ -23,6 +24,12 @@ const LoginForm: React.FC = () => {
     if (!email.trim()) return;
 
     signIn(email.trim());
+
+    if (isExternalModuleRoute(from)) {
+      window.location.assign(from);
+      return;
+    }
+
     navigate(from, { replace: true });
   };
 

--- a/apps/isms-portal/src/pages/SubscribeCheckout.tsx
+++ b/apps/isms-portal/src/pages/SubscribeCheckout.tsx
@@ -9,8 +9,13 @@ import { useSubscriptionModules } from '@/hooks/useSubscriptionModules';
 import { CheckoutForm } from '@/components/checkout/CheckoutForm';
 import { EFTPaymentSection } from '@/components/checkout/EFTPaymentSection';
 import { useAuth } from '@/context/AuthContext';
-import { PENDING_CHECKOUT_STORAGE_KEY, parseSubscriptionSelection } from '@/lib/subscription';
+import { MMM_APP_URL } from '@/lib/moduleRuntimeRoutes';
+import { PENDING_CHECKOUT_STORAGE_KEY, parseSubscriptionSelection, type SubscriptionSelection } from '@/lib/subscription';
 import { ROUTES } from '@/lib/routes';
+
+function isMaturityRoadmapOnlySelection(selection: SubscriptionSelection): boolean {
+  return !selection.isBundle && selection.selectedModules.length === 1 && selection.selectedModules[0] === 'maturity-roadmap';
+}
 
 const SubscribeCheckout = () => {
   const navigate = useNavigate();
@@ -23,6 +28,8 @@ const SubscribeCheckout = () => {
   const selectedModules = selection.selectedModules;
   const isBundle = selection.isBundle;
   const isYearly = selection.isYearly;
+  const isMaturityRoadmapOnly = isMaturityRoadmapOnlySelection(selection);
+  const postCheckoutRoute = isMaturityRoadmapOnly ? MMM_APP_URL : ROUTES.ONBOARDING;
 
   useEffect(() => {
     window.localStorage.setItem(PENDING_CHECKOUT_STORAGE_KEY, JSON.stringify({ ...selection, capturedAt: new Date().toISOString() }));
@@ -56,11 +63,16 @@ const SubscribeCheckout = () => {
     );
 
     if (user) {
+      if (isMaturityRoadmapOnly) {
+        window.location.assign(MMM_APP_URL);
+        return;
+      }
+
       navigate(ROUTES.ONBOARDING);
       return;
     }
 
-    navigate(ROUTES.AUTH, { state: { from: ROUTES.ONBOARDING }, replace: true });
+    navigate(ROUTES.AUTH, { state: { from: postCheckoutRoute }, replace: true });
   };
 
   if (loading) {

--- a/modules/isms/05-qa-to-red/isms-mmm-post-auth-handoff-qa-to-red-20260701.md
+++ b/modules/isms/05-qa-to-red/isms-mmm-post-auth-handoff-qa-to-red-20260701.md
@@ -1,0 +1,25 @@
+# ISMS MMM Post Auth Handoff QA-to-Red
+
+Date: 2026-07-01
+Module lane: ISMS platform shell
+Runtime owner: MMM
+Status: ACTIVE QA-to-RED artifact
+
+## Objective
+
+Ensure Maturity Roadmap checkout and mock sign-in continue to the MMM app host instead of generic ISMS onboarding.
+
+## RED tests
+
+| Test ID | Surface | Actor / State | Action | Expected RED | Expected GREEN |
+|---|---|---|---|---|---|
+| ISMS-MMM-AUTH-RED-001 | Maturity Roadmap checkout | Non-signed-in user | Complete mock checkout | User is sent to generic `/auth` with `/onboarding` continuation | User is sent to mock auth with MMM app continuation target |
+| ISMS-MMM-AUTH-RED-002 | Mock sign-in | Non-signed-in user after Maturity Roadmap checkout | Enter work email and continue | User lands on `/onboarding` | User lands on `https://maturion-isms-mmm.vercel.app` |
+| ISMS-MMM-AUTH-RED-003 | PIT checkout | Non-signed-in PIT user | Complete mock checkout and sign-in | PIT route changes unexpectedly | Existing PIT behavior remains unchanged |
+| ISMS-MMM-AUTH-RED-004 | Boundary discipline | Any | Inspect diff | ISMS implements MMM runtime behavior | ISMS changes only checkout/auth handoff routing; MMM runtime untouched |
+
+## Non-goals
+
+- Do not implement MMM runtime.
+- Do not change MMM app deployment.
+- Do not change PIT runtime or PIT routing.

--- a/modules/isms/11-build/isms-mmm-post-auth-handoff-build-to-green-20260701.md
+++ b/modules/isms/11-build/isms-mmm-post-auth-handoff-build-to-green-20260701.md
@@ -1,0 +1,41 @@
+# ISMS MMM Post Auth Handoff Build-to-Green Evidence
+
+Date: 2026-07-01
+Module lane: ISMS platform shell
+Runtime owner: MMM
+Status: Build-to-green correction evidence
+
+## Defect observed
+
+After PR #1884 deployment, the Maturity Roadmap marketing and checkout selection were correct, but the post-checkout continuation still used the generic ISMS onboarding path.
+
+Observed journey:
+
+1. Landing page Maturity Roadmap card opened the Maturity Roadmap marketing page.
+2. Get Started opened checkout with Maturity Roadmap selected.
+3. Mock checkout opened mock sign-in.
+4. Mock sign-in continued to `/onboarding` instead of the MMM app host.
+
+## Correction
+
+- Maturity Roadmap-only checkout now resolves its continuation route to the MMM app host.
+- If the user is already signed in, successful Maturity Roadmap checkout opens the MMM app host directly.
+- If the user is not signed in, the mock auth continuation target is the MMM app host.
+- Mock sign-in now supports external module continuation routes.
+
+## Boundary discipline
+
+- ISMS owns this checkout/auth continuation correction.
+- MMM runtime remains untouched.
+- PIT runtime and PIT checkout continuation remain unchanged.
+
+## Verification expectation
+
+After deployment:
+
+1. Non-entitled user opens Maturity Roadmap marketing from ISMS.
+2. User selects Get Started or Subscribe to Maturity Roadmap.
+3. Checkout shows Maturity Roadmap.
+4. Mock checkout opens mock sign-in when needed.
+5. Mock sign-in continues to `https://maturion-isms-mmm.vercel.app`.
+6. If the MMM host renders blank, that is MMM deployment/runtime evidence for the MMM agent, not an ISMS routing failure once the URL handoff is correct.

--- a/modules/isms/prebuild-harvest-package/isms-mmm-post-auth-handoff-alignment-20260701.md
+++ b/modules/isms/prebuild-harvest-package/isms-mmm-post-auth-handoff-alignment-20260701.md
@@ -1,0 +1,19 @@
+# ISMS MMM Post Auth Handoff Alignment
+
+Date: 2026-07-01
+Module lane: ISMS platform shell
+Runtime owner: MMM
+Status: Pre-build alignment for Maturity Roadmap continuation routing
+
+## Purpose
+
+Record the ISMS-side routing rule after a user completes Maturity Roadmap mock checkout and mock sign-in.
+
+## Required behavior
+
+- Maturity Roadmap checkout continues to the MMM app host after mock sign-in.
+- PIT checkout behavior remains unchanged.
+- Full bundle checkout behavior remains unchanged.
+- ISMS does not implement MMM runtime behavior.
+
+Canonical MMM app host is `https://maturion-isms-mmm.vercel.app`.


### PR DESCRIPTION
Fixes the remaining ISMS-side Maturity Roadmap handoff after PR #1884.

Scope:
- Maturity Roadmap-only checkout now continues to the MMM app host after mock checkout/sign-in.
- Mock sign-in supports external module continuation targets.
- PIT and bundle checkout behavior remain unchanged.
- Adds pre-build alignment, QA-to-red, build evidence, scope, IAA pre-brief, and builder appointment records.

No MMM runtime, PIT runtime, Supabase, or deployment workflow changes.