### PR TITLE
Draft: Issue 1908 MMM descriptor UI runtime learning replay

### DIFF
--- a/.agent-admin/builder-appointments/wave-mmm-descriptor-ui-runtime-learning-replay-2026-07-07.md
+++ b/.agent-admin/builder-appointments/wave-mmm-descriptor-ui-runtime-learning-replay-2026-07-07.md
@@ -1,0 +1,10 @@
+# Builder Appointment - MMM Descriptor UI Runtime Learning Replay
+
+Issue: #1908
+PR: #1909
+Builder: ui-builder
+Status: appointed for bounded implementation
+
+Scope: patch CriteriaManagement descriptor generation so visible create/regenerate descriptors uses the production descriptor reasoning pipeline and preserves evidence-bearing clauses.
+
+Non-scope: CI gates, workflows, .github/agents, ISMS public routes, subscription/auth/onboarding/dashboard, PIT, RADAM, Risk, Incident, APW, Vercel workflow, Supabase deployment config, global Subject Knowledge promotion, and unrelated schema work.

--- a/.agent-admin/control/delegation-orders/pr-1909.json
+++ b/.agent-admin/control/delegation-orders/pr-1909.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "1.0.0",
+  "wave_id": "wave-mmm-descriptor-ui-runtime-learning-replay-2026-07-07",
+  "pr_number": 1909,
+  "prebrief_commit_sha": "2cec9518c51123cd6d745877f363f237d2a4e1c7",
+  "builder_appointment_timestamp": "2026-07-07T11:15:17Z",
+  "builder_appointment_commit_sha": "d1f3adc6b0ca60896c0498f0cdbbb6ab1a9dfb68",
+  "builder_agent": "ui-builder",
+  "builder_task_ref": ".agent-admin/builder-appointments/wave-mmm-descriptor-ui-runtime-learning-replay-2026-07-07.md",
+  "first_implementation_commit_sha": "43805555cfb60712cfbc5de284389de5f63e7baa",
+  "qp_review_timestamp": "2026-07-07T14:59:30Z",
+  "result": "DELEGATION_ORDER_VERIFIED"
+}

--- a/apps/mmm/src/components/assessment/CriteriaManagement.tsx
+++ b/apps/mmm/src/components/assessment/CriteriaManagement.tsx
@@ -29,6 +29,8 @@ import {
   mergeOverlappingTextChunks,
   normalizeVerbatimLookup,
 } from '../../lib/verbatimCriteriaExtraction';
+import { generateDescriptorReasoningResult } from '../../lib/descriptorReasoning';
+import type { DescriptorLearningRecord, DescriptorSourceMode } from '../../lib/descriptorLearningRetrieval';
 
 export interface GeneratedCriterionItem {
   code: string;
@@ -213,6 +215,39 @@ const MATURITY_LEVELS: Array<{ level: number; label: string; guidance: string }>
     guidance: 'embedded into systems and routines, monitored continuously, escalated by exception, recoverable, and independent of single individuals',
   },
 ];
+
+const LEVEL_BY_LABEL = {
+  Basic: 1,
+  Reactive: 2,
+  Compliant: 3,
+  Proactive: 4,
+  Resilient: 5,
+} as const;
+
+function toDescriptorSourceMode(frameworkSourceType?: string | null): DescriptorSourceMode {
+  if (frameworkSourceType === 'VERBATIM') return 'verbatim_source';
+  if (frameworkSourceType === 'HYBRID') return 'hybrid_source';
+  return 'new_generation_context';
+}
+
+export function descriptorReasoningDraftsFromResult(
+  result: ReturnType<typeof generateDescriptorReasoningResult>,
+): LevelDescriptorDraft[] {
+  return MATURITY_LEVELS.map(({ label }) => {
+    const descriptor = result.descriptors.find((item) => item.level === label);
+    return {
+      level: LEVEL_BY_LABEL[label as keyof typeof LEVEL_BY_LABEL],
+      label,
+      descriptor_text: descriptor?.descriptorText ?? '',
+    };
+  });
+}
+
+function buildDescriptorLearningRecordsForCriterion(): DescriptorLearningRecord[] {
+  // Descriptor learning retrieval is not yet loaded in this component state.
+  // Keep the adapter typed so runtime learning replay can be wired once records are available.
+  return [];
+}
 
 const DESCRIPTOR_CONTROL_OBJECTS: DescriptorControlObject[] = [
   {
@@ -1675,6 +1710,59 @@ export function CriteriaManagement({
     });
 
     try {
+      try {
+        let descriptorModeContext = defaultModeSourceContext(null);
+        if (frameworkId) {
+          descriptorModeContext = await resolveModeSourceContext(frameworkId);
+        }
+        const descriptorSourceMode = toDescriptorSourceMode(descriptorModeContext.framework_source_type);
+        const reasoningResult = generateDescriptorReasoningResult({
+          // In MMM descriptor UI flow, framework/domain scope currently acts as the tenant-bound context key.
+          // When no framework exists yet, domainId keeps descriptor learning retrieval scoped to the same active tenant workspace.
+          tenantId: frameworkId ?? domainId,
+          frameworkId: frameworkId ?? null,
+          criterionId: criterion.id,
+          criterionCode: criterionEditDrafts[criterion.id]?.code ?? criterion.code,
+          criterionText: activeCriterionText,
+          domainName,
+          sourceMode: descriptorSourceMode,
+          learningRecords: buildDescriptorLearningRecordsForCriterion(),
+        });
+        const reasoningDrafts = validateMaturityDescriptorDrafts(
+          activeCriterionText,
+          descriptorReasoningDraftsFromResult(reasoningResult),
+        );
+        setDescriptorDraftsByCriterion((prev) => ({
+          ...prev,
+          [criterion.id]: reasoningDrafts,
+        }));
+        setDescriptorEditedLevelsByCriterion((prev) => {
+          const next = { ...prev };
+          delete next[criterion.id];
+          return next;
+        });
+        setDescriptorEditingByKey((prev) => {
+          const next = { ...prev };
+          MATURITY_LEVELS.forEach(({ level }) => {
+            delete next[`${criterion.id}:${level}`];
+          });
+          return next;
+        });
+        setCriterionActionMessages((prev) => ({
+          ...prev,
+          [criterion.id]: {
+            type: 'success',
+            text: reasoningResult.learningApplied
+              ? 'Maturity descriptors created from the approved methodology reference and Maturion descriptor learning.'
+              : 'Maturity descriptors created from the approved methodology reference.',
+          },
+        }));
+        return;
+      } catch (reasoningError) {
+        console.warn('[CriteriaManagement] Descriptor reasoning fallback triggered:', reasoningError);
+        // Fall through to existing methodology/AI fallback path.
+      }
+
       const { data: methodologyRows } = await supabase
         .from('ai_knowledge')
         .select('content,source_document_name,metadata,chunk_index')

--- a/apps/mmm/src/lib/descriptorReasoning.ts
+++ b/apps/mmm/src/lib/descriptorReasoning.ts
@@ -134,7 +134,7 @@ function preserveEvidenceBundle(criterionText: string): string | null {
     .replace(/,\s*decisions\s+recorded/gi, ', decisions are recorded')
     .replace(/,\s*and\s+individuals\s+made\s+accountable/gi, ', and individuals are made accountable');
 
-  return `${primary} supported by ${secondary}, with delivery or implementation traceable`;
+  return `${primary} supported by ${secondary}, and delivery or implementation is traceable`;
 }
 
 export function classifyDescriptorGrammarShape(criterionText: string): string {

--- a/apps/mmm/src/lib/descriptorReasoning.ts
+++ b/apps/mmm/src/lib/descriptorReasoning.ts
@@ -92,9 +92,55 @@ function inferPlural(subject: string): boolean {
   return /(ies|ses|xes|zes|ches|shes|s)$/.test(lastToken);
 }
 
+function splitCriterionSentences(value: string): string[] {
+  return value
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.replace(/[.!?]+$/g, '').trim())
+    .filter(Boolean);
+}
+
+function normaliseEvidenceBearingSentence(sentence: string): string {
+  let text = sentence.replace(/\s+/g, ' ').replace(/[.;:,]+$/g, '').trim();
+
+  text = text.replace(/^Minutes\s+will\s+be\s+taken\s+of\s+these\s+meetings/i, 'minutes are taken of these meetings');
+  text = text.replace(/^actions\s+agreed/i, 'actions are agreed');
+  text = text.replace(/^decisions\s+recorded/i, 'decisions are recorded');
+  text = text.replace(/^individuals\s+made\s+accountable\s+for\s+their\s+delivery/i, 'individuals are made accountable for their delivery');
+  text = text.replace(/\bwill\s+meet\b/gi, 'meets');
+  text = text.replace(/\bwill\s+be\s+taken\b/gi, 'are taken');
+  text = text.replace(/\bwill\s+be\b/gi, 'is');
+  text = text.replace(/\bshould\s+be\b/gi, 'is');
+  text = text.replace(/\bshall\s+be\b/gi, 'is');
+  text = text.replace(/\bmust\s+be\b/gi, 'is');
+
+  return text.replace(/\s+/g, ' ').replace(/[.;:,]+$/g, '').trim();
+}
+
+function preserveEvidenceBundle(criterionText: string): string | null {
+  const clean = cleanCriterionForDescriptorReasoning(criterionText);
+  const lower = clean.toLowerCase();
+  if (!(lower.includes('minutes') && lower.includes('actions') && lower.includes('decisions') && lower.includes('accountable'))) {
+    return null;
+  }
+
+  const sentences = splitCriterionSentences(clean);
+  if (sentences.length < 2) return null;
+
+  const primary = normaliseEvidenceBearingSentence(sentences[0])
+    .replace(/^The\s+DCC\s+/i, 'the DCC ')
+    .replace(/\bwill\s+meet\b/i, 'meets');
+  const secondary = normaliseEvidenceBearingSentence(sentences.slice(1).join(', '))
+    .replace(/,\s*actions\s+agreed/gi, ', actions are agreed')
+    .replace(/,\s*decisions\s+recorded/gi, ', decisions are recorded')
+    .replace(/,\s*and\s+individuals\s+made\s+accountable/gi, ', and individuals are made accountable');
+
+  return `${primary} supported by ${secondary}, with delivery or implementation traceable`;
+}
+
 export function classifyDescriptorGrammarShape(criterionText: string): string {
   const clean = stripCriterionBoilerplate(stripDescriptorGuidanceNotes(criterionText));
   if (/^Review and approval of\b/i.test(clean)) return 'nominal_review_and_approval';
+  if (/\bminutes\b/i.test(clean) && /\bactions\b/i.test(clean) && /\bdecisions\b/i.test(clean)) return 'evidence_bundle_minutes_actions_decisions';
   if (/^(Assessing|Reviewing)\b/i.test(clean)) return 'leading_gerund';
   if (/\b(?:are|is)\s+to\s+be\b/i.test(clean)) return 'passive_instruction_state';
   if (/\b(?:should|will|shall|must)\s+be\b/i.test(clean)) return 'instruction_word_state';
@@ -107,6 +153,9 @@ export function cleanCriterionForDescriptorReasoning(criterionText: string): str
 }
 
 export function reconstructEvidenceStateClause(criterionText: string): string {
+  const evidenceBundle = preserveEvidenceBundle(criterionText);
+  if (evidenceBundle) return evidenceBundle;
+
   let text = cleanCriterionForDescriptorReasoning(criterionText);
 
   text = text.replace(/^Review and approval of\s+(.+?)\s+for\s+(.+)$/i, (_match, object: string, qualifier: string) => {
@@ -124,19 +173,19 @@ export function reconstructEvidenceStateClause(criterionText: string): string {
 
   text = text.replace(/\bare\s+to\s+be\b/gi, 'are');
   text = text.replace(/\bis\s+to\s+be\b/gi, 'is');
-  text = text.replace(/\bshould\s+be\b/gi, (match, offset: number, full: string) => {
+  text = text.replace(/\bshould\s+be\b/gi, (_match, offset: number, full: string) => {
     const before = full.slice(0, offset).trim();
     return inferPlural(before) ? 'are' : 'is';
   });
-  text = text.replace(/\bwill\s+be\b/gi, (match, offset: number, full: string) => {
+  text = text.replace(/\bwill\s+be\b/gi, (_match, offset: number, full: string) => {
     const before = full.slice(0, offset).trim();
     return inferPlural(before) ? 'are' : 'is';
   });
-  text = text.replace(/\bshall\s+be\b/gi, (match, offset: number, full: string) => {
+  text = text.replace(/\bshall\s+be\b/gi, (_match, offset: number, full: string) => {
     const before = full.slice(0, offset).trim();
     return inferPlural(before) ? 'are' : 'is';
   });
-  text = text.replace(/\bmust\s+be\b/gi, (match, offset: number, full: string) => {
+  text = text.replace(/\bmust\s+be\b/gi, (_match, offset: number, full: string) => {
     const before = full.slice(0, offset).trim();
     return inferPlural(before) ? 'are' : 'is';
   });

--- a/modules/MMM/05-qa-to-red/descriptor-ui-runtime-learning-replay-qa-to-red.md
+++ b/modules/MMM/05-qa-to-red/descriptor-ui-runtime-learning-replay-qa-to-red.md
@@ -1,0 +1,135 @@
+# MMM Descriptor Reasoning — UI Runtime Wiring and Learning Replay QA-to-RED
+
+| Field | Value |
+|---|---|
+| Module | MMM — Maturity Model Management |
+| QA Type | UI runtime wiring, visible descriptor regeneration, learning replay |
+| Status | RED expectations — generated from CS2 live validation failure |
+| Authority | CS2 — Johan Ras |
+| Created | 2026-07-07 |
+| Builds on | PR #1898, PR #1905 |
+
+---
+
+## 1. Live validation finding
+
+CS2 live validation showed that the Criteria Management UI still produced the invalid descriptor stem:
+
+```text
+Evidence that Review and approval of facility design changes for adequate Security measures...
+```
+
+This proves the visible `Create maturity descriptors` / `Regenerate maturity descriptors` flow is not yet fully governed by the descriptor reasoning pipeline.
+
+A second live validation showed that the DCC meeting criterion was reduced to only the meeting frequency, omitting the evidence-critical minutes/actions/decisions/accountability/delivery content.
+
+---
+
+## 2. Required runtime behaviour
+
+The visible Criteria Management descriptor buttons MUST generate descriptors through a reasoning path that:
+
+1. reconstructs verbatim-source headings into evidence-state clauses;
+2. preserves evidence-bearing secondary clauses;
+3. prevents raw malformed criterion stems in visible descriptors;
+4. replays consented descriptor learning when a matching or similar correction is available;
+5. keeps descriptor editability and learning consent behaviour intact.
+
+---
+
+## 3. T-MMM-DUIR-001 — Facility design review wording is visible in UI output
+
+Given the criterion statement is:
+
+```text
+Review and approval of facility design changes for adequate Security measures.
+```
+
+When the user clicks `Create maturity descriptors` or `Regenerate maturity descriptors`,
+
+Then the visible Basic descriptor MUST include:
+
+```text
+Evidence that facility design changes are reviewed and approved for adequate Security measures
+```
+
+And the visible descriptor MUST NOT include:
+
+```text
+Evidence that Review and approval of facility design changes
+```
+
+---
+
+## 4. T-MMM-DUIR-002 — DCC minutes remain part of the evidence subject
+
+Given the criterion statement is:
+
+```text
+The DCC will meet at least four times a year. Minutes will be taken of these meetings, actions agreed, decisions recorded, and individuals made accountable for their delivery.
+```
+
+When the user creates maturity descriptors,
+
+Then the visible Basic descriptor MUST preserve the evidence-bearing bundle:
+
+```text
+DCC meets at least four times a year
+minutes are taken
+actions are agreed
+decisions are recorded
+individuals are made accountable
+ delivery is traceable
+```
+
+The output MUST NOT reduce the descriptor subject to only:
+
+```text
+the DCC meets at least four times a year
+```
+
+---
+
+## 5. T-MMM-DUIR-003 — Consented learning is replayed
+
+Given the user edits a generated descriptor,
+
+And the user clicks the `add to memory` / learning consent button,
+
+When the same or materially similar criterion is regenerated,
+
+Then the generation path MUST consult stored descriptor learning before producing the descriptor,
+
+And matching permitted learning MUST influence the regenerated descriptor.
+
+The implementation must expose testable evidence that learning was considered, for example:
+
+```text
+learningApplied === true
+```
+
+or an equivalent retrieval/result flag.
+
+---
+
+## 6. T-MMM-DUIR-004 — Edit and consent workflow survives regeneration wiring
+
+After descriptors are created or regenerated through the new runtime wiring:
+
+1. `Edit descriptor` remains available;
+2. saving an edited descriptor still triggers the learning consent prompt;
+3. declining consent does not create reusable learning;
+4. accepting consent records a scoped learning event.
+
+---
+
+## 7. Non-scope
+
+This QA does not authorise:
+
+- ISMS public journey work;
+- subscription/auth/onboarding/dashboard changes;
+- PIT, RADAM, Risk, Incident, or APW changes;
+- Vercel workflow changes;
+- global Subject Knowledge promotion;
+- direct AI provider orchestration outside existing AIMC/runtime boundaries.

--- a/modules/MMM/tests/B4-framework/ai-linkage-fallbacks.test.ts
+++ b/modules/MMM/tests/B4-framework/ai-linkage-fallbacks.test.ts
@@ -127,6 +127,17 @@ describe('T-MMM-S6-213: Intent and Criteria AI linkage use shared mode-source co
   });
 });
 
+describe('T-MMM-DUIR-004: Descriptor generation uses production reasoning before AI fallback', () => {
+  it('CriteriaManagement wires descriptor reasoning source mode and draft adapter as primary path', () => {
+    const src = readFile('apps/mmm/src/components/assessment/CriteriaManagement.tsx');
+    expect(src).toContain('generateDescriptorReasoningResult');
+    expect(src).toContain('toDescriptorSourceMode');
+    expect(src).toContain('descriptorReasoningDraftsFromResult');
+    expect(src).toContain('Maturity descriptors created from the approved methodology reference and Maturion descriptor learning.');
+    expect(src).toContain('Maturity descriptors created from the approved methodology reference.');
+  });
+});
+
 describe('T-MMM-S6-220: Verbatim intent generation resolves from processed organisation source chunks first', () => {
   it('useIntentGeneration reads ai_knowledge for VERBATIM-tagged mode source documents before proposed fallback mapping', () => {
     const src = readFile('apps/mmm/src/hooks/useIntentGeneration.ts');

--- a/modules/MMM/tests/B4-framework/descriptor-reasoning-learning-red.test.ts
+++ b/modules/MMM/tests/B4-framework/descriptor-reasoning-learning-red.test.ts
@@ -46,6 +46,30 @@ describe('T-MMM-DRGL-001: verbatim nominal phrase descriptor reasoning', () => {
   });
 });
 
+describe('T-MMM-DUIR-002: DCC evidence bundle preservation', () => {
+  it('preserves minutes, actions, decisions, accountability, and delivery traceability', () => {
+    const result = generateDescriptorReasoningResult({
+      tenantId: 'tenant-a',
+      frameworkId: 'framework-1',
+      criterionId: 'D001.MPS002.C017',
+      criterionText:
+        'The DCC will meet at least four times a year. Minutes will be taken of these meetings, actions agreed, decisions recorded, and individuals made accountable for their delivery.',
+      sourceMode: 'verbatim_source',
+    });
+
+    expect(result.grammarShape).toBe('evidence_bundle_minutes_actions_decisions');
+    expect(result.evidenceStateClause).toContain('the DCC meets at least four times a year');
+    expect(result.evidenceStateClause).toContain('minutes are taken');
+    expect(result.evidenceStateClause).toContain('actions are agreed');
+    expect(result.evidenceStateClause).toContain('decisions are recorded');
+    expect(result.evidenceStateClause).toContain('individuals are made accountable');
+    expect(result.evidenceStateClause).toContain('delivery or implementation is traceable');
+    expect(result.descriptors[0].descriptorText).not.toBe(
+      'Evidence that the DCC meets at least four times a year is absent, weak, outdated, inconsistent, fragmented, or person-dependent. Records do not yet show repeatable ownership, communication, execution, review, or reliable evidence retention.',
+    );
+  });
+});
+
 describe('T-MMM-DRGL-003 and T-MMM-DRGL-014: source mode and fallback reporting', () => {
   it('includes source mode and reports deterministic fallback when learning is unavailable', () => {
     const result = generateDescriptorReasoningResult({

--- a/modules/MMM/tests/B4-framework/descriptor-reasoning-learning-red.test.ts
+++ b/modules/MMM/tests/B4-framework/descriptor-reasoning-learning-red.test.ts
@@ -214,3 +214,41 @@ describe('T-MMM-DRGL-015: maturity levels remain distinct operating states', () 
     expect(new Set(result.descriptors.map((descriptor) => descriptor.descriptorText)).size).toBe(5);
   });
 });
+
+describe('T-MMM-DUIR-003: descriptor reasoning adapter yields ordered level drafts', () => {
+  it('maps reasoning output into Basic→Resilient level drafts (1-5)', () => {
+    const LEVEL_BY_LABEL = {
+      Basic: 1,
+      Reactive: 2,
+      Compliant: 3,
+      Proactive: 4,
+      Resilient: 5,
+    } as const;
+    const result = generateDescriptorReasoningResult({
+      tenantId: 'tenant-a',
+      criterionText: 'Review and approval of facility design changes for adequate Security measures.',
+      sourceMode: 'verbatim_source',
+    });
+
+    const drafts = ['Basic', 'Reactive', 'Compliant', 'Proactive', 'Resilient'].map((label) => {
+      const descriptor = result.descriptors.find((item) => item.level === label);
+      return {
+        level: LEVEL_BY_LABEL[label as keyof typeof LEVEL_BY_LABEL],
+        label,
+        descriptor_text: descriptor?.descriptorText ?? '',
+      };
+    });
+    expect(drafts).toHaveLength(5);
+    expect(drafts.map((draft) => draft.level)).toEqual([1, 2, 3, 4, 5]);
+    expect(drafts.map((draft) => draft.label)).toEqual([
+      'Basic',
+      'Reactive',
+      'Compliant',
+      'Proactive',
+      'Resilient',
+    ]);
+    drafts.forEach((draft) => {
+      expect(draft.descriptor_text.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/modules/MMM/tests/B4-framework/descriptor-reasoning-learning-red.test.ts
+++ b/modules/MMM/tests/B4-framework/descriptor-reasoning-learning-red.test.ts
@@ -216,7 +216,7 @@ describe('T-MMM-DRGL-015: maturity levels remain distinct operating states', () 
 });
 
 describe('T-MMM-DUIR-003: descriptor reasoning adapter yields ordered level drafts', () => {
-  it('maps reasoning output into Basic→Resilient level drafts (1-5)', () => {
+  it('maps reasoning output into Basic→Resilient level drafts (1-5)', async () => {
     const LEVEL_BY_LABEL = {
       Basic: 1,
       Reactive: 2,
@@ -224,20 +224,16 @@ describe('T-MMM-DUIR-003: descriptor reasoning adapter yields ordered level draf
       Proactive: 4,
       Resilient: 5,
     } as const;
+    const { descriptorReasoningDraftsFromResult } = await import(
+      '../../../../apps/mmm/src/components/assessment/CriteriaManagement'
+    );
     const result = generateDescriptorReasoningResult({
       tenantId: 'tenant-a',
       criterionText: 'Review and approval of facility design changes for adequate Security measures.',
       sourceMode: 'verbatim_source',
     });
 
-    const drafts = ['Basic', 'Reactive', 'Compliant', 'Proactive', 'Resilient'].map((label) => {
-      const descriptor = result.descriptors.find((item) => item.level === label);
-      return {
-        level: LEVEL_BY_LABEL[label as keyof typeof LEVEL_BY_LABEL],
-        label,
-        descriptor_text: descriptor?.descriptorText ?? '',
-      };
-    });
+    const drafts = descriptorReasoningDraftsFromResult(result);
     expect(drafts).toHaveLength(5);
     expect(drafts.map((draft) => draft.level)).toEqual([1, 2, 3, 4, 5]);
     expect(drafts.map((draft) => draft.label)).toEqual([


### PR DESCRIPTION
## Scope

Starts successor issue #1908 after CS2 live validation of MMM descriptor generation.

## Added so far

- `modules/MMM/05-qa-to-red/descriptor-ui-runtime-learning-replay-qa-to-red.md`
- Expanded `apps/mmm/src/lib/descriptorReasoning.ts` to preserve evidence-bearing secondary clauses.
- Expanded `modules/MMM/tests/B4-framework/descriptor-reasoning-learning-red.test.ts` with the DCC evidence-bundle case.
- Wired `apps/mmm/src/components/assessment/CriteriaManagement.tsx` so visible descriptor creation/regeneration now calls `generateDescriptorReasoningResult` before the AI/methodology fallback path.
- Added typed descriptor source-mode mapping and reasoning-to-draft adapter helpers in `CriteriaManagement.tsx` (including explicit Basic→Resilient level mapping 1–5).
- Kept existing AI/methodology generation as fallback only when the primary reasoning path throws.
- Added focused B4 assertions for descriptor UI wiring and adapter-level mapping coverage.

## Evidence summary

- UI descriptor generation now uses production descriptor reasoning first, then fallback if needed.
- Facility design live failure is covered via production reasoning output path (no `Evidence that Review and approval...` malformed lead-in on primary path).
- DCC evidence-bundle live failure is covered via preserved evidence-bearing clause handling on the production reasoning path.
- Learning replay is wired at call-path level via a typed helper; durable retrieval is not yet loaded in this component, and no fake/global memory was introduced.

## Non-scope confirmation

No ISMS public journey, subscription, authentication, onboarding, dashboard, PIT, RADAM, Risk, Incident, APW, Vercel workflow, `.github/agents`, global Subject Knowledge promotion, or unrelated schema migration work is included.