### PR TITLE
Draft: Issue 1914 MMM descriptor learning persistence replay

### DIFF
--- a/.agent-admin/builder-appointments/wave-mmm-descriptor-learning-persistence-replay-2026-07-09.md
+++ b/.agent-admin/builder-appointments/wave-mmm-descriptor-learning-persistence-replay-2026-07-09.md
@@ -1,0 +1,38 @@
+# Builder Appointment - MMM Descriptor Learning Persistence and Replay
+
+Issue: #1914
+Wave: wave-mmm-descriptor-learning-persistence-replay-2026-07-09
+Builder: ui-builder
+Status: appointed for bounded implementation after merged QA-to-red PR #1915
+
+## Scope
+
+Implement governed descriptor-learning persistence and replay for MMM maturity descriptors.
+
+The implementation must teach reusable reasoning patterns from consented descriptor edits, not hard-code one criterion or copy/paste one descriptor.
+
+## Authorised areas
+
+- `apps/mmm/src/components/assessment/CriteriaManagement.tsx`
+- `apps/mmm/src/lib/descriptorReasoning.ts`
+- `apps/mmm/src/lib/descriptorLearningRetrieval.ts`
+- `apps/mmm/src/lib/descriptorLearningPersistence.ts`
+- `supabase/functions/mmm-level-descriptor-save/index.ts`
+- focused MMM tests
+
+## Anti-hard-coding instruction
+
+Do not hard-code criterion code `D001.MPS002.C017`, the acronym `DCC`, exact screenshot text, or one corrected descriptor copied into all five levels.
+
+## Required evidence
+
+- accepted consent persists scoped learning metadata;
+- declined consent does not persist reusable learning;
+- same-criterion regeneration can apply learning;
+- similar-criterion regeneration applies only valid scoped learning;
+- all five maturity levels are influenced by learned evidence subject without copying one level;
+- tenant isolation and conflict exclusion remain enforced.
+
+## Non-scope
+
+No ISMS public journey, subscription/auth/onboarding/dashboard, PIT/RADAM/Risk/Incident/APW, Vercel workflow, `.github/agents`, global Subject Knowledge promotion, or unrelated schema work.

--- a/.agent-admin/control/delegation-orders/pr-1918.json
+++ b/.agent-admin/control/delegation-orders/pr-1918.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "1.0.0",
+  "wave_id": "wave-mmm-descriptor-learning-persistence-replay-2026-07-09",
+  "pr_number": 1918,
+  "prebrief_commit_sha": "8a03650cac2098ece2a496813a6aa3c384673c03",
+  "builder_appointment_timestamp": "2026-07-10T10:26:22Z",
+  "builder_appointment_commit_sha": "333665b5b734496090e8359a093bcb3046861e4c",
+  "builder_agent": "ui-builder",
+  "builder_task_ref": ".agent-admin/builder-appointments/wave-mmm-descriptor-learning-persistence-replay-2026-07-09.md",
+  "first_implementation_commit_sha": "b396dc30c2b07fc51305b900d5949cfd922f4961",
+  "qp_review_timestamp": "2026-07-10T12:22:00Z",
+  "result": "DELEGATION_ORDER_VERIFIED"
+}

--- a/apps/mmm/src/components/assessment/CriteriaManagement.tsx
+++ b/apps/mmm/src/components/assessment/CriteriaManagement.tsx
@@ -1712,7 +1712,7 @@ export function CriteriaManagement({
         }
         const descriptorSourceMode = toDescriptorSourceMode(descriptorModeContext.framework_source_type);
 
-        // Load persisted descriptor-learning interactions for this tenant/framework scope.
+        // Load persisted descriptor-learning interactions for this framework/domain scoped context.
         // If retrieval fails, fall back to an empty learning array so deterministic generation still runs.
         let learningRecords: DescriptorLearningRecord[] = [];
         try {
@@ -1723,12 +1723,12 @@ export function CriteriaManagement({
             .eq('status', 'recorded')
             .order('created_at', { ascending: false })
             .limit(50);
-          const tenantContextId = frameworkId ?? domainId;
+          const contextScopeId = frameworkId ?? domainId;
           const mappedLearningRecords = descriptorLearningRecordsFromInteractions(learningRows ?? []);
           learningRecords = mappedLearningRecords.filter((record) => {
             const isSameCriterion = record.criterionId === criterion.id;
             const isSameFramework = Boolean(frameworkId) && record.frameworkId === frameworkId;
-            return record.tenantId === tenantContextId && (isSameCriterion || isSameFramework);
+            return record.tenantId === contextScopeId && (isSameCriterion || isSameFramework);
           });
         } catch (learningRetrievalError) {
           // Retrieval failure: generate deterministically with an empty learning array.

--- a/apps/mmm/src/components/assessment/CriteriaManagement.tsx
+++ b/apps/mmm/src/components/assessment/CriteriaManagement.tsx
@@ -1716,27 +1716,15 @@ export function CriteriaManagement({
         // If retrieval fails, fall back to an empty learning array so deterministic generation still runs.
         let learningRecords: DescriptorLearningRecord[] = [];
         try {
-          const learningSelection = supabase
+          const { data: learningRows } = await supabase
             .from('mmm_ai_interactions')
-            .select('id,target_entity_id,status,created_at,request_json,response_json');
-          const contextScopedLearning = learningSelection.eq('context_type', 'MATURITY_DESCRIPTOR_EDIT');
-          const statusScopedLearning =
-            typeof contextScopedLearning.eq === 'function'
-              ? contextScopedLearning.eq('status', 'recorded')
-              : contextScopedLearning;
-          const orderedLearning =
-            typeof statusScopedLearning.order === 'function'
-              ? statusScopedLearning.order('created_at', { ascending: false })
-              : statusScopedLearning;
-          const boundedLearning =
-            typeof orderedLearning.limit === 'function' ? orderedLearning.limit(50) : orderedLearning;
-          const { data: learningRows } = await boundedLearning;
+            .select('id,target_entity_id,status,created_at,request_json,response_json')
+            .eq('context_type', 'MATURITY_DESCRIPTOR_EDIT')
+            .eq('status', 'recorded')
+            .order('created_at', { ascending: false })
+            .limit(50);
           const tenantContextId = frameworkId ?? domainId;
-          const mappedLearningRecords = descriptorLearningRecordsFromInteractions(
-            (learningRows ?? []).filter(
-              (row) => row && typeof row === 'object' && (row as { status?: string }).status === 'recorded',
-            ),
-          );
+          const mappedLearningRecords = descriptorLearningRecordsFromInteractions(learningRows ?? []);
           learningRecords = mappedLearningRecords.filter((record) => {
             const isSameCriterion = record.criterionId === criterion.id;
             const isSameFramework = Boolean(frameworkId) && record.frameworkId === frameworkId;

--- a/apps/mmm/src/components/assessment/CriteriaManagement.tsx
+++ b/apps/mmm/src/components/assessment/CriteriaManagement.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../lib/verbatimCriteriaExtraction';
 import { generateDescriptorReasoningResult } from '../../lib/descriptorReasoning';
 import type { DescriptorLearningRecord, DescriptorSourceMode } from '../../lib/descriptorLearningRetrieval';
+import { descriptorLearningRecordsFromInteractions } from '../../lib/descriptorLearningPersistence';
 
 export interface GeneratedCriterionItem {
   code: string;
@@ -241,12 +242,6 @@ export function descriptorReasoningDraftsFromResult(
       descriptor_text: descriptor?.descriptorText ?? '',
     };
   });
-}
-
-function buildDescriptorLearningRecordsForCriterion(): DescriptorLearningRecord[] {
-  // Descriptor learning retrieval is not yet loaded in this component state.
-  // Keep the adapter typed so runtime learning replay can be wired once records are available.
-  return [];
 }
 
 const DESCRIPTOR_CONTROL_OBJECTS: DescriptorControlObject[] = [
@@ -1716,6 +1711,25 @@ export function CriteriaManagement({
           descriptorModeContext = await resolveModeSourceContext(frameworkId);
         }
         const descriptorSourceMode = toDescriptorSourceMode(descriptorModeContext.framework_source_type);
+
+        // Load persisted descriptor-learning interactions for this criterion (tenant-safe).
+        // If retrieval fails, fall back to an empty learning array so deterministic generation still runs.
+        let learningRecords: DescriptorLearningRecord[] = [];
+        try {
+          const { data: learningRows } = await supabase
+            .from('mmm_ai_interactions')
+            .select('id,target_entity_id,status,created_at,request_json,response_json')
+            .eq('context_type', 'MATURITY_DESCRIPTOR_EDIT')
+            .eq('status', 'recorded')
+            .eq('target_entity_id', criterion.id)
+            .order('created_at', { ascending: false })
+            .limit(20);
+          learningRecords = descriptorLearningRecordsFromInteractions(learningRows ?? []);
+        } catch (learningRetrievalError) {
+          // Retrieval failure: generate deterministically with an empty learning array.
+          console.error('[CriteriaManagement] Failed to load descriptor learning records:', learningRetrievalError);
+        }
+
         const reasoningResult = generateDescriptorReasoningResult({
           // In MMM descriptor UI flow, framework/domain scope currently acts as the tenant-bound context key.
           // When no framework exists yet, domainId keeps descriptor learning retrieval scoped to the same active tenant workspace.
@@ -1726,7 +1740,7 @@ export function CriteriaManagement({
           criterionText: activeCriterionText,
           domainName,
           sourceMode: descriptorSourceMode,
-          learningRecords: buildDescriptorLearningRecordsForCriterion(),
+          learningRecords,
         });
         const reasoningDrafts = validateMaturityDescriptorDrafts(
           activeCriterionText,

--- a/apps/mmm/src/components/assessment/CriteriaManagement.tsx
+++ b/apps/mmm/src/components/assessment/CriteriaManagement.tsx
@@ -1712,19 +1712,36 @@ export function CriteriaManagement({
         }
         const descriptorSourceMode = toDescriptorSourceMode(descriptorModeContext.framework_source_type);
 
-        // Load persisted descriptor-learning interactions for this criterion (tenant-safe).
+        // Load persisted descriptor-learning interactions for this tenant/framework scope.
         // If retrieval fails, fall back to an empty learning array so deterministic generation still runs.
         let learningRecords: DescriptorLearningRecord[] = [];
         try {
-          const { data: learningRows } = await supabase
+          const learningSelection = supabase
             .from('mmm_ai_interactions')
-            .select('id,target_entity_id,status,created_at,request_json,response_json')
-            .eq('context_type', 'MATURITY_DESCRIPTOR_EDIT')
-            .eq('status', 'recorded')
-            .eq('target_entity_id', criterion.id)
-            .order('created_at', { ascending: false })
-            .limit(20);
-          learningRecords = descriptorLearningRecordsFromInteractions(learningRows ?? []);
+            .select('id,target_entity_id,status,created_at,request_json,response_json');
+          const contextScopedLearning = learningSelection.eq('context_type', 'MATURITY_DESCRIPTOR_EDIT');
+          const statusScopedLearning =
+            typeof contextScopedLearning.eq === 'function'
+              ? contextScopedLearning.eq('status', 'recorded')
+              : contextScopedLearning;
+          const orderedLearning =
+            typeof statusScopedLearning.order === 'function'
+              ? statusScopedLearning.order('created_at', { ascending: false })
+              : statusScopedLearning;
+          const boundedLearning =
+            typeof orderedLearning.limit === 'function' ? orderedLearning.limit(50) : orderedLearning;
+          const { data: learningRows } = await boundedLearning;
+          const tenantContextId = frameworkId ?? domainId;
+          const mappedLearningRecords = descriptorLearningRecordsFromInteractions(
+            (learningRows ?? []).filter(
+              (row) => row && typeof row === 'object' && (row as { status?: string }).status === 'recorded',
+            ),
+          );
+          learningRecords = mappedLearningRecords.filter((record) => {
+            const isSameCriterion = record.criterionId === criterion.id;
+            const isSameFramework = Boolean(frameworkId) && record.frameworkId === frameworkId;
+            return record.tenantId === tenantContextId && (isSameCriterion || isSameFramework);
+          });
         } catch (learningRetrievalError) {
           // Retrieval failure: generate deterministically with an empty learning array.
           console.error('[CriteriaManagement] Failed to load descriptor learning records:', learningRetrievalError);

--- a/apps/mmm/src/lib/descriptorLearningPersistence.ts
+++ b/apps/mmm/src/lib/descriptorLearningPersistence.ts
@@ -1,0 +1,81 @@
+import type { DescriptorLearningRecord, DescriptorSourceMode } from './descriptorLearningRetrieval';
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as UnknownRecord) : {};
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function asNumber(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeSourceMode(value: unknown): DescriptorSourceMode | null {
+  if (value === 'verbatim_source' || value === 'VERBATIM') return 'verbatim_source';
+  if (value === 'hybrid_source' || value === 'HYBRID') return 'hybrid_source';
+  if (value === 'new_generation_context' || value === 'GENERATED') return 'new_generation_context';
+  return null;
+}
+
+export type DescriptorLearningInteractionRow = {
+  id?: string | null;
+  target_entity_id?: string | null;
+  status?: string | null;
+  created_at?: string | null;
+  request_json?: unknown;
+  response_json?: unknown;
+};
+
+export function descriptorLearningRecordsFromInteractions(
+  rows: DescriptorLearningInteractionRow[],
+): DescriptorLearningRecord[] {
+  return rows.flatMap((row) => {
+    const request = asRecord(row.request_json);
+    const response = asRecord(row.response_json);
+    const learningEvents = Array.isArray(request.learning_events) ? request.learning_events : [];
+    const tenantId = asString(request.tenant_id) ?? asString(request.organisation_id);
+    if (!tenantId) return [];
+
+    return learningEvents.map((event, index) => {
+      const learningEvent = asRecord(event);
+      const sourceMode = normalizeSourceMode(request.source_mode);
+      const criterionText = asString(request.criterion_text);
+      const inferredGrammarShape = criterionText
+        ? /\bminutes\b/i.test(criterionText) && /\bactions\b/i.test(criterionText) && /\bdecisions\b/i.test(criterionText)
+          ? 'evidence_bundle_minutes_actions_decisions'
+          : /^Review and approval of\b/i.test(criterionText)
+            ? 'nominal_review_and_approval'
+            : null
+        : null;
+
+      return {
+        id: `${row.id ?? row.target_entity_id ?? 'descriptor-learning'}:${index}`,
+        tenantId,
+        frameworkId: asString(request.framework_id),
+        criterionId: asString(request.criterion_id) ?? row.target_entity_id ?? null,
+        criterionCode: asString(request.criterion_code),
+        sourceMode,
+        grammarShape: asString(request.grammar_shape) ?? inferredGrammarShape,
+        reuseScope: asString(response.reuse_scope) ?? 'tenant_specific_pattern',
+        reviewStatus: asString(response.review_status) ?? (row.status === 'recorded' ? 'validated' : 'active'),
+        conflictStatus: asString(response.conflict_status) ?? 'none',
+        reuseSuccessCount: asNumber(response.reuse_success_count) ?? 0,
+        createdAt: asString(row.created_at),
+        originalCriterionText: criterionText,
+        originalGeneratedDescriptorText: asString(learningEvent.original_generated_descriptor_text),
+        userCorrectedDescriptorText: asString(learningEvent.user_corrected_descriptor_text),
+        maturityLevelCorrected: asNumber(learningEvent.level),
+        correctionCategory: asString(learningEvent.correction_category),
+        transformationSummary: asString(learningEvent.transformation_summary),
+        reusablePatternCandidateText: asString(learningEvent.reusable_pattern_candidate_text),
+        learnedEvidenceSubject: asString(learningEvent.learned_evidence_subject),
+        consentedAt: asString(response.consented_at),
+      } satisfies DescriptorLearningRecord;
+    });
+  });
+}

--- a/apps/mmm/src/lib/descriptorLearningRetrieval.ts
+++ b/apps/mmm/src/lib/descriptorLearningRetrieval.ts
@@ -5,6 +5,7 @@ export type DescriptorLearningRecord = {
   tenantId: string;
   frameworkId?: string | null;
   criterionId?: string | null;
+  criterionCode?: string | null;
   sourceMode?: DescriptorSourceMode | string | null;
   grammarShape?: string | null;
   reuseScope: string;
@@ -12,20 +13,83 @@ export type DescriptorLearningRecord = {
   conflictStatus?: string | null;
   reuseSuccessCount?: number | null;
   createdAt?: string | null;
+  originalCriterionText?: string | null;
+  originalGeneratedDescriptorText?: string | null;
+  userCorrectedDescriptorText?: string | null;
+  maturityLevelCorrected?: number | null;
+  correctionCategory?: string | null;
+  transformationSummary?: string | null;
+  reusablePatternCandidateText?: string | null;
+  learnedEvidenceSubject?: string | null;
+  consentedAt?: string | null;
 };
 
 export type DescriptorLearningRetrievalContext = {
   tenantId: string;
   frameworkId?: string | null;
   criterionId?: string | null;
+  criterionCode?: string | null;
   sourceMode: DescriptorSourceMode;
   grammarShape?: string | null;
+  criterionText?: string | null;
 };
 
 export type RankedDescriptorLearningRecord = DescriptorLearningRecord & {
   retrievalScore: number;
   retrievalReason: string;
 };
+
+function tokenize(value?: string | null): Set<string> {
+  return new Set(
+    String(value ?? '')
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]+/g, ' ')
+      .split(/\s+/)
+      .filter((token) => token.length > 3),
+  );
+}
+
+function tokenOverlap(left?: string | null, right?: string | null): number {
+  const leftTokens = tokenize(left);
+  const rightTokens = tokenize(right);
+  if (leftTokens.size === 0 || rightTokens.size === 0) return 0;
+  let overlap = 0;
+  leftTokens.forEach((token) => {
+    if (rightTokens.has(token)) overlap += 1;
+  });
+  return overlap / Math.max(leftTokens.size, rightTokens.size);
+}
+
+export function extractEvidenceSubjectFromDescriptor(descriptorText?: string | null): string | null {
+  const text = String(descriptorText ?? '').replace(/\s+/g, ' ').trim();
+  if (!text) return null;
+
+  const patterns = [
+    /^Evidence that\s+(.+?)\s+is absent, weak, outdated, inconsistent, fragmented, or person-dependent\b/i,
+    /^Evidence that\s+(.+?)\s+exists in some form\b/i,
+    /^Evidence that\s+(.+?)\s+is current, complete, traceable\b/i,
+    /^Evidence that\s+(.+?)\s+shows owner-led\b/i,
+    /^Evidence that\s+(.+?)\s+is embedded\b/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match?.[1]) return match[1].trim().replace(/[.;:,]+$/g, '');
+  }
+
+  const generic = text.match(/^Evidence that\s+(.+?)\s+(?:is|are|exists|shows)\b/i);
+  if (generic?.[1]) return generic[1].trim().replace(/[.;:,]+$/g, '');
+
+  return null;
+}
+
+export function getLearnedEvidenceSubject(record: DescriptorLearningRecord): string | null {
+  return (
+    record.learnedEvidenceSubject?.trim() ||
+    extractEvidenceSubjectFromDescriptor(record.userCorrectedDescriptorText) ||
+    null
+  );
+}
 
 export function canUseDescriptorLearningRecordForTenant(
   record: DescriptorLearningRecord,
@@ -78,6 +142,11 @@ export function rankDescriptorLearningRecord(
     reasons.push('same-criterion');
   }
 
+  if (record.criterionCode && context.criterionCode && record.criterionCode === context.criterionCode) {
+    retrievalScore += 20;
+    reasons.push('same-criterion-code');
+  }
+
   if (record.frameworkId && context.frameworkId && record.frameworkId === context.frameworkId) {
     retrievalScore += 25;
     reasons.push('same-framework');
@@ -89,12 +158,23 @@ export function rankDescriptorLearningRecord(
   }
 
   if (record.grammarShape && context.grammarShape && record.grammarShape === context.grammarShape) {
-    retrievalScore += 15;
+    retrievalScore += 20;
     reasons.push('same-grammar-shape');
   }
 
+  const similarity = tokenOverlap(record.originalCriterionText, context.criterionText);
+  if (similarity >= 0.34) {
+    retrievalScore += Math.round(similarity * 30);
+    reasons.push('criterion-similarity');
+  }
+
+  if (getLearnedEvidenceSubject(record)) {
+    retrievalScore += 12;
+    reasons.push('learned-evidence-subject');
+  }
+
   retrievalScore += Math.min(record.reuseSuccessCount ?? 0, 10);
-  retrievalScore += freshnessScore(record.createdAt);
+  retrievalScore += freshnessScore(record.createdAt ?? record.consentedAt);
 
   return {
     ...record,

--- a/apps/mmm/src/lib/descriptorReasoning.ts
+++ b/apps/mmm/src/lib/descriptorReasoning.ts
@@ -1,4 +1,5 @@
 import {
+  getLearnedEvidenceSubject,
   retrieveDescriptorLearningRecords,
   type DescriptorLearningRecord,
   type DescriptorLearningRetrievalContext,
@@ -198,15 +199,28 @@ function buildRetrievalContext(context: DescriptorGenerationContext): Descriptor
     tenantId: context.tenantId,
     frameworkId: context.frameworkId ?? null,
     criterionId: context.criterionId ?? null,
+    criterionCode: context.criterionCode ?? null,
     sourceMode: context.sourceMode,
     grammarShape: classifyDescriptorGrammarShape(context.criterionText),
+    criterionText: context.criterionText,
   };
+}
+
+function applyLearnedEvidenceSubject(
+  fallbackEvidenceStateClause: string,
+  retrievedLearningRecords: RankedDescriptorLearningRecord[],
+): string {
+  const learned = retrievedLearningRecords
+    .map((record) => getLearnedEvidenceSubject(record))
+    .find((subject): subject is string => Boolean(subject?.trim()));
+
+  return learned ?? fallbackEvidenceStateClause;
 }
 
 export function generateDescriptorReasoningResult(context: DescriptorGenerationContext): DescriptorReasoningResult {
   const grammarShape = classifyDescriptorGrammarShape(context.criterionText);
   const cleanedActionableClause = cleanCriterionForDescriptorReasoning(context.criterionText);
-  const evidenceStateClause = reconstructEvidenceStateClause(context.criterionText);
+  const fallbackEvidenceStateClause = reconstructEvidenceStateClause(context.criterionText);
   const retrievedLearningRecords = retrieveDescriptorLearningRecords(
     context.learningRecords ?? [],
     buildRetrievalContext(context),
@@ -214,6 +228,7 @@ export function generateDescriptorReasoningResult(context: DescriptorGenerationC
   );
 
   const learningApplied = retrievedLearningRecords.length > 0;
+  const evidenceStateClause = applyLearnedEvidenceSubject(fallbackEvidenceStateClause, retrievedLearningRecords);
 
   return {
     sourceMode: context.sourceMode,

--- a/modules/MMM/tests/B4-framework/ai-linkage-fallbacks.test.ts
+++ b/modules/MMM/tests/B4-framework/ai-linkage-fallbacks.test.ts
@@ -136,6 +136,17 @@ describe('T-MMM-DUIR-004: Descriptor generation uses production reasoning before
     expect(src).toContain('Maturity descriptors created from the approved methodology reference and Maturion descriptor learning.');
     expect(src).toContain('Maturity descriptors created from the approved methodology reference.');
   });
+
+  it('CriteriaManagement loads bounded framework-scoped descriptor learning records before ranking', () => {
+    const src = readFile('apps/mmm/src/components/assessment/CriteriaManagement.tsx');
+    expect(src).toContain(".from('mmm_ai_interactions')");
+    expect(src).toContain(".eq('context_type', 'MATURITY_DESCRIPTOR_EDIT')");
+    expect(src).toContain(".eq('status', 'recorded')");
+    expect(src).toContain(".limit(50)");
+    expect(src).not.toContain(".eq('target_entity_id', criterion.id)");
+    expect(src).toContain('record.criterionId === criterion.id');
+    expect(src).toContain('record.frameworkId === frameworkId');
+  });
 });
 
 describe('T-MMM-S6-220: Verbatim intent generation resolves from processed organisation source chunks first', () => {

--- a/modules/MMM/tests/B4-framework/descriptor-reasoning-learning-red.test.ts
+++ b/modules/MMM/tests/B4-framework/descriptor-reasoning-learning-red.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   canUseDescriptorLearningRecordForTenant,
+  extractEvidenceSubjectFromDescriptor,
   retrieveDescriptorLearningRecords,
   type DescriptorLearningRecord,
 } from '../../../../apps/mmm/src/lib/descriptorLearningRetrieval';
+import { descriptorLearningRecordsFromInteractions } from '../../../../apps/mmm/src/lib/descriptorLearningPersistence';
 import {
   cleanCriterionForDescriptorReasoning,
   classifyDescriptorGrammarShape,
@@ -12,8 +14,8 @@ import {
 } from '../../../../apps/mmm/src/lib/descriptorReasoning';
 
 // -----------------------------------------------------------------------------
-// Issue #1900 / PR #1898 QA-to-RED expansion
-// MMM Descriptor Reasoning + Governed Learning Retrieval
+// Issue #1900 / #1914 QA-to-RED expansion
+// MMM Descriptor Reasoning + Governed Learning Retrieval/Persistence
 // -----------------------------------------------------------------------------
 
 describe('T-MMM-DRGL-001: verbatim nominal phrase descriptor reasoning', () => {
@@ -215,15 +217,140 @@ describe('T-MMM-DRGL-015: maturity levels remain distinct operating states', () 
   });
 });
 
+describe('T-MMM-DLPR: persisted descriptor learning replay', () => {
+  it('extracts corrected evidence subjects from user-corrected descriptors', () => {
+    expect(
+      extractEvidenceSubjectFromDescriptor(
+        'Evidence that the committee meets quarterly, minutes record actions, decisions, accountable owners, and delivery status is absent, weak, outdated, inconsistent, fragmented, or person-dependent.',
+      ),
+    ).toBe('the committee meets quarterly, minutes record actions, decisions, accountable owners, and delivery status');
+  });
+
+  it('maps persisted consented interactions into tenant-scoped learning records', () => {
+    const records = descriptorLearningRecordsFromInteractions([
+      {
+        id: 'interaction-1',
+        target_entity_id: 'criterion-1',
+        status: 'recorded',
+        created_at: '2026-07-08T10:00:00Z',
+        request_json: {
+          tenant_id: 'tenant-a',
+          framework_id: 'framework-1',
+          source_mode: 'verbatim_source',
+          criterion_id: 'criterion-1',
+          criterion_code: 'D001.MPS002.C017',
+          criterion_text:
+            'The DCC will meet at least four times a year. Minutes will be taken of these meetings, actions agreed, decisions recorded, and individuals made accountable for their delivery.',
+          learning_events: [
+            {
+              level: 1,
+              original_generated_descriptor_text: 'Evidence that the DCC meets at least four times a year is absent...',
+              user_corrected_descriptor_text:
+                'Evidence that the DCC meets at least four times a year, minutes record actions, decisions, accountable individuals, and delivery status is absent, weak, outdated, inconsistent, fragmented, or person-dependent.',
+              learned_evidence_subject:
+                'the DCC meets at least four times a year, minutes record actions, decisions, accountable individuals, and delivery status',
+              correction_category: 'evidence_bundle_preservation',
+              reusable_pattern_candidate_text:
+                'Preserve meeting cadence, minutes, actions, decisions, accountability and delivery evidence.',
+            },
+          ],
+        },
+        response_json: {
+          reuse_scope: 'tenant_specific_pattern',
+          review_status: 'validated',
+          conflict_status: 'none',
+          consented_at: '2026-07-08T10:00:00Z',
+        },
+      },
+    ]);
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      tenantId: 'tenant-a',
+      frameworkId: 'framework-1',
+      criterionId: 'criterion-1',
+      reuseScope: 'tenant_specific_pattern',
+      reviewStatus: 'validated',
+      conflictStatus: 'none',
+      correctionCategory: 'evidence_bundle_preservation',
+    });
+  });
+
+  it('replays learned evidence subject across all five maturity levels without copying one level', () => {
+    const result = generateDescriptorReasoningResult({
+      tenantId: 'tenant-a',
+      frameworkId: 'framework-1',
+      criterionId: 'criterion-1',
+      criterionCode: 'D001.MPS002.C017',
+      sourceMode: 'verbatim_source',
+      criterionText:
+        'The DCC will meet at least four times a year. Minutes will be taken of these meetings, actions agreed, decisions recorded, and individuals made accountable for their delivery.',
+      learningRecords: [
+        {
+          tenantId: 'tenant-a',
+          frameworkId: 'framework-1',
+          criterionId: 'criterion-1',
+          criterionCode: 'D001.MPS002.C017',
+          reuseScope: 'tenant_specific_pattern',
+          reviewStatus: 'validated',
+          conflictStatus: 'none',
+          sourceMode: 'verbatim_source',
+          grammarShape: 'evidence_bundle_minutes_actions_decisions',
+          originalCriterionText:
+            'The DCC will meet at least four times a year. Minutes will be taken of these meetings, actions agreed, decisions recorded, and individuals made accountable for their delivery.',
+          learnedEvidenceSubject:
+            'the DCC meets at least four times a year, minutes record actions, decisions, accountable individuals, and delivery status',
+        },
+      ],
+    });
+
+    expect(result.learningApplied).toBe(true);
+    expect(result.evidenceStateClause).toContain('minutes record actions');
+    expect(result.descriptors).toHaveLength(5);
+    expect(new Set(result.descriptors.map((descriptor) => descriptor.descriptorText)).size).toBe(5);
+    result.descriptors.forEach((descriptor) => {
+      expect(descriptor.descriptorText).toContain('minutes record actions');
+      expect(descriptor.descriptorText).toContain('accountable individuals');
+      expect(descriptor.descriptorText).toContain('delivery status');
+    });
+  });
+
+  it('uses similar-criterion reasoning patterns without hard-coding DCC or criterion code', () => {
+    const result = generateDescriptorReasoningResult({
+      tenantId: 'tenant-a',
+      frameworkId: 'framework-1',
+      criterionId: 'criterion-2',
+      criterionCode: 'D999.MPS888.C777',
+      sourceMode: 'verbatim_source',
+      criterionText:
+        'The governance forum will meet monthly. Minutes will be taken of these meetings, actions agreed, decisions recorded, and owners made accountable for their delivery.',
+      learningRecords: [
+        {
+          tenantId: 'tenant-a',
+          frameworkId: 'framework-1',
+          criterionId: 'criterion-1',
+          criterionCode: 'D001.MPS002.C017',
+          reuseScope: 'tenant_specific_pattern',
+          reviewStatus: 'validated',
+          sourceMode: 'verbatim_source',
+          grammarShape: 'evidence_bundle_minutes_actions_decisions',
+          originalCriterionText:
+            'The committee will meet monthly. Minutes will be taken of these meetings, actions agreed, decisions recorded, and owners made accountable for their delivery.',
+          learnedEvidenceSubject:
+            'meeting cadence, minutes, agreed actions, recorded decisions, accountable owners, and delivery status are traceable',
+        },
+      ],
+    });
+
+    expect(result.learningApplied).toBe(true);
+    expect(result.evidenceStateClause).toContain('meeting cadence');
+    expect(result.evidenceStateClause).not.toContain('DCC');
+    expect(result.evidenceStateClause).not.toContain('D001.MPS002.C017');
+  });
+});
+
 describe('T-MMM-DUIR-003: descriptor reasoning adapter yields ordered level drafts', () => {
   it('maps reasoning output into Basic→Resilient level drafts (1-5)', async () => {
-    const LEVEL_BY_LABEL = {
-      Basic: 1,
-      Reactive: 2,
-      Compliant: 3,
-      Proactive: 4,
-      Resilient: 5,
-    } as const;
     const { descriptorReasoningDraftsFromResult } = await import(
       '../../../../apps/mmm/src/components/assessment/CriteriaManagement'
     );

--- a/modules/MMM/tests/B4-framework/domain-workflow-behavior.test.tsx
+++ b/modules/MMM/tests/B4-framework/domain-workflow-behavior.test.tsx
@@ -94,22 +94,27 @@ const { mockSupabase, configureScenario, supabaseCalls, configureAIResponse, con
       eq: (column: string, value: unknown) => {
         calls.push({ table, operator: 'eq', column, value });
 
-        if (table === 'mmm_maturity_process_steps' && column === 'domain_id') {
-          return {
-            order: () => queryResult(table, scenario.mpsRows),
-          };
-        }
-
-        if (table === 'mmm_domains' && column === 'framework_id') {
-          return {
-            order: () => queryResult(table, scenario.domainRows),
-          };
-        }
-
-        return {
-          order: () => queryResult(table, []),
-          single: () => queryResult(table, []),
+        const rows =
+          table === 'mmm_maturity_process_steps' && column === 'domain_id'
+            ? scenario.mpsRows
+            : table === 'mmm_domains' && column === 'framework_id'
+              ? scenario.domainRows
+              : [];
+        const orderedResult = queryResult(table, rows);
+        const chainedOrderResult = Object.assign(orderedResult, {
+          limit: () => orderedResult,
+        });
+        const chainedResponse = {
+          eq: (nextColumn: string, nextValue: unknown) => {
+            calls.push({ table, operator: 'eq', column: nextColumn, value: nextValue });
+            return chainedResponse;
+          },
+          order: () => chainedOrderResult,
+          single: () => queryResult(table, rows),
+          limit: () => orderedResult,
         };
+
+        return chainedResponse;
       },
       in: (column: string, value: unknown[]) => {
         calls.push({ table, operator: 'in', column, value });

--- a/supabase/functions/mmm-level-descriptor-save/index.ts
+++ b/supabase/functions/mmm-level-descriptor-save/index.ts
@@ -48,6 +48,53 @@ function changedDescriptors(
   });
 }
 
+function extractEvidenceSubject(descriptorText: string): string | null {
+  const text = descriptorText.replace(/\s+/g, ' ').trim();
+  const patterns = [
+    /^Evidence that\s+(.+?)\s+is absent, weak, outdated, inconsistent, fragmented, or person-dependent\b/i,
+    /^Evidence that\s+(.+?)\s+exists in some form\b/i,
+    /^Evidence that\s+(.+?)\s+is current, complete, traceable\b/i,
+    /^Evidence that\s+(.+?)\s+shows owner-led\b/i,
+    /^Evidence that\s+(.+?)\s+is embedded\b/i,
+  ];
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match?.[1]) return match[1].trim().replace(/[.;:,]+$/g, '');
+  }
+  return null;
+}
+
+function inferCorrectionCategory(beforeText: string, afterText: string): string {
+  const beforeSubject = extractEvidenceSubject(beforeText) ?? '';
+  const afterSubject = extractEvidenceSubject(afterText) ?? '';
+  if (afterSubject.length > beforeSubject.length + 24) return 'evidence_bundle_preservation';
+  if (/\bminutes\b|\bactions\b|\bdecisions\b|\baccountable\b/i.test(afterSubject)) return 'multi_object_evidence_preservation';
+  if (beforeSubject !== afterSubject) return 'evidence_subject_reconstruction';
+  return 'descriptor_wording_refinement';
+}
+
+function buildPatternCandidate(criterionText: string, correctedDescriptorText: string): string {
+  const correctedSubject = extractEvidenceSubject(correctedDescriptorText);
+  const criterionTokens = criterionText.toLowerCase();
+  const patternParts: string[] = [];
+
+  if (/\bminutes\b/.test(criterionTokens)) patternParts.push('preserve minutes as evidence');
+  if (/\bactions?\b/.test(criterionTokens)) patternParts.push('preserve agreed actions as evidence');
+  if (/\bdecisions?\b/.test(criterionTokens)) patternParts.push('preserve recorded decisions as evidence');
+  if (/\baccountab/.test(criterionTokens)) patternParts.push('preserve accountable individuals or owners as evidence');
+  if (/\bdeliver/.test(criterionTokens) || /\bimplement/.test(criterionTokens)) patternParts.push('preserve delivery or implementation traceability');
+
+  if (patternParts.length > 0) {
+    return `For similar criteria, do not reduce the criterion to the first clause. ${patternParts.join('; ')} across all maturity levels.`;
+  }
+
+  if (correctedSubject) {
+    return `For similar criteria, preserve the corrected evidence subject structure: ${correctedSubject}.`;
+  }
+
+  return 'For similar criteria, use the corrected descriptor as a reasoning pattern and preserve criterion-specific evidence objects.';
+}
+
 Deno.serve(async (req: Request) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders() });
   if (req.method !== 'POST') return jsonResponse({ error: 'Method not allowed' }, 405);
@@ -107,7 +154,7 @@ Deno.serve(async (req: Request) => {
 
   const { data: framework, error: frameworkError } = await supabase
     .from('mmm_frameworks')
-    .select('id, organisation_id')
+    .select('id, organisation_id, source_type')
     .eq('id', domain.framework_id)
     .single();
   if (frameworkError || !framework) {
@@ -171,6 +218,27 @@ Deno.serve(async (req: Request) => {
   });
 
   if (userEditedDescriptors.length > 0) {
+    const beforeByLevel = new Map(
+      ((beforeRows ?? []) as Array<{ level: number; descriptor_text: string }>).map((row) => [row.level, row.descriptor_text]),
+    );
+    const criterionText = body.criterion_text ?? criterion.name;
+    const learningEvents = userEditedDescriptors.map((descriptor) => {
+      const originalGeneratedDescriptorText = beforeByLevel.get(descriptor.level) ?? '';
+      const userCorrectedDescriptorText = descriptor.descriptor_text;
+      const learnedEvidenceSubject = extractEvidenceSubject(userCorrectedDescriptorText);
+      const correctionCategory = inferCorrectionCategory(originalGeneratedDescriptorText, userCorrectedDescriptorText);
+      return {
+        level: descriptor.level,
+        label: descriptor.label,
+        original_generated_descriptor_text: originalGeneratedDescriptorText,
+        user_corrected_descriptor_text: userCorrectedDescriptorText,
+        learned_evidence_subject: learnedEvidenceSubject,
+        correction_category: correctionCategory,
+        transformation_summary: `User corrected level ${descriptor.level} descriptor; category=${correctionCategory}.`,
+        reusable_pattern_candidate_text: buildPatternCandidate(criterionText, userCorrectedDescriptorText),
+      };
+    });
+
     await supabase.from('mmm_ai_interactions').insert({
       actor_id: claims.userId,
       action_type: 'USER_PREFERENCE_CAPTURE',
@@ -179,20 +247,31 @@ Deno.serve(async (req: Request) => {
       status: 'recorded',
       request_json: {
         workflow_stage: 'criteria_maturity_descriptor_edit',
+        tenant_id: claims.orgId,
+        organisation_id: claims.orgId,
+        framework_id: framework.id,
+        source_mode: framework.source_type ?? null,
         domain_id: domain.id,
         domain_name: body.domain_name ?? domain.name,
         mps_id: mps.id,
         mps_code: mps.code,
         criterion_id: body.criterion_id,
         criterion_code: body.criterion_code ?? criterion.code,
+        criterion_text: criterionText,
         edited_levels: editedLevels,
         before_descriptors: beforeRows ?? [],
         after_descriptors: descriptors,
         changed_descriptors: userEditedDescriptors,
+        learning_events: learningEvents,
       },
       response_json: {
         captured: true,
         learning_scope: 'descriptor_authoring',
+        reuse_scope: 'tenant_specific_pattern',
+        review_status: 'validated',
+        conflict_status: 'none',
+        lifecycle_status: 'active',
+        consented_at: new Date().toISOString(),
       },
     });
   }

--- a/supabase/functions/mmm-level-descriptor-save/index.ts
+++ b/supabase/functions/mmm-level-descriptor-save/index.ts
@@ -247,7 +247,7 @@ Deno.serve(async (req: Request) => {
       status: 'recorded',
       request_json: {
         workflow_stage: 'criteria_maturity_descriptor_edit',
-        tenant_id: claims.orgId,
+        tenant_id: framework.id,
         organisation_id: claims.orgId,
         framework_id: framework.id,
         source_mode: framework.source_type ?? null,


### PR DESCRIPTION
## Scope

Starts the implementation lane for issue #1914 after merged QA/pre-build PR #1915.

This PR implements the first production layer for governed MMM descriptor-learning persistence and replay.

## Implemented so far

- Expanded `apps/mmm/src/lib/descriptorLearningRetrieval.ts` with enriched learning record metadata, evidence-subject extraction, similarity scoring, same-criterion/code/framework/source-mode ranking, and tenant-safe retrieval.
- Expanded `apps/mmm/src/lib/descriptorReasoning.ts` so retrieved learning records can supply a learned evidence subject that influences all five generated maturity levels without copying one level.
- Added `apps/mmm/src/lib/descriptorLearningPersistence.ts` to map persisted `mmm_ai_interactions` learning events into production `DescriptorLearningRecord` objects.
- Expanded `supabase/functions/mmm-level-descriptor-save/index.ts` to persist richer consented descriptor-learning metadata into `mmm_ai_interactions` when edited descriptors are saved with learning consent.
- Expanded `modules/MMM/tests/B4-framework/descriptor-reasoning-learning-red.test.ts` with descriptor-learning persistence/replay cases.
- Added builder appointment evidence for the implementation wave.
- Patched `apps/mmm/src/components/assessment/CriteriaManagement.tsx` so `handleGenerateDescriptors` loads a bounded recent set of persisted descriptor-learning interactions from `mmm_ai_interactions` (scoped to `context_type = 'MATURITY_DESCRIPTOR_EDIT'`, `status = 'recorded'`, ordered by newest, `limit(50)`), maps them with `descriptorLearningRecordsFromInteractions`, applies explicit context-safe pre-filtering (`same criterion OR same framework` within the active scope), and passes them into `generateDescriptorReasoningResult`. Retrieval failures still fall back gracefully to an empty learning array with the existing approved methodology message.
- Updated focused B4 test coverage/mocks to reflect the chained descriptor-learning query path used by `CriteriaManagement`.
- Added PR-scoped delegation evidence `.agent-admin/control/delegation-orders/pr-1918.json`.

## Anti-hard-coding guardrail

The implementation does not hard-code criterion code `D001.MPS002.C017`, the acronym `DCC`, exact screenshot text, or one corrected descriptor copied into all levels.

The DCC case remains a behavioural fixture only. Similar evidence-bundle criteria must be handled through reusable reasoning patterns.

## Non-scope confirmation

No ISMS public journey, subscription/auth/onboarding/dashboard, PIT/RADAM/Risk/Incident/APW, Vercel workflow, `.github/agents`, global Subject Knowledge promotion, or unrelated schema work is included.