### PR TITLE
Add safe public chat route telemetry

### DIFF
--- a/.agent-admin/scope-declarations/apw-public-chat-route-telemetry-v01.md
+++ b/.agent-admin/scope-declarations/apw-public-chat-route-telemetry-v01.md
@@ -1,0 +1,47 @@
+SCOPE_SCHEMA_VERSION: v2
+PR_NUMBER: PENDING
+ISSUE: APW public chat route telemetry
+BRANCH: apw-public-chat-route-telemetry-v01
+OWNER: chatgpt-cs2-proxy
+DATE_UTC: 2026-07-07T15:10:00Z
+
+# Scope Declaration - APW Public Chat Route Telemetry v0.1
+
+## PR Responsibility Domain
+
+RESPONSIBILITY_DOMAIN: Add safe route telemetry for the APW public chat gateway so controlled-preview route evidence can be captured from Render logs.
+
+## Explicitly In Scope
+
+IN_SCOPE:
+- Add safe public-chat route telemetry logging.
+- Log route, page and history count only.
+- Add a test proving telemetry exists.
+- Add a test guard that prompt text and answer text are not logged.
+- Preserve Maturion as the final public response authority.
+
+## Explicitly Out of Scope
+
+OUT_OF_SCOPE:
+- Changing routing decisions.
+- Changing prompt handling.
+- Changing answer generation.
+- Logging prompt text.
+- Logging answer text.
+- Logging headers, cookies, tokens, credentials, IP addresses, tenant data, customer data, or user identity.
+- Environment setting changes.
+- Database or Supabase changes.
+- Registry changes.
+- Retrieval or embedding changes.
+- Agent contract changes.
+
+## FILES_CHANGED
+
+FILES_CHANGED: 3
+- `.agent-admin/scope-declarations/apw-public-chat-route-telemetry-v01.md`
+- `apps/mat-ai-gateway/routers/ai_routes.py`
+- `apps/mat-ai-gateway/tests/test_public_chat.py`
+
+## Evidence Boundary
+
+This PR only makes route evidence visible in service logs. It does not approve production activation or change APW Specialist routing behaviour.

--- a/.agent-admin/scope-declarations/apw-public-chat-route-telemetry-v01.md
+++ b/.agent-admin/scope-declarations/apw-public-chat-route-telemetry-v01.md
@@ -1,9 +1,9 @@
 SCOPE_SCHEMA_VERSION: v2
-PR_NUMBER: PENDING
-ISSUE: APW public chat route telemetry
+PR_NUMBER: 1913
+ISSUE: #1913 - Add safe public chat route telemetry
 BRANCH: apw-public-chat-route-telemetry-v01
 OWNER: chatgpt-cs2-proxy
-DATE_UTC: 2026-07-07T15:10:00Z
+DATE_UTC: 2026-07-08T10:10:00Z
 
 # Scope Declaration - APW Public Chat Route Telemetry v0.1
 
@@ -37,8 +37,9 @@ OUT_OF_SCOPE:
 
 ## FILES_CHANGED
 
-FILES_CHANGED: 3
+FILES_CHANGED: 4
 - `.agent-admin/scope-declarations/apw-public-chat-route-telemetry-v01.md`
+- `.agent-admin/scope-declarations/pr-1913.md`
 - `apps/mat-ai-gateway/routers/ai_routes.py`
 - `apps/mat-ai-gateway/tests/test_public_chat.py`
 

--- a/.agent-admin/scope-declarations/pr-1913.md
+++ b/.agent-admin/scope-declarations/pr-1913.md
@@ -1,0 +1,48 @@
+SCOPE_SCHEMA_VERSION: v2
+PR_NUMBER: 1913
+ISSUE: #1913 - Add safe public chat route telemetry
+BRANCH: apw-public-chat-route-telemetry-v01
+OWNER: chatgpt-cs2-proxy
+DATE_UTC: 2026-07-08T10:10:00Z
+
+# Scope Declaration - PR #1913
+
+## PR Responsibility Domain
+
+RESPONSIBILITY_DOMAIN: Safe telemetry instrumentation for APW public chat route evidence. This PR makes route evidence visible in Render logs without changing routing behaviour or logging sensitive content.
+
+## Explicitly In Scope
+
+IN_SCOPE:
+- Add route telemetry for successful public-chat responses.
+- Log only route, page and history count.
+- Add regression coverage for telemetry emission.
+- Add regression coverage that prompt text and answer text are not logged.
+- Support APW controlled-preview evidence capture.
+
+## Explicitly Out of Scope
+
+OUT_OF_SCOPE:
+- Routing decision changes.
+- Prompt handling changes.
+- Answer generation changes.
+- Environment changes.
+- Database or Supabase changes.
+- Registry changes.
+- Retrieval, vector or embedding changes.
+- Agent contract changes.
+- Logging prompt text.
+- Logging answer text.
+- Logging headers, cookies, tokens, credentials, IP addresses, tenant data, customer data or user identity.
+
+## FILES_CHANGED
+
+FILES_CHANGED: 4
+- `.agent-admin/scope-declarations/apw-public-chat-route-telemetry-v01.md`
+- `.agent-admin/scope-declarations/pr-1913.md`
+- `apps/mat-ai-gateway/routers/ai_routes.py`
+- `apps/mat-ai-gateway/tests/test_public_chat.py`
+
+## Evidence Boundary
+
+This PR supports controlled-preview evidence capture only. It is not production activation approval.

--- a/apps/mat-ai-gateway/routers/ai_routes.py
+++ b/apps/mat-ai-gateway/routers/ai_routes.py
@@ -23,6 +23,9 @@ from services.transcription import AudioTranscriber
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1", tags=["AI Services"])
 
+# ---------------------------------------------------------------------------
+# Module-level service singletons instantiated once and shared across requests
+# ---------------------------------------------------------------------------
 _parser = DocumentParser()
 _scorer = MaturityScorer()
 _transcriber = AudioTranscriber()
@@ -30,6 +33,10 @@ _generator = ReportGenerator()
 _analyser = ImageAnalyser()
 _public_chat = PublicChatService()
 
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
 
 class ParseRequest(BaseModel):
     document_url: str
@@ -39,6 +46,10 @@ class ParseRequest(BaseModel):
     @field_validator("user_instructions")
     @classmethod
     def escape_user_instructions(cls, v: str | None) -> str | None:
+        """
+        Escape angle brackets in user_instructions to prevent breaking
+        surrounding instructions wrappers downstream.
+        """
         if v is None:
             return v
         return v.replace("<", "&lt;").replace(">", "&gt;")
@@ -84,8 +95,17 @@ class PublicChatRequest(BaseModel):
         return cleaned
 
 
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
 @router.post("/parse")
 def parse_document(request: ParseRequest) -> dict:
+    """
+    Document Parsing: converts PDF/DOCX criteria into structured JSON.
+
+    Architecture: system-architecture.md section 3.4
+    """
     return _parser.parse(
         document_url=request.document_url,
         tenant_id=request.tenant_id,
@@ -95,6 +115,11 @@ def parse_document(request: ParseRequest) -> dict:
 
 @router.post("/score")
 def score_maturity(request: ScoreRequest) -> dict:
+    """
+    Maturity Scoring: derives maturity level from evidence and criteria.
+
+    Architecture: system-architecture.md section 3.4
+    """
     if request.evidence is None:
         evidence: list[Union[str, dict]] = []
     elif isinstance(request.evidence, list):
@@ -113,6 +138,11 @@ def score_maturity(request: ScoreRequest) -> dict:
 
 @router.post("/transcribe")
 def transcribe_audio(request: TranscribeRequest) -> dict:
+    """
+    Audio Transcription: converts audio recording to timestamped transcript.
+
+    Architecture: system-architecture.md section 3.4
+    """
     return _transcriber.transcribe(
         audio_url=request.audio_url,
         tenant_id=request.tenant_id,
@@ -121,6 +151,11 @@ def transcribe_audio(request: TranscribeRequest) -> dict:
 
 @router.post("/report")
 def generate_report(request: ReportRequest) -> dict:
+    """
+    Report Generation: produces DOCX/PDF/JSON audit report.
+
+    Architecture: system-architecture.md section 3.4
+    """
     audit_data = request.audit_data or {"audit_id": request.audit_id}
     return _generator.generate(
         audit_data=audit_data,
@@ -131,6 +166,11 @@ def generate_report(request: ReportRequest) -> dict:
 
 @router.post("/analyse-image")
 def analyse_image(request: AnalyseImageRequest) -> dict:
+    """
+    Image Analysis: extracts compliance description from photo evidence.
+
+    Architecture: system-architecture.md section 3.4
+    """
     return _analyser.analyse(
         image_url=request.image_url,
         tenant_id=request.tenant_id,
@@ -139,6 +179,7 @@ def analyse_image(request: AnalyseImageRequest) -> dict:
 
 @router.post("/public-chat")
 def public_chat(request: PublicChatRequest) -> dict:
+    """Public Maturion chat endpoint for the APW public website."""
     try:
         result = _public_chat.answer(
             message=request.message,

--- a/apps/mat-ai-gateway/routers/ai_routes.py
+++ b/apps/mat-ai-gateway/routers/ai_routes.py
@@ -1,7 +1,7 @@
 """
-routers/ai_routes.py - AI Gateway route definitions.
+routers/ai_routes.py — AI Gateway route definitions.
 
-Architecture reference: modules/mat/02-architecture/system-architecture.md section 3.3
+Architecture reference: modules/mat/02-architecture/system-architecture.md §3.3
   Five AI service endpoints exposed by the MAT AI Gateway.
 """
 
@@ -20,11 +20,11 @@ from services.reporting import ReportGenerator
 from services.scoring import MaturityScorer
 from services.transcription import AudioTranscriber
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn.error")
 router = APIRouter(prefix="/api/v1", tags=["AI Services"])
 
 # ---------------------------------------------------------------------------
-# Module-level service singletons instantiated once and shared across requests
+# Module-level service singletons — instantiated once, shared across requests
 # ---------------------------------------------------------------------------
 _parser = DocumentParser()
 _scorer = MaturityScorer()
@@ -48,7 +48,7 @@ class ParseRequest(BaseModel):
     def escape_user_instructions(cls, v: str | None) -> str | None:
         """
         Escape angle brackets in user_instructions to prevent breaking
-        surrounding instructions wrappers downstream.
+        surrounding <instructions>...</instructions> wrappers downstream.
         """
         if v is None:
             return v
@@ -102,9 +102,9 @@ class PublicChatRequest(BaseModel):
 @router.post("/parse")
 def parse_document(request: ParseRequest) -> dict:
     """
-    Document Parsing: converts PDF/DOCX criteria into structured JSON.
+    Document Parsing — converts PDF/DOCX criteria into structured JSON.
 
-    Architecture: system-architecture.md section 3.4
+    Architecture: system-architecture.md §3.4
     """
     return _parser.parse(
         document_url=request.document_url,
@@ -116,9 +116,9 @@ def parse_document(request: ParseRequest) -> dict:
 @router.post("/score")
 def score_maturity(request: ScoreRequest) -> dict:
     """
-    Maturity Scoring: derives maturity level from evidence and criteria.
+    Maturity Scoring — derives maturity level from evidence and criteria.
 
-    Architecture: system-architecture.md section 3.4
+    Architecture: system-architecture.md §3.4
     """
     if request.evidence is None:
         evidence: list[Union[str, dict]] = []
@@ -139,9 +139,9 @@ def score_maturity(request: ScoreRequest) -> dict:
 @router.post("/transcribe")
 def transcribe_audio(request: TranscribeRequest) -> dict:
     """
-    Audio Transcription: converts audio recording to timestamped transcript.
+    Audio Transcription — converts audio recording to timestamped transcript.
 
-    Architecture: system-architecture.md section 3.4
+    Architecture: system-architecture.md §3.4
     """
     return _transcriber.transcribe(
         audio_url=request.audio_url,
@@ -152,9 +152,9 @@ def transcribe_audio(request: TranscribeRequest) -> dict:
 @router.post("/report")
 def generate_report(request: ReportRequest) -> dict:
     """
-    Report Generation: produces DOCX/PDF/JSON audit report.
+    Report Generation — produces DOCX/PDF/JSON audit report.
 
-    Architecture: system-architecture.md section 3.4
+    Architecture: system-architecture.md §3.4
     """
     audit_data = request.audit_data or {"audit_id": request.audit_id}
     return _generator.generate(
@@ -167,9 +167,9 @@ def generate_report(request: ReportRequest) -> dict:
 @router.post("/analyse-image")
 def analyse_image(request: AnalyseImageRequest) -> dict:
     """
-    Image Analysis: extracts compliance description from photo evidence.
+    Image Analysis — extracts compliance description from photo evidence.
 
-    Architecture: system-architecture.md section 3.4
+    Architecture: system-architecture.md §3.4
     """
     return _analyser.analyse(
         image_url=request.image_url,

--- a/apps/mat-ai-gateway/routers/ai_routes.py
+++ b/apps/mat-ai-gateway/routers/ai_routes.py
@@ -1,12 +1,13 @@
 """
-routers/ai_routes.py — AI Gateway route definitions.
+routers/ai_routes.py - AI Gateway route definitions.
 
-Architecture reference: modules/mat/02-architecture/system-architecture.md §3.3
+Architecture reference: modules/mat/02-architecture/system-architecture.md section 3.3
   Five AI service endpoints exposed by the MAT AI Gateway.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Union
 
 from fastapi import APIRouter, HTTPException
@@ -19,11 +20,9 @@ from services.reporting import ReportGenerator
 from services.scoring import MaturityScorer
 from services.transcription import AudioTranscriber
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1", tags=["AI Services"])
 
-# ---------------------------------------------------------------------------
-# Module-level service singletons — instantiated once, shared across requests
-# ---------------------------------------------------------------------------
 _parser = DocumentParser()
 _scorer = MaturityScorer()
 _transcriber = AudioTranscriber()
@@ -31,10 +30,6 @@ _generator = ReportGenerator()
 _analyser = ImageAnalyser()
 _public_chat = PublicChatService()
 
-
-# ---------------------------------------------------------------------------
-# Request models
-# ---------------------------------------------------------------------------
 
 class ParseRequest(BaseModel):
     document_url: str
@@ -44,10 +39,6 @@ class ParseRequest(BaseModel):
     @field_validator("user_instructions")
     @classmethod
     def escape_user_instructions(cls, v: str | None) -> str | None:
-        """
-        Escape angle brackets in user_instructions to prevent breaking
-        surrounding <instructions>...</instructions> wrappers downstream.
-        """
         if v is None:
             return v
         return v.replace("<", "&lt;").replace(">", "&gt;")
@@ -93,17 +84,8 @@ class PublicChatRequest(BaseModel):
         return cleaned
 
 
-# ---------------------------------------------------------------------------
-# Routes
-# ---------------------------------------------------------------------------
-
 @router.post("/parse")
 def parse_document(request: ParseRequest) -> dict:
-    """
-    Document Parsing — converts PDF/DOCX criteria into structured JSON.
-
-    Architecture: system-architecture.md §3.4
-    """
     return _parser.parse(
         document_url=request.document_url,
         tenant_id=request.tenant_id,
@@ -113,11 +95,6 @@ def parse_document(request: ParseRequest) -> dict:
 
 @router.post("/score")
 def score_maturity(request: ScoreRequest) -> dict:
-    """
-    Maturity Scoring — derives maturity level from evidence and criteria.
-
-    Architecture: system-architecture.md §3.4
-    """
     if request.evidence is None:
         evidence: list[Union[str, dict]] = []
     elif isinstance(request.evidence, list):
@@ -136,11 +113,6 @@ def score_maturity(request: ScoreRequest) -> dict:
 
 @router.post("/transcribe")
 def transcribe_audio(request: TranscribeRequest) -> dict:
-    """
-    Audio Transcription — converts audio recording to timestamped transcript.
-
-    Architecture: system-architecture.md §3.4
-    """
     return _transcriber.transcribe(
         audio_url=request.audio_url,
         tenant_id=request.tenant_id,
@@ -149,11 +121,6 @@ def transcribe_audio(request: TranscribeRequest) -> dict:
 
 @router.post("/report")
 def generate_report(request: ReportRequest) -> dict:
-    """
-    Report Generation — produces DOCX/PDF/JSON audit report.
-
-    Architecture: system-architecture.md §3.4
-    """
     audit_data = request.audit_data or {"audit_id": request.audit_id}
     return _generator.generate(
         audit_data=audit_data,
@@ -164,11 +131,6 @@ def generate_report(request: ReportRequest) -> dict:
 
 @router.post("/analyse-image")
 def analyse_image(request: AnalyseImageRequest) -> dict:
-    """
-    Image Analysis — extracts compliance description from photo evidence.
-
-    Architecture: system-architecture.md §3.4
-    """
     return _analyser.analyse(
         image_url=request.image_url,
         tenant_id=request.tenant_id,
@@ -177,13 +139,19 @@ def analyse_image(request: AnalyseImageRequest) -> dict:
 
 @router.post("/public-chat")
 def public_chat(request: PublicChatRequest) -> dict:
-    """Public Maturion chat endpoint for the APW public website."""
     try:
-        return _public_chat.answer(
+        result = _public_chat.answer(
             message=request.message,
             history=request.history,
             context=request.context,
         )
+        logger.info(
+            "public_chat_route route=%s page=%s history_count=%s",
+            result.get("apw_specialist_route"),
+            result.get("page"),
+            result.get("history_count"),
+        )
+        return result
     except (RuntimeError, KeyError) as exc:
         raise HTTPException(
             status_code=502,

--- a/apps/mat-ai-gateway/tests/test_public_chat.py
+++ b/apps/mat-ai-gateway/tests/test_public_chat.py
@@ -78,7 +78,7 @@ def test_public_chat_does_not_use_apw_route_for_private_request(test_client, mon
 
 def test_public_chat_logs_safe_route_telemetry(test_client, monkeypatch, caplog):
     monkeypatch.setenv(APW_FLAG, "true")
-    caplog.set_level(logging.INFO, logger="apps.mat-ai-gateway.routers.ai_routes")
+    caplog.set_level(logging.INFO, logger="routers.ai_routes")
 
     response = test_client.post(
         "/api/v1/public-chat",

--- a/apps/mat-ai-gateway/tests/test_public_chat.py
+++ b/apps/mat-ai-gateway/tests/test_public_chat.py
@@ -78,7 +78,7 @@ def test_public_chat_does_not_use_apw_route_for_private_request(test_client, mon
 
 def test_public_chat_logs_safe_route_telemetry(test_client, monkeypatch, caplog):
     monkeypatch.setenv(APW_FLAG, "true")
-    caplog.set_level(logging.INFO, logger="routers.ai_routes")
+    caplog.set_level(logging.INFO, logger="uvicorn.error")
 
     response = test_client.post(
         "/api/v1/public-chat",
@@ -94,5 +94,6 @@ def test_public_chat_logs_safe_route_telemetry(test_client, monkeypatch, caplog)
     assert "public_chat_route" in log_text
     assert "apw_specialist_internal_draft_candidate" in log_text
     assert "page=/apw" in log_text
+    assert "history_count=0" in log_text
     assert "How does APW onboarding work?" not in log_text
     assert response.json()["answer"] not in log_text

--- a/apps/mat-ai-gateway/tests/test_public_chat.py
+++ b/apps/mat-ai-gateway/tests/test_public_chat.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 
 APW_FLAG = "APW_SPECIALIST_PUBLIC_INTEGRATION_ENABLED"
 
@@ -72,3 +74,25 @@ def test_public_chat_does_not_use_apw_route_for_private_request(test_client, mon
     assert body["source"] == "maturion-public-chat"
     assert body["apw_specialist_route"] == "maturion_only"
     assert "Maturion final answer" not in body["answer"]
+
+
+def test_public_chat_logs_safe_route_telemetry(test_client, monkeypatch, caplog):
+    monkeypatch.setenv(APW_FLAG, "true")
+    caplog.set_level(logging.INFO, logger="apps.mat-ai-gateway.routers.ai_routes")
+
+    response = test_client.post(
+        "/api/v1/public-chat",
+        json={
+            "message": "How does APW onboarding work?",
+            "history": [],
+            "context": {"source": "apw-public-website", "page": "/apw"},
+        },
+    )
+
+    assert response.status_code == 200
+    log_text = caplog.text
+    assert "public_chat_route" in log_text
+    assert "apw_specialist_internal_draft_candidate" in log_text
+    assert "page=/apw" in log_text
+    assert "How does APW onboarding work?" not in log_text
+    assert response.json()["answer"] not in log_text


### PR DESCRIPTION
## Summary

Adds safe route telemetry for the public Maturion chat endpoint so the APW controlled-preview evidence record can capture internal route behaviour from Render logs.

## Changes

- Adds a `public_chat_route` log line after successful `/api/v1/public-chat` responses.
- Logs only safe metadata:
  - `apw_specialist_route`
  - `page`
  - `history_count`
- Adds a regression test proving telemetry is emitted.
- Adds a regression guard proving prompt text and answer text are not logged.
- Adds a scoped governance declaration for the telemetry wave.

## Boundaries

- No routing decision changes.
- No prompt handling changes.
- No answer-generation changes.
- No environment changes.
- No Supabase/database changes.
- No registry changes.
- No retrieval/vector/embedding changes.
- No agent contract changes.
- Does not log prompt text.
- Does not log answer text.
- Does not log headers, cookies, tokens, credentials, IP addresses, tenant data, customer data or user identity.

## Expected Render evidence after deployment

A successful public-chat request should emit a safe log line similar to:

```text
public_chat_route route=apw_specialist_internal_draft_candidate page=/ history_count=0
```

Restricted prompts should produce route evidence such as:

```text
public_chat_route route=maturion_only page=/ history_count=0
```

Rollback/flag-disabled proof should produce:

```text
public_chat_route route=apw_integration_disabled page=/ history_count=0
```

## Evidence purpose

This PR supports evidence capture only. It does not approve production activation or alter APW Specialist behaviour.