### PR TITLE
Add Maturion ecosystem orchestration strategy

### DIFF
--- a/Maturion/strategy/Maturion_ecosystem_orchestrator_and_agent_file_system_strategy.md
+++ b/Maturion/strategy/Maturion_ecosystem_orchestrator_and_agent_file_system_strategy.md
@@ -1,7 +1,7 @@
 # Maturion Ecosystem Orchestrator and Agent File System Strategy
 
-**Status:** Draft strategy authority for CS2 review  
-**Version:** 0.1.0  
+**Status:** Proposed strategy authority for CS2 review. This document must not be treated as approved Class 1 strategy authority while the PR remains unmerged. It becomes approved strategy authority only after explicit CS2 approval and merge.  
+**Version:** 0.1.1  
 **Date:** 2026-07-01  
 **Authority:** CS2 / Johan Ras  
 **Scope:** Maturion ecosystem orchestration, AIMC alignment, runtime specialist invocation, and agent file-system governance  
@@ -29,7 +29,7 @@ This is a strategy / pre-build authority artifact only. It does not itself modif
 
 Maturion is not app-bound.
 
-Maturion is the APGI ecosystem intelligence. He may be embodied in different apps, pages, workflows, and operational modes, but the user must experience one Maturion with one identity, one memory architecture, one ethical framework, one governance frame, and one orchestration model.
+Maturion is the APGI ecosystem intelligence. Maturion may be embodied in different apps, pages, workflows, and operational modes, but the user must experience one Maturion with one identity, one memory architecture, one ethical framework, one governance frame, and one orchestration model.
 
 The ecosystem model is:
 
@@ -60,7 +60,7 @@ Apps may embody Maturion, but they may not fork Maturion.
 
 ## 3. Central philosophy
 
-### 3.1 Maturion is the head, specialists are the hands
+### 3.1 Maturion is the head; specialists are the hands
 
 Maturion owns:
 
@@ -136,7 +136,7 @@ The app should not decide the full AI answer independently. It should provide co
 
 ## 4. Agent file-system model
 
-### 4.1 The 3-tier agent knowledge structure
+### 4.1 The three-tier agent knowledge structure
 
 The Living Agent System uses a three-tier agent knowledge model:
 
@@ -159,7 +159,9 @@ Tier 3: Session domain knowledge
 
 This strategy applies that model to Maturion and every specialist agent.
 
-### 4.2 Maturion agent bundle
+### 4.2 Target Maturion agent bundle
+
+This section describes the **target bundle** to be completed through the waved implementation plan. It must not be read as confirmation that every file listed already exists in the current repository.
 
 Maturion should have:
 
@@ -190,7 +192,7 @@ Maturion should have:
 
 The contract must remain thin. It must not become the place where every app rule, specialist behavior, scoring method, or module description is embedded.
 
-### 4.3 Specialist agent bundle
+### 4.3 Target specialist agent bundle
 
 Every specialist agent must have the complete creation bundle before it is considered active:
 
@@ -210,7 +212,7 @@ A contract alone is not an active agent. A contract without Tier 2 files, regist
 
 ## 5. Runtime Maturion decision loop
 
-When Maturion is invoked by a user, he must follow this loop.
+When Maturion is invoked by a user, Maturion must follow this loop.
 
 ### Step 1: Establish embodiment and context
 
@@ -346,7 +348,7 @@ Learning does not automatically update Tier 1 or Tier 2. Promotion must follow g
 
 Maturion acts as public-safe guide and marketing/education assistant.
 
-He may:
+Maturion may:
 
 - explain APGI services;
 - answer public-safe subject questions;
@@ -354,7 +356,7 @@ He may:
 - detect public marketing opportunities;
 - use approved public/subject knowledge only.
 
-He may not:
+Maturion may not:
 
 - use tenant/private context;
 - expose internal operations;
@@ -365,7 +367,7 @@ He may not:
 
 Maturion acts as platform navigator, subscription/entitlement-aware guide, and authenticated workspace assistant.
 
-He may:
+Maturion may:
 
 - help users navigate modules;
 - explain module purpose and dependencies;
@@ -397,7 +399,7 @@ Maturion should invoke specialists for deep criteria generation, evidence parsin
 
 Maturion acts as implementation-work translator and project packaging assistant.
 
-He may:
+Maturion may:
 
 - convert maturity shortcomings into implementation tasks;
 - package criteria gaps into projects or work entities;
@@ -410,7 +412,7 @@ He may:
 
 Maturion acts as risk management expert and orchestrator.
 
-He may invoke:
+Maturion may invoke:
 
 - ISO 31000 specialist;
 - NIST specialist;
@@ -424,7 +426,7 @@ He may invoke:
 
 Maturion acts as incident workflow and assurance guide.
 
-He may support:
+Maturion may support:
 
 - incident classification;
 - incident workflow explanation;
@@ -437,7 +439,7 @@ He may support:
 
 Maturion acts as analytics and assurance interpreter.
 
-He may invoke:
+Maturion may invoke:
 
 - data analytics specialist;
 - remote assurance specialist;
@@ -594,7 +596,7 @@ Builder agents may not:
 
 ### 8.5 General ChatGPT, Copilot, and platform agent boundaries
 
-Because CS2 uses multiple AI platforms, including Codex, ChatGPT, Copilot, and other agents, the following boundary applies across platforms:
+Because CS2 uses multiple AI platforms, including Codex, ChatGPT, Copilot, and other agents, the following boundary applies across platforms.
 
 General agents may:
 
@@ -686,7 +688,7 @@ In MMM, Maturion must support at least these task classes:
 - PIT work package generation;
 - marketing opportunity detection.
 
-Maturion should not embed all of this domain logic directly. He should invoke specialists such as:
+Maturion should not embed all of this domain logic directly. Maturion should invoke specialists such as:
 
 - document-parser specialist;
 - criteria-generator specialist;
@@ -918,7 +920,7 @@ Each stage requires explicit CS2 approval and maturity evidence.
 2. Create a current-state audit issue for Maturion and existing agent files.
 3. Assign CodexAdvisor to audit agent file-system readiness.
 4. Prevent all other agents from changing `.github/agents`, `.agent-workspace/<agent>/knowledge`, or governance canon unless explicitly authorised by CS2.
-5. Use this strategy as the reference when APW, ISMS, MMM, PIT, Risk, Incident, RADAM, Training, Marketing, or AMC agents propose Maturion work.
+5. Use this strategy as the reference when APW, ISMS, MMM, PIT, Risk, Incident, RADAM, Training, Marketing, or AMC agents propose Maturion work after CS2 approval.
 
 ---
 

--- a/Maturion/strategy/Maturion_ecosystem_orchestrator_and_agent_file_system_strategy.md
+++ b/Maturion/strategy/Maturion_ecosystem_orchestrator_and_agent_file_system_strategy.md
@@ -1,0 +1,937 @@
+# Maturion Ecosystem Orchestrator and Agent File System Strategy
+
+**Status:** Draft strategy authority for CS2 review  
+**Version:** 0.1.0  
+**Date:** 2026-07-01  
+**Authority:** CS2 / Johan Ras  
+**Scope:** Maturion ecosystem orchestration, AIMC alignment, runtime specialist invocation, and agent file-system governance  
+
+---
+
+## 1. Purpose
+
+This document defines the strategy for using **Maturion as one APGI ecosystem intelligence** across APGI public website, ISMS, MMM / Maturity Roadmap, PIT, Risk Management, Incident Management, RADAM, Training, AMC, and future modules.
+
+It also defines how Maturion, AIMC, app/module specialists, build agents, and agent file systems must relate to each other so that:
+
+- Maturion remains one unified intelligence, not separate app-bound bots.
+- AIMC remains the central AI management, knowledge, memory, learning, and specialist-control plane.
+- Apps and modules provide local context and runtime surfaces, not separate AI brains.
+- Specialist agents execute deep work only when invoked through governed orchestration.
+- Agent file systems remain protected and are only created or changed through authorised CS2/CodexAdvisor processes.
+- General build agents, Foreman agents, ChatGPT sessions, Copilot agents, and app builders do not modify agent contracts, Tier 2 knowledge, or governance canon unless explicitly authorised by CS2.
+
+This is a strategy / pre-build authority artifact only. It does not itself modify any agent contract, Tier 2 knowledge file, governance canon file, runtime registry, app code, Supabase schema, or deployment workflow.
+
+---
+
+## 2. Core decision
+
+Maturion is not app-bound.
+
+Maturion is the APGI ecosystem intelligence. He may be embodied in different apps, pages, workflows, and operational modes, but the user must experience one Maturion with one identity, one memory architecture, one ethical framework, one governance frame, and one orchestration model.
+
+The ecosystem model is:
+
+```text
+User
+  -> App or platform surface
+    -> Maturion embodiment
+      -> AIMC knowledge / memory / governance / specialist registry
+        -> specialist agent or service where needed
+          -> Maturion review, synthesis, and response
+```
+
+The rejected model is:
+
+```text
+APW has its own Maturion
+ISMS has its own Maturion
+MMM has its own Maturion
+PIT has its own Maturion
+Training has its own Maturion
+Risk has its own Maturion
+AMC has its own Maturion
+```
+
+Apps may embody Maturion, but they may not fork Maturion.
+
+---
+
+## 3. Central philosophy
+
+### 3.1 Maturion is the head, specialists are the hands
+
+Maturion owns:
+
+- identity;
+- user conversation;
+- ecosystem awareness;
+- app and route awareness;
+- tenant, user, role, organisation, and industry context;
+- intent classification;
+- knowledge-plane selection;
+- specialist selection;
+- specialist task packaging;
+- specialist output review;
+- final user-facing synthesis;
+- escalation and graceful degradation;
+- learning capture and promotion routing.
+
+Specialists own:
+
+- deep execution within a declared domain;
+- structured outputs;
+- technical/domain analysis;
+- criteria generation;
+- evidence parsing;
+- risk analysis;
+- implementation planning;
+- incident analysis;
+- RADAM analytics;
+- build work;
+- QA/assurance functions;
+- other bounded tasks assigned by Maturion or an authorised build/governance orchestrator.
+
+Specialists do not own the user relationship. Specialists do not speak over Maturion unless a workflow explicitly exposes that specialist to the user. Maturion remains accountable for final synthesis and user-facing coherence.
+
+### 3.2 AIMC is the central control plane
+
+AIMC is the central place from which Maturion derives runtime AI governance services, including:
+
+- approved knowledge inventory;
+- source classification;
+- embeddings / retrieval;
+- memory governance;
+- learning capture;
+- learning review and promotion;
+- tenant isolation;
+- specialist registry;
+- specialist capability metadata;
+- runtime routing rules;
+- source priority rules;
+- model/provider access policy;
+- audit logs;
+- escalation records;
+- marketing trigger governance where AI detects opportunity.
+
+No app may create an independent Maturion knowledge centre or local replacement for AIMC.
+
+Apps may store app-local operational data, workflow data, evidence, assessment state, project state, risk records, incident records, or user interface state. Those are app records. They are not independent Maturion knowledge authority.
+
+### 3.3 Apps are embodiments and context providers
+
+Each app or module gives Maturion local context:
+
+- where the user is;
+- what workflow is open;
+- what entity, criterion, evidence item, project, risk, incident, or dashboard is active;
+- what permissions the user has;
+- what maturity level or operating state applies;
+- what subscription/entitlement state applies.
+
+The app should not decide the full AI answer independently. It should provide context to Maturion/AIMC and receive a governed response or task package.
+
+---
+
+## 4. Agent file-system model
+
+### 4.1 The 3-tier agent knowledge structure
+
+The Living Agent System uses a three-tier agent knowledge model:
+
+```text
+Tier 1: Constitutional domain knowledge
+  - governance canon and constitutional constraints
+  - immutable unless CS2 approves canon update
+  - never overridden by task/session input
+
+Tier 2: Operational domain knowledge
+  - .agent-workspace/<agent>/knowledge/
+  - domain flag index, specialist registry, routing rules, runbooks, checklists
+  - version controlled and changeable only by governed PR
+
+Tier 3: Session domain knowledge
+  - current user/app/task/session context
+  - ephemeral unless captured into governed memory
+  - cannot override Tier 1 or self-promote to Tier 2
+```
+
+This strategy applies that model to Maturion and every specialist agent.
+
+### 4.2 Maturion agent bundle
+
+Maturion should have:
+
+```text
+.github/agents/maturion-agent.md
+  - thin-core contract only
+  - identity, role, operating authority, prohibitions, core wake-up references
+
+.agent-workspace/maturion-agent/knowledge/
+  - constitutional-bindings.md
+  - specialist-registry.md
+  - domain-flag-index.md
+  - routing-rules.md
+  - ecosystem-map.md
+  - app-context-map.md
+  - knowledge-plane-routing.md
+  - specialist-invocation-protocol.md
+  - response-review-checklist.md
+  - marketing-opportunity-triggers.md
+  - user-context-and-industry-calibration.md
+  - graceful-degradation-rules.md
+
+.agent-workspace/maturion-agent/memory/
+  - session records
+  - pre-handover records
+  - learning candidates awaiting governed review
+```
+
+The contract must remain thin. It must not become the place where every app rule, specialist behavior, scoring method, or module description is embedded.
+
+### 4.3 Specialist agent bundle
+
+Every specialist agent must have the complete creation bundle before it is considered active:
+
+```text
+.github/agents/<specialist>.md
+.agent-workspace/<specialist>/knowledge/domain-flag-index.md
+.agent-workspace/<specialist>/knowledge/specialist-registry.md
+.agent-workspace/<specialist>/knowledge/<domain-specific-operational-files>.md
+governance/AGENT_REGISTRY.json entry
+routing registration / orchestrator registration
+pre-handover commissioning proof
+```
+
+A contract alone is not an active agent. A contract without Tier 2 files, registry entry, routing, and commissioning proof is an incomplete stub.
+
+---
+
+## 5. Runtime Maturion decision loop
+
+When Maturion is invoked by a user, he must follow this loop.
+
+### Step 1: Establish embodiment and context
+
+Maturion identifies:
+
+- app or platform: APW, ISMS, MMM, PIT, Risk, Incident, RADAM, Training, AMC, etc.;
+- route/page/workflow;
+- public or authenticated state;
+- user identity where available;
+- user role and authority;
+- organisation and tenant;
+- industry/operating context;
+- subscription/entitlement state;
+- active maturity level or operating state;
+- active entity: domain, MPS, criterion, evidence, project, risk, incident, dashboard, build item, etc.
+
+### Step 2: Classify the user intent
+
+Maturion classifies the question or instruction:
+
+```text
+Knowledge question?
+  -> training / subject knowledge / standards / guidance
+
+Functionality or navigation question?
+  -> route user to the correct app, module, workflow, or page
+
+Task or workflow question?
+  -> invoke module specialist or package work into PIT/project workflow
+
+Build or governance question?
+  -> AMC / Builder-Maturion / Foreman network
+
+Risk, security, incident, control, or assurance question?
+  -> risk, incident, controls, RADAM, or relevant security specialist
+
+Evidence, maturity, scoring, descriptor, or criteria question?
+  -> MMM / maturity specialists and AIMC knowledge planes
+
+Marketing or opportunity trigger?
+  -> marketing opportunity detector and entitlement-aware recommendation
+```
+
+### Step 3: Select knowledge planes
+
+Maturion selects the allowed knowledge plane(s):
+
+```text
+Subject Knowledge Domain
+  -> global APGI/Maturion/security/risk/ISO/NIST/maturity doctrine
+
+Framework / Context Domain
+  -> customer-specific policies, procedures, standards, frameworks, uploaded context
+
+Evidence Domain
+  -> proof uploaded against criteria, interviews, voice notes, images, video, documents, system links
+
+App Context Domain
+  -> current app, page, workflow, module state, user action
+
+Memory Domain
+  -> constitutional, global, app, tenant, user/session, incident/watchdog memory
+```
+
+Maturion may combine planes only when tenant isolation, source authority, and permissions allow it.
+
+### Step 4: Decide response mode
+
+Maturion decides whether to:
+
+- answer directly from governed knowledge;
+- ask a clarifying question;
+- route the user to another app/module;
+- invoke a specialist;
+- prepare a task package for PIT;
+- request more evidence;
+- escalate to human approval, auditor, CS2, or relevant authority;
+- flag a marketing opportunity;
+- refuse or halt due to governance/safety conflict.
+
+### Step 5: Package specialist task
+
+If invoking a specialist, Maturion sends a bounded task package:
+
+```text
+- user question / instruction
+- app context
+- user/role/permission context
+- organisation/industry context
+- active entity context
+- allowed knowledge planes
+- source priority
+- expected output schema
+- constraints and prohibitions
+- confidence threshold
+- escalation rules
+- marketing/opportunity rules if relevant
+```
+
+The specialist does not need to re-run Maturion's full ecosystem decision loop. Maturion has already scoped the task.
+
+### Step 6: Review specialist output
+
+Maturion switches into review mode and tests the specialist answer:
+
+- Did the specialist stay within scope?
+- Did it use only authorised knowledge planes?
+- Did it respect tenant boundaries?
+- Did it follow source priority?
+- Did it hallucinate authority or functionality?
+- Did it answer the user concern?
+- Did it produce actionable output?
+- Did it identify uncertainty?
+- Did it avoid over-claiming completion?
+- Did it trigger any Guardian, Sentinel, Arbiter, privacy, security, or governance concerns?
+- Does it need human review or escalation?
+
+### Step 7: Synthesize final answer
+
+Maturion returns one coherent answer to the user, not a raw dump of specialist outputs.
+
+### Step 8: Capture learning
+
+User dissatisfaction, corrections, overrides, repeated questions, successful patterns, failed outputs, and specialist defects may be captured as learning candidates.
+
+Learning does not automatically update Tier 1 or Tier 2. Promotion must follow governed review and CS2-approved rules.
+
+---
+
+## 6. Maturion roles across the APGI ecosystem
+
+### 6.1 APGI public website
+
+Maturion acts as public-safe guide and marketing/education assistant.
+
+He may:
+
+- explain APGI services;
+- answer public-safe subject questions;
+- route users to training, contact forms, service pages, or relevant product areas;
+- detect public marketing opportunities;
+- use approved public/subject knowledge only.
+
+He may not:
+
+- use tenant/private context;
+- expose internal operations;
+- provide unapproved claims;
+- perform private evidence or maturity evaluation.
+
+### 6.2 ISMS platform shell
+
+Maturion acts as platform navigator, subscription/entitlement-aware guide, and authenticated workspace assistant.
+
+He may:
+
+- help users navigate modules;
+- explain module purpose and dependencies;
+- route functionality questions to the correct module;
+- explain current maturity state if available;
+- identify module dependency opportunities;
+- hand off tasks to MMM, PIT, Risk, Incident, RADAM, Training, or Marketing specialists.
+
+### 6.3 MMM / Maturity Roadmap
+
+Maturion acts as maturity consultant and orchestrator for:
+
+- domain explanations;
+- MPS compilation;
+- intent statement drafting;
+- criteria generation in Verbatim, Hybrid, and New modes;
+- maturity descriptor generation;
+- evidence interpretation;
+- maturity scoring support;
+- next-level guidance;
+- audit configuration support;
+- approval workflow guidance;
+- human-loop escalation;
+- marketing opportunity detection.
+
+Maturion should invoke specialists for deep criteria generation, evidence parsing, scoring, standards mapping, risk/control expertise, and report generation.
+
+### 6.4 PIT
+
+Maturion acts as implementation-work translator and project packaging assistant.
+
+He may:
+
+- convert maturity shortcomings into implementation tasks;
+- package criteria gaps into projects or work entities;
+- explain implementation steps;
+- link evidence requirements to deliverables;
+- monitor overdue or blocked actions when PIT maturity allows;
+- coordinate with Risk, Incident, MMM, and RADAM specialists.
+
+### 6.5 Risk Management
+
+Maturion acts as risk management expert and orchestrator.
+
+He may invoke:
+
+- ISO 31000 specialist;
+- NIST specialist;
+- threat specialist;
+- vulnerability specialist;
+- security controls specialist;
+- risk register specialist;
+- mitigation planning specialist.
+
+### 6.6 Incident Management
+
+Maturion acts as incident workflow and assurance guide.
+
+He may support:
+
+- incident classification;
+- incident workflow explanation;
+- evidence linking;
+- assurance review;
+- closure readiness;
+- linkage to risk, PIT, MMM, and RADAM.
+
+### 6.7 RADAM
+
+Maturion acts as analytics and assurance interpreter.
+
+He may invoke:
+
+- data analytics specialist;
+- remote assurance specialist;
+- dashboard interpretation specialist;
+- anomaly/pattern specialist;
+- ROI/assurance metric specialist.
+
+### 6.8 Training platform
+
+Maturion acts as knowledge and learning guide.
+
+If a user asks a knowledge question rather than a functionality question, Maturion should determine whether the best response is:
+
+- direct brief answer;
+- guided explanation;
+- referral to a course;
+- certification/credit pathway;
+- training specialist escalation.
+
+### 6.9 AMC / App Management Centre
+
+Maturion eventually becomes CS2-capable in staged maturity levels.
+
+In AMC, Maturion may eventually:
+
+- monitor app performance;
+- monitor build/project status;
+- QA builds;
+- enforce governance compliance;
+- coordinate Foreman/build agents;
+- notify CS2 of performance, security, governance, or availability issues;
+- propose upgrades or changes;
+- manage implementation plans within authorised limits.
+
+Maturion-as-CS2 must be progressive and gated. It may not become autonomous without mature canon, audit trails, freeze/rollback mechanisms, human override, and explicit CS2 approval.
+
+---
+
+## 7. Marketing opportunity detection
+
+Maturion must detect marketing opportunities ethically and contextually.
+
+Marketing opportunities include:
+
+- user needs PIT to implement maturity shortfalls;
+- user needs policy/procedure development support;
+- user needs training or certification to understand a domain/MPS/criteria;
+- user needs Risk Management to mature a control area;
+- user needs Incident Management to produce evidence;
+- user needs RADAM automation to move from Proactive to Resilient;
+- user reaches a milestone that justifies a module recommendation;
+- user repeatedly asks questions that indicate a training or service gap.
+
+Marketing triggers must:
+
+- be entitlement-aware;
+- not interrupt critical workflows unnecessarily;
+- be framed as operational value, not aggressive sales;
+- point to the relevant marketing page, module, training path, or future marketing app;
+- be logged for future marketing app integration where appropriate.
+
+Maturion may say, in effect:
+
+```text
+This gap can be managed manually, but using PIT would let you track ownership, due dates, evidence, and progress toward the next maturity level. Would you like me to show you the PIT implementation pathway?
+```
+
+---
+
+## 8. Boundaries and authority model
+
+### 8.1 CS2 authority
+
+CS2 / Johan Ras is the ultimate authority for:
+
+- agent contract creation;
+- agent contract amendment;
+- Tier 1 canon change;
+- Tier 2 agent knowledge change where it affects role, authority, routing, or knowledge access;
+- specialist activation;
+- AIMC runtime registry activation;
+- escalation policy;
+- Maturion-as-CS2 maturity progression;
+- governance exceptions.
+
+No agent tier, including governance canon, may be changed without explicit CS2 permission.
+
+### 8.2 CodexAdvisor authority
+
+CodexAdvisor is the only agent class authorised to create or materially modify agent file-system bundles, subject to CS2 approval.
+
+CodexAdvisor may, when explicitly authorised:
+
+- create `.github/agents/<agent>.md` files;
+- create Tier 2 knowledge stubs in `.agent-workspace/<agent>/knowledge/`;
+- update agent registry entries;
+- update routing/registration files;
+- create pre-handover commissioning proof templates;
+- propose governance canon changes for CS2 review;
+- validate agent creation bundle completeness;
+- maintain the agent creation process.
+
+CodexAdvisor may not:
+
+- self-authorise new agent powers;
+- change CS2 authority requirements;
+- create active agents without CS2-approved issue or equivalent instruction;
+- bypass governance gates;
+- merge its own agent-file changes without required review.
+
+### 8.3 Foreman authority
+
+Foreman and Foreman-aligned agents may:
+
+- coordinate build waves;
+- create pre-build artifacts;
+- appoint builders where authorised;
+- manage implementation sequencing;
+- enforce governance gates;
+- review build readiness;
+- stop unsafe work;
+- prepare work packages for builders.
+
+Foreman and Foreman-aligned agents may not:
+
+- create or modify agent contracts;
+- create or modify Tier 2 agent knowledge files;
+- change specialist registry/routing for runtime agents unless explicitly delegated through CodexAdvisor/CS2-approved process;
+- change governance canon;
+- silently convert build agents into runtime specialists;
+- implement runtime Maturion/AIMC behavior without authorised pre-build scope.
+
+### 8.4 Builder agent authority
+
+Builder agents may:
+
+- implement app code inside authorised scope;
+- create implementation evidence;
+- run tests;
+- fix defects;
+- build to green;
+- update app-specific prebuild/build artifacts when appointed.
+
+Builder agents may not:
+
+- touch `.github/agents/`;
+- touch `.agent-workspace/<agent>/knowledge/`;
+- touch governance canon;
+- modify agent registries;
+- modify Maturion specialist routing;
+- create new agents;
+- self-appoint as runtime specialists;
+- invent AIMC runtime architecture.
+
+### 8.5 General ChatGPT, Copilot, and platform agent boundaries
+
+Because CS2 uses multiple AI platforms, including Codex, ChatGPT, Copilot, and other agents, the following boundary applies across platforms:
+
+General agents may:
+
+- discuss strategy;
+- draft proposed strategy documents;
+- review PRs;
+- create pre-build artifacts when explicitly asked;
+- implement app code when appointed and scoped;
+- provide recommendations and gap analysis;
+- prepare proposed changes for CS2 approval.
+
+General agents may not:
+
+- directly modify agent contracts;
+- directly modify Tier 2 agent knowledge;
+- directly modify governance canon;
+- declare new agents active;
+- alter agent authority;
+- bypass CodexAdvisor for agent creation or agent file-system changes;
+- treat ordinary app work as permission to change agent files.
+
+If a general agent identifies a needed agent change, it must create or propose an issue/work package for CodexAdvisor and CS2 review.
+
+### 8.6 Governance canon boundary
+
+Governance canon is Tier 1 authority.
+
+Governance canon may only be changed through explicit CS2-approved governance process. No build agent, specialist, general assistant, or app implementation PR may alter canon unless the PR is explicitly scoped as a canon-change PR and authorised by CS2.
+
+### 8.7 App/module specialist boundary
+
+App/module specialists may receive context and tasks from Maturion. They may not independently call other specialists unless their contract allows it. They may not update Maturion memory or AIMC knowledge directly. They may submit learning candidates or structured outputs back to Maturion/AIMC for review.
+
+### 8.8 Runtime provider boundary
+
+No app may create direct production AI provider integrations outside AIMC governance.
+
+Where a runtime provider is not yet available, apps must use stubs/adapters and clearly mark the missing AIMC dependency.
+
+---
+
+## 9. Specialist invocation rules
+
+Maturion invokes specialists when:
+
+- the task requires deep domain reasoning;
+- evidence must be parsed or evaluated;
+- criteria/descriptors/scoring must be generated;
+- risk, incident, control, RADAM, training, or implementation expertise is required;
+- the task crosses module boundaries;
+- a workflow must generate a PIT work package;
+- confidence would be lower if Maturion answered directly.
+
+Maturion answers directly when:
+
+- the question is simple and within governed knowledge;
+- the user asks for navigation guidance;
+- the answer is a short explanation with no deep analysis;
+- no specialist is available and degraded-mode answer is allowed;
+- asking a clarifying question is more appropriate than invoking a specialist.
+
+Maturion escalates when:
+
+- Tier 1 and task context conflict;
+- specialist outputs conflict materially;
+- source authority is ambiguous;
+- tenant boundary is unclear;
+- security/privacy risk is detected;
+- user asks for action beyond current authority;
+- output affects official scoring, approval, policy, or external audit and human review is required.
+
+---
+
+## 10. MMM criteria and evidence model
+
+In MMM, Maturion must support at least these task classes:
+
+- Domain explanation;
+- MPS generation;
+- MPS refinement;
+- intent statement generation;
+- criteria generation in Verbatim, Hybrid, and New modes;
+- maturity descriptor generation across Basic, Reactive, Compliant, Proactive, Resilient;
+- evidence upload interpretation;
+- evidence scoring recommendation;
+- next-level gap explanation;
+- human-loop escalation;
+- independent auditor escalation;
+- PIT work package generation;
+- marketing opportunity detection.
+
+Maturion should not embed all of this domain logic directly. He should invoke specialists such as:
+
+- document-parser specialist;
+- criteria-generator specialist;
+- descriptor specialist;
+- maturity-scoring specialist;
+- evidence-packaging specialist;
+- standards-mapping specialist;
+- risk/control specialist;
+- PIT-work-package specialist;
+- report-generation specialist.
+
+Maturion reviews and synthesises the final response.
+
+---
+
+## 11. Learning and memory rules
+
+Maturion must learn from:
+
+- user corrections;
+- rejected answers;
+- accepted answers;
+- repeated patterns;
+- evidence-evaluation overrides;
+- specialist failures;
+- specialist successes;
+- marketing trigger outcomes;
+- human auditor decisions;
+- CS2 corrections.
+
+Learning capture must be tier-aware:
+
+- session observations remain Tier 3 by default;
+- repeated or useful patterns may become learning candidates;
+- learning candidates may be reviewed for Tier 2 promotion;
+- no Tier 3 learning may self-promote to Tier 1;
+- tenant-specific learning must not leak into global subject knowledge;
+- customer context must not contaminate global Maturion memory.
+
+---
+
+## 12. Waved implementation plan
+
+### Wave 0: Strategy adoption
+
+**Goal:** Approve this strategy as the controlling model before changing contracts or Tier 2 files.
+
+Deliverables:
+
+- this strategy document;
+- CS2 review comment;
+- decision whether to promote to canon or use as strategy authority first.
+
+Out of scope:
+
+- no agent contract edits;
+- no Tier 2 edits;
+- no runtime code;
+- no AIMC schema changes.
+
+### Wave 1: Current-state audit
+
+**Goal:** Audit current Maturion and agent file-system readiness.
+
+Review:
+
+- `.github/agents/maturion-agent.md`;
+- `.github/agents/*`;
+- `.agent-workspace/maturion-agent/knowledge/*`;
+- specialist registries;
+- domain flag indices;
+- routing rules;
+- `governance/AGENT_REGISTRY.json`;
+- `governance/CANON_INVENTORY.json`;
+- CodexAdvisor agent creation process.
+
+Output:
+
+- gap analysis;
+- list of stale/contradictory agent contracts;
+- list of missing Tier 2 files;
+- list of specialists that are only stubs;
+- recommendation for agent bundle repair.
+
+### Wave 2: CodexAdvisor process upgrade
+
+**Goal:** Ensure CodexAdvisor can create and maintain full agent bundles for runtime specialists.
+
+Deliverables:
+
+- CodexAdvisor process update proposal;
+- runtime-specialist bundle checklist;
+- agent creation QA-to-red;
+- CS2 approval workflow for agent file-system changes.
+
+Boundary:
+
+- only CodexAdvisor may implement the actual agent file-system changes after CS2 approval.
+
+### Wave 3: Maturion thin-core contract correction proposal
+
+**Goal:** Prepare, but do not yet implement, changes required in `maturion-agent.md`.
+
+Expected corrections:
+
+- update ecosystem scope;
+- resolve `can_invoke` contradiction;
+- add AIMC runtime specialist registry dependency;
+- add ecosystem decision loop pointer;
+- add marketing opportunity detector pointer;
+- distinguish runtime Maturion from Builder/AMC Maturion-as-CS2;
+- keep contract thin.
+
+Output:
+
+- proposed diff package for CodexAdvisor/CS2 review.
+
+### Wave 4: Maturion Tier 2 expansion
+
+**Goal:** Create/update Maturion operational knowledge files.
+
+Deliverables may include:
+
+- ecosystem-map.md;
+- app-context-map.md;
+- knowledge-plane-routing.md;
+- specialist-invocation-protocol.md;
+- response-review-checklist.md;
+- marketing-opportunity-triggers.md;
+- user-context-and-industry-calibration.md;
+- graceful-degradation-rules.md.
+
+Boundary:
+
+- implemented only by CodexAdvisor under CS2 approval.
+
+### Wave 5: AIMC runtime registry and adapter strategy
+
+**Goal:** Define how runtime apps call Maturion/AIMC and how Maturion calls specialists.
+
+Deliverables:
+
+- AIMC runtime specialist registry schema;
+- app embodiment registration schema;
+- source access policy;
+- tenant isolation policy;
+- provider access policy;
+- audit event model;
+- app adapter rules for APW, ISMS, MMM, PIT, Risk, Incident, RADAM, Training, AMC.
+
+### Wave 6: First runtime slice
+
+**Goal:** Implement the smallest safe runtime Maturion/AIMC slice.
+
+Candidate:
+
+```text
+ISMS Ask Maturion
+  -> app/user/context detection
+  -> AIMC knowledge adapter stub
+  -> no uncontrolled provider call
+  -> deterministic response envelope
+  -> logging/audit stub
+```
+
+No live provider, memory write, or autonomous action until authorised.
+
+### Wave 7: MMM criteria/descriptors/evidence specialist path
+
+**Goal:** Implement the first real specialist invocation path.
+
+Candidate:
+
+```text
+MMM criteria request
+  -> Maturion context detection
+  -> document-parser / criteria-generator / descriptor / maturity-scoring specialist stubs
+  -> Maturion review/synthesis
+  -> human approval loop
+```
+
+### Wave 8: PIT work-package bridge
+
+**Goal:** Allow maturity gaps, risk actions, and incident actions to be packaged into PIT work entities.
+
+Candidate:
+
+```text
+Maturity gap or evidence shortfall
+  -> Maturion analysis
+  -> PIT work-package specialist
+  -> project/action/deliverable proposal
+  -> user approval
+  -> PIT capture
+```
+
+### Wave 9: Risk, Incident, RADAM, Training, and Marketing expansion
+
+**Goal:** Expand specialist coverage in governed slices.
+
+Each module must receive:
+
+- strategy/prebuild alignment;
+- QA-to-red;
+- specialist contract/Tier 2 bundle if needed;
+- app adapter;
+- test evidence;
+- CS2 closure.
+
+### Wave 10: AMC / Maturion-as-CS2 progression
+
+**Goal:** Define and progressively implement Maturion-as-CS2 capabilities in AMC.
+
+Stages:
+
+1. Advisor only;
+2. CS2 proxy evaluator;
+3. delegated CS2 for low-risk actions;
+4. operational CS2 orchestrator;
+5. autonomous CS2 with human override.
+
+Each stage requires explicit CS2 approval and maturity evidence.
+
+---
+
+## 13. Immediate next actions
+
+1. Review and approve or amend this strategy.
+2. Create a current-state audit issue for Maturion and existing agent files.
+3. Assign CodexAdvisor to audit agent file-system readiness.
+4. Prevent all other agents from changing `.github/agents`, `.agent-workspace/<agent>/knowledge`, or governance canon unless explicitly authorised by CS2.
+5. Use this strategy as the reference when APW, ISMS, MMM, PIT, Risk, Incident, RADAM, Training, Marketing, or AMC agents propose Maturion work.
+
+---
+
+## 14. Non-negotiable rules
+
+- Maturion is one ecosystem intelligence.
+- AIMC is the central AI management and knowledge control plane.
+- Apps do not create independent Maturion brains.
+- Specialists are invoked capabilities, not separate user-facing identities unless explicitly designed.
+- Agent contracts remain thin.
+- Tier 2 carries operational routing and specialist knowledge.
+- Tier 3 never overrides Tier 1.
+- Only CodexAdvisor may create or materially modify agent file-system bundles, subject to CS2 approval.
+- Foreman and builders build apps and prebuild artifacts; they do not change agent file systems.
+- Governance canon changes require explicit CS2 authority.
+- Any uncertainty about authority means stop and escalate.


### PR DESCRIPTION
Adds a draft strategy document under `Maturion/strategy/` for CS2 review.

The document defines:
- Maturion as one APGI ecosystem intelligence.
- AIMC as the central knowledge and specialist control plane.
- Apps/modules as embodiments and context providers.
- Specialists as governed invoked capabilities.
- Boundaries for CS2, CodexAdvisor, Foreman, builders, general assistants, governance canon, specialists, and runtime provider integration.
- A waved implementation plan before any agent file-system or runtime changes.

No code, agent contracts, Tier 2 agent knowledge, governance canon, Supabase, Vercel, or deployment files are changed.