### PR TITLE
Batch 9 package

### DIFF
--- a/.agent-admin/scope-declarations/maturion-batch9-decision-v01.md
+++ b/.agent-admin/scope-declarations/maturion-batch9-decision-v01.md
@@ -1,0 +1,124 @@
+# Scope Declaration — Batch 9 Decision v0.1
+
+**Scope ID**: APW-BATCH9-DECISION-V01  
+**Repository**: `APGI-cmy/maturion-isms`  
+**Wave**: Batch 9 — APW Specialist Production Activation Decision v0.1  
+**Date**: 2026-07-02  
+**Authority**: CS2 — Johan Ras  
+**Operating Role**: Foreman-led governed delivery  
+**Task Type**: production activation decision wave — evidence review and go/no-go disposition only  
+**Affected Scope**: APW Specialist public integration decision record and governance evidence  
+**Implementation Status**: Decision wave only; no production environment switch is changed by this PR
+
+---
+
+## 1. Purpose
+
+This wave follows Batch 8 and records the governed Batch 9 decision boundary for APW Specialist public integration.
+
+It answers:
+
+```text
+Is there sufficient controlled preview evidence to approve broader production activation of the APW Specialist public integration, or must activation remain deferred pending more evidence?
+```
+
+---
+
+## 2. Source Authority
+
+This scope is governed by:
+
+- Batch 1 Runtime Agent Network prebuild;
+- Batch 2 Runtime Knowledge Grounding prebuild;
+- Batch 3 APW Specialist prebuild;
+- Batch 4 Runtime Activation Readiness Pack;
+- Batch 5 APW Specialist Red Tests + Stubs;
+- Batch 6 APW Specialist Build-to-Green;
+- Batch 7 Public APW Maturion Integration;
+- Batch 8 Controlled Preview package;
+- `Maturion/prebuild/runtime-activation-readiness/APW-Controlled-Preview-Runbook-v0.1.md`;
+- Foreman operating model and PR scope discipline.
+
+---
+
+## 3. In Scope
+
+This wave may:
+
+1. review whether Batch 8 preview evidence exists and is sufficient;
+2. record a production activation decision state;
+3. define required go/no-go criteria;
+4. define monitoring and rollback expectations for any later production enablement;
+5. preserve Maturion as final public response authority;
+6. preserve APW Specialist as a governed helper behind Maturion;
+7. record whether activation is approved, deferred, or rejected;
+8. provide governance evidence for the decision wave.
+
+---
+
+## 4. Out of Scope
+
+This wave does not:
+
+- change production environment variables;
+- enable production by default;
+- create or mutate Supabase tables, policies, functions, migrations or data;
+- create or mutate runtime registry records;
+- create embeddings, vector search, retrieval services, or database-backed knowledge operations;
+- expose APW Specialist directly to public users;
+- let APW Specialist produce final public answers;
+- grant Maturion or APW Specialist CS2 authority;
+- change `.github/agents` contracts;
+- perform live provider calls from this PR;
+- override missing preview evidence.
+
+---
+
+## 5. Required Evidence for Approval
+
+Production activation may only be approved if there is a preview evidence record showing:
+
+1. target preview or staging environment;
+2. flag value before preview;
+3. `APW_SPECIALIST_PUBLIC_INTEGRATION_ENABLED=true` preview state;
+4. `/health` result for the target service;
+5. valid APW prompt route result;
+6. public APGI prompt route result;
+7. restricted prompt route result;
+8. rollback flag-off result;
+9. reviewer confirmation;
+10. no stop condition triggered.
+
+---
+
+## 6. Initial Decision Boundary
+
+At the start of this wave, no live preview evidence record has been verified in this PR.
+
+Therefore, this wave must not approve broader production activation unless that evidence is added and reviewed in-scope.
+
+---
+
+## 7. Success Criteria
+
+This wave succeeds when:
+
+1. the decision record is created;
+2. the decision is explicit and evidence-based;
+3. missing evidence is not hidden or treated as passed;
+4. rollback and monitoring expectations are documented;
+5. Maturion remains final public response authority;
+6. APW Specialist remains behind Maturion;
+7. no production configuration is changed by this PR;
+8. PR-bound scope, PR-scoped delegation evidence and IAA prebrief are present after PR number assignment.
+
+---
+
+## 8. Expected Disposition Options
+
+The decision record must select one of:
+
+- `APPROVED_FOR_PRODUCTION_ENABLEMENT` — only if all evidence is present and accepted;
+- `DEFERRED_PENDING_PREVIEW_EVIDENCE` — if preview evidence is absent or incomplete;
+- `REMAIN_IN_CONTROLLED_PREVIEW` — if evidence is partially acceptable but not sufficient for broader enablement;
+- `REJECTED_OR_ROLLBACK_REQUIRED` — if preview evidence shows unsafe behaviour.

--- a/.agent-admin/scope-declarations/pr-1903.md
+++ b/.agent-admin/scope-declarations/pr-1903.md
@@ -1,35 +1,43 @@
+SCOPE_SCHEMA_VERSION: v2
+PR_NUMBER: 1903
+ISSUE: #1903 - Batch 9 package
+BRANCH: maturion-batch9-decision-v01
+OWNER: chatgpt-cs2-proxy
+DATE_UTC: 2026-07-02T11:20:00Z
+
 # Scope Declaration - PR #1903
 
-Scope ID: PR-1903-APW-BATCH9-DECISION-V01
-Repository: APGI-cmy/maturion-isms
-Pull Request: #1903
-Wave: Batch 9 decision package
-Date: 2026-07-02
-Authority: CS2 - Johan Ras
-Status: Draft decision package
+## PR Responsibility Domain
 
-## Changed files in scope
+RESPONSIBILITY_DOMAIN: Batch 9 APW Specialist decision package. This PR records the decision state after Batch 8 and does not change runtime behaviour.
 
-1. `.agent-admin/scope-declarations/maturion-batch9-decision-v01.md`
-2. `Maturion/prebuild/runtime-activation-readiness/APW-Batch9-Decision-Record-v0.1.md`
-3. `.agent-admin/scope-declarations/pr-1903.md`
-4. `.agent-admin/control/delegation-orders/pr-1903.json`
+## Explicitly In Scope
 
-## In scope
-
+IN_SCOPE:
 - Record the Batch 9 decision state.
 - Use the Batch 8 preview runbook as the evidence standard.
 - Record whether preview evidence is verified.
 - Preserve the public authority boundary.
+- Preserve Maturion as the final public response authority.
 
-## Out of scope
+## Explicitly Out of Scope
 
-- Runtime changes.
-- Environment changes.
+OUT_OF_SCOPE:
+- Runtime code changes.
+- Environment setting changes.
 - Database changes.
 - Registry changes.
+- Retrieval or embedding changes.
 - Agent contract changes.
+- Broader enablement without preview evidence.
 
-## Gate note
+## FILES_CHANGED
 
-Delegation evidence is PR-scoped at `.agent-admin/control/delegation-orders/pr-1903.json`.
+FILES_CHANGED: 3
+- `.agent-admin/scope-declarations/maturion-batch9-decision-v01.md`
+- `Maturion/prebuild/runtime-activation-readiness/APW-Batch9-Decision-Record-v0.1.md`
+- `.agent-admin/scope-declarations/pr-1903.md`
+
+## Decision Boundary
+
+The decision state remains `DEFERRED_PENDING_PREVIEW_EVIDENCE` until a completed preview evidence record is captured and reviewed.

--- a/.agent-admin/scope-declarations/pr-1903.md
+++ b/.agent-admin/scope-declarations/pr-1903.md
@@ -1,0 +1,35 @@
+# Scope Declaration - PR #1903
+
+Scope ID: PR-1903-APW-BATCH9-DECISION-V01
+Repository: APGI-cmy/maturion-isms
+Pull Request: #1903
+Wave: Batch 9 decision package
+Date: 2026-07-02
+Authority: CS2 - Johan Ras
+Status: Draft decision package
+
+## Changed files in scope
+
+1. `.agent-admin/scope-declarations/maturion-batch9-decision-v01.md`
+2. `Maturion/prebuild/runtime-activation-readiness/APW-Batch9-Decision-Record-v0.1.md`
+3. `.agent-admin/scope-declarations/pr-1903.md`
+4. `.agent-admin/control/delegation-orders/pr-1903.json`
+
+## In scope
+
+- Record the Batch 9 decision state.
+- Use the Batch 8 preview runbook as the evidence standard.
+- Record whether preview evidence is verified.
+- Preserve the public authority boundary.
+
+## Out of scope
+
+- Runtime changes.
+- Environment changes.
+- Database changes.
+- Registry changes.
+- Agent contract changes.
+
+## Gate note
+
+Delegation evidence is PR-scoped at `.agent-admin/control/delegation-orders/pr-1903.json`.

--- a/Maturion/prebuild/runtime-activation-readiness/APW-Batch9-Decision-Record-v0.1.md
+++ b/Maturion/prebuild/runtime-activation-readiness/APW-Batch9-Decision-Record-v0.1.md
@@ -1,0 +1,33 @@
+# APW Batch 9 Decision Record v0.1
+
+Status: Draft decision record
+Date: 2026-07-02
+Authority: CS2 - Johan Ras
+
+## Decision question
+
+Should APW Specialist public integration move beyond controlled preview?
+
+## Evidence standard
+
+The Batch 8 runbook requires a preview record with target environment, health check result, prompt and route samples, rollback result, and reviewer decision.
+
+## Evidence currently verified in this PR
+
+Batch 8 has been merged. The preview runbook and automated tests exist. A completed live preview record has not yet been verified in this PR.
+
+## Decision state
+
+DEFERRED_PENDING_PREVIEW_EVIDENCE
+
+## Reason
+
+The available evidence is sufficient to confirm the controlled preview package, but not sufficient to approve broader use.
+
+## Boundary
+
+No runtime setting is changed by this decision record. Maturion remains the final public response authority. APW Specialist remains behind Maturion.
+
+## Next step
+
+Capture the required preview evidence, then open a separate enablement decision if CS2 approves.

--- a/Maturion/prebuild/runtime-activation-readiness/APW-Batch9-Decision-Record-v0.1.md
+++ b/Maturion/prebuild/runtime-activation-readiness/APW-Batch9-Decision-Record-v0.1.md
@@ -24,6 +24,8 @@ DEFERRED_PENDING_PREVIEW_EVIDENCE
 
 The available evidence is sufficient to confirm the controlled preview package, but not sufficient to approve broader use.
 
+This decision is deliberately conservative. Missing preview evidence is not treated as approval.
+
 ## Boundary
 
 No runtime setting is changed by this decision record. Maturion remains the final public response authority. APW Specialist remains behind Maturion.


### PR DESCRIPTION
## Summary

Adds the Batch 9 decision package.

Decision state: `DEFERRED_PENDING_PREVIEW_EVIDENCE`.

This PR records that Batch 8 is merged and that the preview runbook/tests exist, but a completed live preview evidence record has not yet been verified.

No runtime, environment, database, registry, retrieval, or agent-contract changes are included. Maturion remains the final public response authority.